### PR TITLE
706 analyse svn mirrors

### DIFF
--- a/lib/git_repository/cloning.rb
+++ b/lib/git_repository/cloning.rb
@@ -34,7 +34,7 @@ module GitRepository::Cloning
   end
 
   def pull
-    with_head_change do
+    with_head_change head_oid do
       git_exec 'remote', 'update'
     end
   end


### PR DESCRIPTION
fixes #706 

The pre-pull `head_oid` wasn't set at the correct place: It was set after fetching from the remote svn repo, which resulted in the previous and current head being set to the same value.

This way the function to analyse changed files had no commits to iterate over.
