### PR TITLE
improve decision for html or plain text sending of file

### DIFF
--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -4,9 +4,6 @@ class FilesController < ApplicationController
   before_filter :check_write_permissions, only: [:new, :create]
   before_filter :check_read_permissions
 
-  OWL_API_HEADER_PARTS = ['text/xml;',
-                          'text/html, image/gif, image/jpeg, *;']
-
   def files
     @info = repository.path_info(params[:path], oid)
 
@@ -124,9 +121,13 @@ class FilesController < ApplicationController
   end
 
   def owl_api_header_in_accept_header?
-    OWL_API_HEADER_PARTS.any? do |owl_api_header_part|
-      request.accept.try(:include?, owl_api_header_part)
-    end
+    # OWL API sends those two http accept headers in different requests:
+    # application/rdf+xml, application/xml; q=0.5, text/xml; q=0.3, */*; q=0.2
+    # text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
+    # The latter conflicts with what browsers send.
+    accepts = request.accepts.compact
+    (accepts.present? && accepts.first != Mime::HTML) ||
+      accepts[0..2] == [Mime::HTML, Mime::GIF, Mime::JPEG]
   end
 
   def existing_file_requested_as_html?


### PR DESCRIPTION
This is a fix for what @cmaeder mentioned at the end of a meeting (on top of #783):
`request.header` computes an accept request from the sent http headers. What we want to check is the plain request header how it is sent by browsers.

And of course, I put the check into a separate method to make the code more readable.
