### PR TITLE
fix display of whitespace-containing entity-names

### DIFF
--- a/app/helpers/sentence_helper.rb
+++ b/app/helpers/sentence_helper.rb
@@ -2,7 +2,7 @@ module SentenceHelper
 
   def format_for_view(sentence)
     if sentence.display_text? then
-      sentence.display_text.gsub(/<(\S*)>/, "<strong>\\1</strong>" ).html_safe
+      sentence.display_text.gsub(/<([^>]*)>/, "<strong>\\1</strong>" ).html_safe
     else
       "#{sentence.text}".sub(/\s%\(#{sentence.name}\)%/, '')
     end


### PR DESCRIPTION
As entities can contain underscores/whitespace, we should be
able to display this sentences correctly, for example this
OWL-Sentence:
  XML:

```
  <SubClassOf>
    <Class IRI="#Glass_Walkers"/>
    <Class IRI="#Tribe"/>
  </SubClassOf>
```

  Manchester:

```
  Class: Glass_Walkers SubClassOf: Tribe
```

Should be displayed like this:
`Class: Glass Walkers SubClassOf: Tribe`
and not like this:
`Class: SubClassOf: Tribe`
This occured because Class: `<Glass Walkers>`
could not be correctly replaced (because it was expected to not
contain whitespace). This change now only expects that a
`<>` construct does not contain any more `>` chars.
