### PR TITLE
adjust hets path for Mac OS X homebrew compliance.

### DIFF
--- a/config/hets.yml
+++ b/config/hets.yml
@@ -5,20 +5,24 @@ hets_path:
   - /opt/local/bin/hets
   - ~/code/hets/hets
   - ~/ontohub/Hets/hets
-  - /usr/local/opt/hets/Hets.app/Contents/Resources/hets
+  - /usr/local/opt/hets/bin/hets-bin
+  - /usr/local/opt/hets/bin/hets
+  - /usr/local/opt/hets-binary/Hets.app/Contents/Resources/hets
   - /Applications/Hets.app/Contents/Resources/hets
 hets_lib:
   - /usr/lib/hets/hets-lib
   - ~/dev/hets/lib
   - ~/ontohub/Hets
-  - /usr/local/opt/hets/Hets.app/Contents/Resources/Hets-lib
+  - /usr/local/opt/hets-lib
+  - /usr/local/opt/hets-binary/Hets.app/Contents/Resources/Hets-lib
   - /Applications/Hets.app/Contents/Resources/Hets-lib
 hets_owl_tools:
   - /usr/lib/hets/hets-owl-tools
   - ~/dev/hets/OWL2
   - ~/code/hets/OWL2
   - ~/ontohub/Hets/OWL2
-  - /usr/local/opt/hets/Hets.app/Contents/Resources/hets-owl-tools
+  - /usr/local/opt/hets/lib/hets-owl-tools/
+  - /usr/local/opt/hets-binary/Hets.app/Contents/Resources/hets-owl-tools
   - /Applications/Hets.app/Contents/Resources/hets-owl-tools
 
 version_minimum_revision: 18480


### PR DESCRIPTION
Updates the `hets.yml` path specifications for finding hets on Mac OS X systems which install hets
via homebrew.

---

Hopefully this will be the last homebrew related change ;)
