### PR TITLE
adjust cycle-check migration to be valid

### DIFF
--- a/db/migrate/20131213135056_add_cycle_checker_to_e_edges.rb
+++ b/db/migrate/20131213135056_add_cycle_checker_to_e_edges.rb
@@ -1,6 +1,12 @@
 class AddCycleCheckerToEEdges < ActiveRecord::Migration
-  extend Dagnabit::Migration
-  def change
+  include Dagnabit::Migration
+
+  def up
+    create_cycle_check_trigger :e_edges
   end
-  create_cycle_check_trigger :e_edges
+
+  def down
+    drop_cycle_check_trigger :e_edges
+  end
+
 end


### PR DESCRIPTION
it is now possible to rollback the migration.

This fixes #503 (which can be closed upon merge).
