### PR TITLE
fix ontology button display permission check

### DIFF
--- a/app/views/ontologies/_menu.html.haml
+++ b/app/views/ontologies/_menu.html.haml
@@ -9,7 +9,7 @@
           %ul.dropdown-menu{role: 'menu'}
             - if show_oops?
               %li= link_to 'design with OOPS', repository_ontology_ontology_version_oops_request_path(*resource_chain, current_version), method: 'post'
-      - if can? :write, resource.parent
+      - if can? :write, resource.repository
         = link_to 'Edit', [:edit, *resource_chain], class: 'btn btn-default'
       - if Settings.format_selection
         .btn-group


### PR DESCRIPTION
fixes #720

can't test the permission check locally, because i don't have a public writable repository (sandbox) here, but the check is the same as in the controller now.
