### PR TITLE
reverse boolean on authorized key remove

### DIFF
--- a/lib/authorized_keys_manager.rb
+++ b/lib/authorized_keys_manager.rb
@@ -27,7 +27,7 @@ class AuthorizedKeysManager
         lines = []
         f.each_line { |l| lines << l }
         f.rewind
-        lines.each { |line| f << line if is?(line, key_id) }
+        lines.each { |line| f << line unless is?(line, key_id) }
         f.truncate(f.pos)
       end
 


### PR DESCRIPTION
When we remove a key, we should only delete
the specific key and not every other key.

---

fixes #559

should as a hotfix be propagated to master (and ontohub.org) as fast as possible.
