### PR TITLE
select links w/ real import kind for import-graph

### DIFF
--- a/app/assets/javascripts/plugins/graph.js.coffee
+++ b/app/assets/javascripts/plugins/graph.js.coffee
@@ -98,7 +98,7 @@ displayGraph = (data) ->
     else if the_mode == "import"
       import_edges = []
       for import_edge in edges
-        if import_edge.info.kind == "import_or_view"
+        if import_edge.info.kind == "import"
           import_edges.push(import_edge)
       import_edges
 


### PR DESCRIPTION
We split the kind "import_or_view" into
"import" and "view". The display of those
links the graphs view needed to be adjusted to
account for this change.

---

Solves #429.
