### PR TITLE
alter startup-script to use valid syntax

### DIFF
--- a/script/start-development
+++ b/script/start-development
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 rake sunspot:solr:start &
-bin/sidekiq -q default,hets -c 1 -v  >> log/sidekiq.log &
+bin/sidekiq -q default -q hets -c 1 -v  >> log/sidekiq.log &
 rails s &
 
 trap "rake sunspot:solr:stop" INT


### PR DESCRIPTION
The valid syntax for sidekiq queues uses
-q flags before every queue instead of
the comma-separated list.
Look [here](https://github.com/mperham/sidekiq/blob/master/Changes.md#2172) for more information.

---

Fixes sidekiq problems as reported by @eugenk and myself.

Should be propagated to master immediately.
