### PR TITLE
899 do not fail on non existence

### DIFF
--- a/app/models/ontology_version/states.rb
+++ b/app/models/ontology_version/states.rb
@@ -11,6 +11,8 @@ module OntologyVersion::States
 
   include StateUpdater
 
+  TERMINAL_STATES = %w(failed done)
+
   included do
     after_save :after_update_state, if: :state_changed?
   end

--- a/lib/timeout_worker.rb
+++ b/lib/timeout_worker.rb
@@ -30,7 +30,7 @@ Therefore the timeout-job will not continue. It will also not be rescheduled.
   end
 
   def state_not_terminal?(ontology_version)
-    !(ontology_version.state == 'failed' || ontology_version.state == 'done')
+    !OntologyVersion::States::TERMINAL_STATES.include?(ontology_version.state)
   end
 
 end


### PR DESCRIPTION
When parsing fails, the corresponding ontology-version might be roll-backed (in case of imports or inner ontologies). So when the time for the timeout-job comes, the ontology version can't be found.
This is not really an error, but to err on the safe side we will still generate a message in our production log.
