### PR TITLE
use proper path

### DIFF
--- a/test/integration/ontology_state.rb
+++ b/test/integration/ontology_state.rb
@@ -7,7 +7,7 @@ class OntologyStateTest < ActionController::IntegrationTest
   end
 
   test 'ontology state' do
-    visit ontology_path(@ontology)
+    visit repository_ontology_path(@ontology.repository, @ontology)
 
     # check current status
     assert_equal "pending", find("#ontology-state span").text


### PR DESCRIPTION
The usage of the wrong path raised an exception because there is no `ontology_path` any more.
