### PR TITLE
remove save_current_ontologies

### DIFF
--- a/app/models/repository/git_repositories.rb
+++ b/app/models/repository/git_repositories.rb
@@ -248,13 +248,6 @@ module Repository::GitRepositories
     end
   end
 
-  # saves all ontologies at the current state in the database
-  def save_current_ontologies(user=nil)
-    git.files do |entry|
-      save_ontology entry.last_change[:oid], entry.path, user, fast_parse: true
-    end
-  end
-
   def user_info(user)
     {email: user.email, name: user.name}
   end


### PR DESCRIPTION
Fixes #610. This was dead code. It was used previously, but when we changed ontohub to use `suspended_save_ontologies`, this method wasn't deleted.
