### PR TITLE
switch iri column of AlternativeIri to text

### DIFF
--- a/db/migrate/20131226111826_change_type_of_iri_for_alternative_iris.rb
+++ b/db/migrate/20131226111826_change_type_of_iri_for_alternative_iris.rb
@@ -1,0 +1,5 @@
+class ChangeTypeOfIriForAlternativeIris < ActiveRecord::Migration
+  def change
+    change_column :alternative_iris, :iri, :text
+  end
+end


### PR DESCRIPTION
Since some IRIs could be longer than 255 chars
this is necessary.

---

fixes #534 
