### PR TITLE
use savepoint for nested sql transaction

### DIFF
--- a/app/models/ontology/entities.rb
+++ b/app/models/ontology/entities.rb
@@ -54,7 +54,7 @@ module Ontology::Entities
     # Delete previous set of categories
     delete_edges
     subclasses = self.sentences.where("text LIKE '%SubClassOf%'").select { |sentence| sentence.text.split(" ").size == 4 }
-    transaction do
+    transaction requires_new: true do
       subclasses.each do |s|
         c1, c2 = s.hierarchical_class_names
         


### PR DESCRIPTION
This may be able to fix the #576 issue.

We assume that the problem was related to the fact that
the failing cycle-checker would fail the transaction
(as true nested transactions are not supported by PostgreSQL)
and the next query (the logic_id check, or now the projects query)
is still executed as part of the transaction-block. However the
transaction does not exist anymore so the system fails.

However `requires_new: true` will add a savepoint. So
if the cycle-check (the content of the transaction-block)
fails, it will only rollback to the savepoint, but the
transaction will still exist.

---

This pretty much tells the whole story.
However it is quite hard, not to say **impossible** to test for this.
