### PR TITLE
Only use major and minor ruby VM version on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.1.1
+  - 2.1
 
 branches:
   except:


### PR DESCRIPTION
Ruby 2.1.2 is released and our travis config uses 2.1.1. Usage of 2.1 in travis config prevents changing the version again for every patch release.
