### PR TITLE
replace last occurrence of old name of renamed method

### DIFF
--- a/app/models/repository_file.rb
+++ b/app/models/repository_file.rb
@@ -61,7 +61,7 @@ class RepositoryFile < FakeRecord
 
   def ontologies(child_name=nil)
     @ontologies ||= if file?
-      ontos = repository.ontologies.find_with_path(path).parents_first
+      ontos = repository.ontologies.with_path(path).parents_first
       ontos.map!{ |o| o.children.where(name: child_name) }.flatten! if child_name
       ontos
     end


### PR DESCRIPTION
This is a change that should've been done in 556d9e007120cfbfbb79070544b4928f26bfa0eb but was forgotten. Without this change, the repository file browser is broken.

Created #972 for further action
