### PR TITLE
Maintenance mode for Ontohub

### DIFF
--- a/git/lib/git_shell.rb
+++ b/git/lib/git_shell.rb
@@ -12,6 +12,11 @@ class GitShell
   end
 
   def exec
+    if Ontohub::Application.config.data_root.join("maintenance.txt").exist?
+      $stderr.puts "System in maintenance mode. Please try again later."
+      exit 1
+    end
+
     exit 1 unless @command
     
     parse_cmd

--- a/lib/capistrano/tasks/maintenance.cap
+++ b/lib/capistrano/tasks/maintenance.cap
@@ -1,0 +1,15 @@
+namespace :maintenance do
+  desc "Enable maintenance mode"
+  task :enable do
+    on roles(:app) do
+      execute "touch #{current_path}/data/maintenance.txt"
+    end
+  end
+
+  desc "Disable maintenance mode"
+  task :disable do
+    on roles(:app) do
+      execute "rm -f #{current_path}/data/maintenance.txt"
+    end
+  end
+end

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -3,3 +3,6 @@ RewriteEngine On
 # remove ending slash
 RewriteRule ^(.+)/$ /$1 [R=301,L]
 
+# Maintenance mode
+RewriteCond %{DOCUMENT_ROOT}/../data/maintenance.txt -f
+RewriteRule .* /503.html [R=503,L]


### PR DESCRIPTION
Added capistrano tasks to disable the web interface and the Git shell for maintenance.
