### PR TITLE
add support for multiple repo-clone methods.

### DIFF
--- a/app/assets/javascripts/repository/clone-url.js.coffee
+++ b/app/assets/javascripts/repository/clone-url.js.coffee
@@ -2,3 +2,20 @@
 # Select Clone URL on click
 $(".clone-url").on 'click', ->
   @select()
+
+window.activate_clone_url = (fragment) ->
+  activate = (clone_type) ->
+    $('p.clone_url_block').each (index, el) ->
+      selection = $(el)
+      if selection.data('clone') == clone_type
+        selection.show()
+      else
+        selection.hide()
+  clone_type = fragment
+  clone_type = 'git' if !fragment.length
+  activate(clone_type)
+
+jQuery ->
+  activate_clone_url location.hash.substring(1)
+  $('a.clone_method_link').on 'click', ->
+    activate_clone_url $(this).data('clone')

--- a/app/assets/stylesheets/repository.css.sass
+++ b/app/assets/stylesheets/repository.css.sass
@@ -4,6 +4,9 @@ $grayLighter: #ddd
 .clone-url
   cursor: text !important
 
+.clone_url_block[data-default-visible="false"]
+  display: none
+
 .url_maps
   .source
     text-align: right

--- a/app/helpers/repositories_helper.rb
+++ b/app/helpers/repositories_helper.rb
@@ -1,0 +1,26 @@
+module RepositoriesHelper
+
+  def clone_methods(visible: nil)
+    methods = %w{git ssh-git}
+    methods.map! { |method| [method, method == visible]} if visible
+    methods
+  end
+
+  def clone_method_links
+    clone_methods.map do |clone_method|
+      link_to clone_method, "##{clone_method}",
+        class: 'clone_method_link',
+        data: {clone: clone_method}
+    end.join(', ')
+  end
+
+  def repository_clone_url(repository, clone_type: 'git', port: nil)
+    case clone_type
+    when 'git'
+      repository_tree_url(repository, protocol: 'git', port: nil) << '.git'
+    when 'ssh-git'
+      "git@#{Settings.hostname}:#{repository.path}.git"
+    end
+  end
+
+end

--- a/app/views/repositories/_clone_url.html.haml
+++ b/app/views/repositories/_clone_url.html.haml
@@ -1,0 +1,9 @@
+.clone_urls
+  - clone_methods(visible: 'git').each do |(clone_type, visible)|
+    %p.clone_url_block{data: {clone: clone_type, default_visible: visible.to_s}}
+      Clone with
+      %span= clone_type
+      %input.form-control.clone-url{type: 'text', readonly: true, value: repository_clone_url(resource, clone_type: clone_type, port: nil)}
+  %p
+    You can clone the repository with these methods:
+    = raw clone_method_links

--- a/app/views/repositories/show.html.haml
+++ b/app/views/repositories/show.html.haml
@@ -2,9 +2,8 @@
 
 - if resource.remote?
   = render partial: 'source'
-%p
-  Clone URL:
-  %input.form-control.clone-url{type: 'text', readonly: true, value: repository_tree_url(resource, protocol: 'git', port: nil) << '.git' }
+
+= render partial: 'clone_url'
 
 - if resource.is_private
   %h2 Private


### PR DESCRIPTION
Should be pretty self explanatory.

It adds support for displaying multiple clone methods (like github does).
And it adds the _new_ clone-method `ssh-git`.
