### PR TITLE
display head commit in production too

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -7,3 +7,4 @@ exception_notifier:
 git:
   user: 'git'
   group: 'git'
+display_head_commit: true


### PR DESCRIPTION
this is needed for it to work on develop.ontohub.org.
