### PR TITLE
test for correct column type

### DIFF
--- a/spec/models/project.rb
+++ b/spec/models/project.rb
@@ -4,7 +4,7 @@ describe Project do
 
   context 'Migrations' do
     %w(name institution homepage description contact).each do |column|
-      it { should have_db_column(column).of_type :string }
+      it { should have_db_column(column).of_type :text }
     end
 
     it { should have_and_belong_to_many :ontologies }


### PR DESCRIPTION
The spec tested for `string` even though the migrations say `text`. I don't know why the wrong spec passes on travis. It didn't pass on my machine though.
