### PR TITLE
Checkout files in a shared directory.

### DIFF
--- a/app/models/ontology_version/files.rb
+++ b/app/models/ontology_version/files.rb
@@ -25,7 +25,7 @@ module OntologyVersion::Files
   end
 
   def tmp_dir
-    Rails.root.join("tmp","commits",commit_oid)
+    Ontohub::Application.config.commits_path.join(commit_oid)
   end
 
   # path to the raw file

--- a/config/initializers/paths.rb
+++ b/config/initializers/paths.rb
@@ -9,8 +9,8 @@ module PathsInitializer
         config.data_root = Rails.root.join('data').sub(%r(/releases/\d+/), "/current/")
       end
 
-      config.git_root = config.data_root.join('repositories')
-      config.git_working_copies_root = config.data_root.join('working_copies')
+      config.git_root     = config.data_root.join('repositories')
+      config.commits_path = config.data_root.join('commits')
       config.max_read_filesize = 512 * 1024
 
       settings = Settings.git

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,8 +21,7 @@ class ActiveSupport::TestCase
 
   setup do
     # clean git repositories
-    FileUtils.rmtree Ontohub::Application.config.git_root
-    FileUtils.rmtree Ontohub::Application.config.git_working_copies_root
+    FileUtils.rmtree Ontohub::Application.config.data_root
     FileUtils.rmtree Repository::Symlink::PATH
   end
 


### PR DESCRIPTION
Otherwise they get lost with each deployment and have to be reparsed with Hets.
