### PR TITLE
Create shared/config directory during deployment.

### DIFF
--- a/lib/capistrano/tasks/deploy.cap
+++ b/lib/capistrano/tasks/deploy.cap
@@ -28,6 +28,7 @@ namespace :deploy do
         within release_path do
           execute :rake, "secret:replace"
         end
+        execute :mkdir, "-p #{shared_path.join('config')}"
         execute :mv, "#{release_secret} #{shared_secret}"
       end
       


### PR DESCRIPTION
On new deployments, the directory for shared config files (as the secret_token.rb for example) was not created.
