### PR TITLE
Fix keyword style for worker

### DIFF
--- a/lib/base_worker.rb
+++ b/lib/base_worker.rb
@@ -1,0 +1,18 @@
+class BaseWorker
+  include Sidekiq::Worker
+
+  # Because of the JSON-Parsing the hash which contains the try_count will
+  # contain the try_count key as a string and not as a symbol (which is
+  # necessary for the keyword-style to work).  This method is usually called
+  # inside of `perform` of a specific worker.
+  def establish_arguments(args, try_count: 1)
+    if args.last.is_a?(Hash) && args.last['try_count']
+      hash = args.pop
+      @try_count = hash['try_count']
+    else
+      @try_count = try_count
+    end
+    @args = args
+  end
+
+end

--- a/lib/worker.rb
+++ b/lib/worker.rb
@@ -1,21 +1,14 @@
 require 'sidekiq/worker'
 
 # Worker for Sidekiq
-class Worker
-  include Sidekiq::Worker
+class Worker < BaseWorker
 
   # Because of the JSON-Parsing the hash which contains
   # the try_count will contain the try_count key
   # as a string and not as a symbol (which is necessary
   # for the keyword-style to work).
   def perform(*args, try_count: 1)
-    if args.last.is_a?(Hash) && args.last['try_count']
-      hash = args.pop
-      @try_count = hash['try_count']
-    else
-      @try_count = try_count
-    end
-    @args = args
+    establish_arguments(args, try_count: try_count)
     execute_perform(try_count, *args)
   end
 
@@ -54,13 +47,7 @@ class SequentialWorker < Worker
   sidekiq_options queue: 'sequential'
 
   def perform(*args, try_count: 1)
-    if args.last.is_a?(Hash) && args.last['try_count']
-      hash = args.pop
-      @try_count = hash['try_count']
-    else
-      @try_count = try_count
-    end
-    @args = args
+    establish_arguments(args, try_count: try_count)
     ConcurrencyBalancer.sequential_lock do
       execute_perform(try_count, *args)
     end


### PR DESCRIPTION
Just came across this particular problem (parsing will fail with invalid params).

As the reader might remember we changed the original layout on request as part of pull-request
#750 (for #685), because we did not want calls like this `perform(1, ...` as the reader might not know what

the `1` stands for. So we used keyword args: `perform(try_count: 1, ...`. However this results in some problems now. These two commits should fix the problem.

However we could also go back to the old solution and just use a constant to explain the `1`.
For example: `INITIAL_TRY_COUNT = 1` which would allow us this call: `perform(INITIAL_TRY_COUNT, ...`. 
