### PR TITLE
fix resolving of name/path for SSHAccessController

### DIFF
--- a/app/controllers/ssh_access_controller.rb
+++ b/app/controllers/ssh_access_controller.rb
@@ -18,4 +18,12 @@ class SSHAccessController < InheritedResources::Base
                   provide_to_user: false}
   end
 
+  def self.controller_name
+    @controller_name = "s_s_h_access"
+  end
+
+  def self.controller_path
+    @controller_path = "s_s_h_access"
+  end
+
 end


### PR DESCRIPTION
The rspec tests utilize the controller_path and controller_name methods
in order to determine the route. They sadly need to be manually
adjusted.
