### PR TITLE
change hets date checking to revision checking.

### DIFF
--- a/config/hets.yml
+++ b/config/hets.yml
@@ -21,7 +21,7 @@ hets_owl_tools:
   - /usr/local/opt/hets/Hets.app/Contents/Resources/hets-owl-tools
   - /Applications/Hets.app/Contents/Resources/hets-owl-tools
 
-version_minimum_date: 2014-01-29
+version_minimum_revision: 18480
 
 stack_size: 1G
 


### PR DESCRIPTION
Fixes the version checking of hets. As of last week hets uses the revision number instead of the
Date as secondary identification of a version.

I would ask @corny and @nning to also update the master branch when they merge this (i would ask that you do this) and to update hets on all affected deployment-machines.
