### PR TITLE
checkout file for specific version

### DIFF
--- a/app/models/ontology_version/files.rb
+++ b/app/models/ontology_version/files.rb
@@ -30,7 +30,7 @@ module OntologyVersion::Files
 
   # path to the raw file
   def raw_path
-    tmp_dir.join("raw",ontology.path)
+    tmp_dir.join("raw",commit_oid,ontology.path)
   end
 
   # path to the raw file, checks out the raw file if is missing


### PR DESCRIPTION
This should fix #405 

If a version of an ontology was sent to Hets, it was checked out from the git repository to a file.
When sending the ontology again to hets, the version is only checked out, if the (previously created) file doesn't exist any more.
The filename didn't change with a new version though.
This way, the old version is sent to hets.

The fix creates distinct files for each version.
