### PR TITLE
symlink public/assets

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,7 +5,7 @@ set :branch,         Settings.hostname
 
 set :application,    "ontohub"
 set :deploy_to,      "/srv/http/ontohub"
-set :linked_dirs,    %w{ data log tmp/pids tmp/cache tmp/sockets }
+set :linked_dirs,    %w{ data log tmp/pids tmp/cache tmp/sockets public/assets }
 set :bundle_without, "development deployment test"
 set :rails_env,      "production"
 


### PR DESCRIPTION
capistrano-rails adds public/assets to linked_dirs, but we overwrite it:
https://github.com/capistrano/rails/blob/v1.1.1/lib/capistrano/tasks/assets.rake#L99
