### PR TITLE
fix to_s of Links to use new iri-syntax

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -32,8 +32,8 @@ class Link < ActiveRecord::Base
     if name 
       string = name
     else
-      array = iri.split("#")
-      string = array[1]
+      array = iri.split("?")
+      string = array.last
     end
     return string
   end


### PR DESCRIPTION
IRI has '?' as delimiter now, and not '#'.
Also we should never return nil in to_s, since
link_to will fail with the gsub error.

Should fix #480.
