### PR TITLE
OS X hets management

### DIFF
--- a/config/hets.yml
+++ b/config/hets.yml
@@ -21,6 +21,6 @@ hets_owl_tools:
   - /usr/local/opt/hets/Hets.app/Contents/Resources/hets-owl-tools
   - /Applications/Hets.app/Contents/Resources/hets-owl-tools
 
-hets_version_minimum_date: 2013-12-20
+hets_version_minimum_date: 2014-01-06
 
 hets_stack_size: 1G


### PR DESCRIPTION
This is another hets related change for Mac OS X systems.
If we install hets with homebrew, there is a difference to paths we need to use (as homebrew
will install/symlink to `/usr/local/opt`).

---

On another note i have created a homebrew tap which allows Mac OS X users to handle
their hets via homebrew. You can find it [here](https://github.com/0robustus1/homebrew-hets).

Here are some instructions:
- `brew tap 0robustus1/hets` will add the repository to homebrew and allow you to install hets
- `brew install hets --with-nightly` will install hets
  - it will also install the latest nightly build of the hets binary
  - it will also add a `hets-update` script to your `PATH` which will allow you to the most recent nightly build (once it changes)
  - it will also add `hets` to you `PATH` which is actually a script which will set the correct environment (like the `script` script did in the usual hets root path.

As with all homebrew projects if you perform `homebrew update` you can fetch new versions of the formula which will allow you to update to a new base version of hets (including owl-tools and the like).
