### PR TITLE
move expect into it-block for onto-controller spec

### DIFF
--- a/spec/controllers/ontologies_controller_spec.rb
+++ b/spec/controllers/ontologies_controller_spec.rb
@@ -47,7 +47,9 @@ describe OntologiesController do
         end
 
         it{ should respond_with :found }
-        expect(response).to redirect_to([repository, :ontologies])
+        it 'should redirect to ontologies-index of repository' do
+          expect(response).to redirect_to([repository, :ontologies])
+        end
       end
 
       context 'unsuccessful deletion' do


### PR DESCRIPTION
expect (and also response) should only be used inside of
an examples. Examples are the content of `it`-blocks.
`context`-blocks do not represent examples.

---

This should give the rspec specs a running chance at passing ;)
