### PR TITLE
fix the extraction of internal iri when parsing

### DIFF
--- a/app/models/ontology/import.rb
+++ b/app/models/ontology/import.rb
@@ -20,7 +20,7 @@ module Ontology::Import
         },
         ontology: Proc.new { |h|
           child_name = h['name']
-          internal_iri = h['name'][1..-2]
+          internal_iri = h['name'][1..-2] if h['name'][0] == '<'
 
           if h['reference'] == 'true'
             ontology = Ontology.find_with_iri(internal_iri)
@@ -134,9 +134,6 @@ module Ontology::Import
 
             logic_callback.link(h, link)
           end
-        },
-        import: Proc.new { |h|
-          ontology.iri = ExternalRepository.determine_iri(h['library'])
         }
       save!
       versions.each { |version| version.save! }


### PR DESCRIPTION
Since a hets update, hets does not enclose uris
consistently in angle brackets. We need to
check for them, before stripping the uri.

Also deactivates the Reference-Node-Callback (unnecessary).

---

to be directly introduced into staging and master - **hotfix**.
