### PR TITLE
634 fork and unmirror repository

### DIFF
--- a/app/assets/javascripts/repository/edit_remote.js.coffee
+++ b/app/assets/javascripts/repository/edit_remote.js.coffee
@@ -51,6 +51,6 @@ $ ->
     change_options()
     change_type_display()
 
-    source_address_el.on('change', change_options)
-    source_address_el.on('change', change_type_display)
+    source_address_el.on('input', change_options)
+    source_address_el.on('input', change_type_display)
   return

--- a/app/assets/javascripts/repository/edit_remote.js.coffee
+++ b/app/assets/javascripts/repository/edit_remote.js.coffee
@@ -30,6 +30,10 @@ $ ->
       source_address_el.val().trim().length > 0
 
     was_source_address_set = is_source_address_set()
+
+    reset_was_source_address_set = () ->
+      was_source_address_set = is_source_address_set()
+
     change_options = (event) ->
       if !was_source_address_set && is_source_address_set()
         modify_access_list 'mirror'
@@ -40,9 +44,9 @@ $ ->
 
     change_type_display = (event) ->
       if !was_source_address_set && is_source_address_set()
-        type_el.fadeIn()
+        type_el.stop(true,true).fadeIn({queue: false}).css({display: 'none'}).slideDown()
       else if was_source_address_set && !is_source_address_set()
-        type_el.fadeOut()
+        type_el.stop(true,true).fadeOut({queue: false}).slideUp()
       else if !was_source_address_set && !is_source_address_set()
         type_el.hide()
       else
@@ -53,4 +57,5 @@ $ ->
 
     source_address_el.on('input', change_options)
     source_address_el.on('input', change_type_display)
+    source_address_el.on('input', reset_was_source_address_set)
   return

--- a/app/assets/javascripts/repository/edit_remote.js.coffee
+++ b/app/assets/javascripts/repository/edit_remote.js.coffee
@@ -10,7 +10,9 @@ $ ->
     options_non_mirror = _.clone(options_all)
     options_mirror     = _.filter(options_all, mirror_option)
 
-    # If options are not set one by one, the select box won't change.
+    type_el = $($('#repository_form #remote_type')[0])
+
+    # If options are not set one by one, the select box wont change.
     set_options = (options, converter, last_value) ->
       input_access_el.options.length = 0
       for option, index in options
@@ -36,7 +38,19 @@ $ ->
       else if !was_source_address_set && !is_source_address_set()
         modify_access_list 'non_mirror'
 
+    change_type_display = (event) ->
+      if !was_source_address_set && is_source_address_set()
+        type_el.fadeIn()
+      else if was_source_address_set && !is_source_address_set()
+        type_el.fadeOut()
+      else if !was_source_address_set && !is_source_address_set()
+        type_el.hide()
+      else
+        type_el.show()
+
     change_options()
+    change_type_display()
 
     source_address_el.on('change', change_options)
+    source_address_el.on('change', change_type_display)
   return

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -12,6 +12,7 @@ class RepositoriesController < InheritedResources::Base
   end
 
   def update
+    resource.convert_to_local! if params[:un_mirror]
     params[:repository].except!(:source_address, :source_type, :name)
     super
   end

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -8,6 +8,7 @@ class RepositoriesController < InheritedResources::Base
 
   def create
     resource.user = current_user
+    resource.remote_type = params[:remote_type]
     super
   end
 

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -13,7 +13,8 @@ class RepositoriesController < InheritedResources::Base
 
   def update
     resource.convert_to_local! if params[:un_mirror]
-    params[:repository].except!(:source_address, :source_type, :remote_type, :name)
+    params[:repository].except!(
+      :source_address, :source_type, :remote_type, :name)
     super
   end
 

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -8,13 +8,12 @@ class RepositoriesController < InheritedResources::Base
 
   def create
     resource.user = current_user
-    resource.remote_type = params[:remote_type]
     super
   end
 
   def update
     resource.convert_to_local! if params[:un_mirror]
-    params[:repository].except!(:source_address, :source_type, :name)
+    params[:repository].except!(:source_address, :source_type, :remote_type, :name)
     super
   end
 

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -16,8 +16,8 @@ class RepositoriesController < InheritedResources::Base
 
   def update
     resource.convert_to_local! if params[:un_mirror]
-    params[:repository].except!(
-      :source_address, :source_type, :remote_type, :name)
+    params[:repository].
+      except!(:source_address, :source_type, :remote_type, :name)
     super
   end
 

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -8,6 +8,9 @@ class RepositoriesController < InheritedResources::Base
 
   def create
     resource.user = current_user
+    unless params[:source_address]
+      params[:repository].except!(:source_type, :remote_type)
+    end
     super
   end
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -18,6 +18,7 @@ class Repository < ActiveRecord::Base
                   :description,
                   :source_type,
                   :source_address,
+                  :remote_type,
                   :access
   attr_accessor :user
 

--- a/app/models/repository/importing.rb
+++ b/app/models/repository/importing.rb
@@ -54,11 +54,11 @@ module Repository::Importing
   def async_remote(method)
     raise "object is #{state}" if locked?
     update_state! 'pending'
-    async :remote_send, method
+    async :remote_send, method, remote_type
   end
 
   # executes a pull/clone job
-  def remote_send(method)
+  def remote_send(method, remote_type)
     # build arguments
     args    = []
     args   << source_address if method == 'clone'
@@ -70,6 +70,7 @@ module Repository::Importing
     do_or_set_failed do
       update_state! 'fetching'
       result = git.send(method, *args)
+      convert_to_local! if remote_type == 'fork'
 
       update_state! 'processing'
       suspended_save_ontologies \

--- a/app/models/repository/importing.rb
+++ b/app/models/repository/importing.rb
@@ -58,7 +58,7 @@ module Repository::Importing
   end
 
   # executes a pull/clone job
-  def remote_send(method, remote_type)
+  def remote_send(method, remote_type=nil)
     # build arguments
     args    = []
     args   << source_address if method == 'clone'

--- a/app/models/repository/importing.rb
+++ b/app/models/repository/importing.rb
@@ -17,6 +17,8 @@ module Repository::Importing
   included do
     include StateUpdater
 
+    attr_accessor :remote_type
+
     scope :with_source, where("source_type IS NOT null")
 
     # Ready for pulling

--- a/app/models/repository/importing.rb
+++ b/app/models/repository/importing.rb
@@ -38,8 +38,8 @@ module Repository::Importing
   end
 
   def convert_to_local!
-    source_address = nil
-    source_type = nil
+    self.source_address = nil
+    self.source_type = nil
     save!
   end
 

--- a/app/models/repository/importing.rb
+++ b/app/models/repository/importing.rb
@@ -29,18 +29,21 @@ module Repository::Importing
     }
 
     validates_inclusion_of :state,       in: STATES
-    validates_with SourceTypeValidator, if: :mirror?
+    validates_with SourceTypeValidator, if: :source_address?
 
-    before_validation ->{ detect_source_type }
-    after_create ->{ async_remote :clone }, if: :mirror?
+    before_validation ->() { detect_source_type if new_record? }
+    after_create ->() { async_remote :clone }, if: :source_address?
   end
 
   def mirror?
-    source_address?
+    source_address? && source_type?
+  end
+
+  def fork?
+    source_address? && !source_type?
   end
 
   def convert_to_local!
-    self.source_address = nil
     self.source_type = nil
     save!
   end

--- a/app/views/repositories/_form.html.haml
+++ b/app/views/repositories/_form.html.haml
@@ -7,15 +7,7 @@
     = f.input :source_address, as: :url
 
     #remote_type.form-group
-      = f.label t('repository.remote_type.label')
-      .col-lg-10
-        = radio_button_tag(:remote_type, 'mirror', [nil, 'mirror'].include?(params[:remote_type]))
-        = label_tag t('repository.remote_type.mirror')
-
-        = radio_button_tag(:remote_type, 'fork', params[:remote_type]=='fork')
-        = label_tag t('repository.remote_type.fork')
-
-        = t 'repository.remote_type.text'
+      = f.input :remote_type, collection: Repository::REMOTE_TYPES, include_blank: false, as: :radio_buttons, hint: t('repository.remote_type.text')
 
   - if !resource.new_record? && resource.mirror?
     .form-group

--- a/app/views/repositories/_form.html.haml
+++ b/app/views/repositories/_form.html.haml
@@ -6,6 +6,17 @@
   - if resource.new_record?
     = f.input :source_address, as: :url
 
+    #remote_type.form-group
+      = f.label t('repository.remote_type.label')
+      .col-lg-10
+        = radio_button_tag(:remote_type, 'mirror', [nil, 'mirror'].include?(params[:remote_type]))
+        = label_tag t('repository.remote_type.mirror')
+
+        = radio_button_tag(:remote_type, 'fork', params[:remote_type]=='fork')
+        = label_tag t('repository.remote_type.fork')
+
+        = t 'repository.remote_type.text'
+
   - if !resource.new_record? && resource.mirror?
     .form-group
       = f.label t('repository.un_mirror.label')

--- a/app/views/repositories/_form.html.haml
+++ b/app/views/repositories/_form.html.haml
@@ -5,5 +5,12 @@
 
   - if resource.new_record?
     = f.input :source_address, as: :url
-  
+
+  - if !resource.new_record? && resource.mirror?
+    .form-group
+      = f.label t('repository.un_mirror.label')
+      .col-lg-10
+        = check_box_tag :un_mirror
+        = t 'repository.un_mirror.text'
+
   = f.button :wrapped

--- a/app/views/repositories/_form.html.haml
+++ b/app/views/repositories/_form.html.haml
@@ -7,7 +7,7 @@
     = f.input :source_address, as: :url
 
     #remote_type.form-group
-      = f.input :remote_type, collection: Repository::REMOTE_TYPES, include_blank: false, as: :radio_buttons, hint: t('repository.remote_type.text')
+      = f.input :remote_type, collection: Repository::REMOTE_TYPES, as: :radio_buttons, hint: t('repository.remote_type.text')
 
   - if !resource.new_record? && resource.mirror?
     .form-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,9 +46,6 @@ en:
         public_r: Public readable
         public_rw: Public readable and writable
     remote_type:
-      label: Type
-      fork: Fork
-      mirror: Mirror
       text: A mirror will be synchronized periodically. A fork is just a one-time copy.
     un_mirror:
       label: Un-mirror

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,14 @@ en:
         private_rw: Private readable and writable
         public_r: Public readable
         public_rw: Public readable and writable
+    remote_type:
+      label: Type
+      fork: Fork
+      mirror: Mirror
+      text: A mirror will be synchronized periodically. A fork is just a one-time copy.
+    un_mirror:
+      label: Un-mirror
+      text: If you un-mirror this repository, it won't get synchronized with the remote reposoitory any mor
   repository_directory:
     create: Successfully created directory "%{name}".
     create_additional: "That is, the following directories have been created: %{directories}"
@@ -53,10 +61,7 @@ en:
       placeholder:
         name: Directory name
       hint:
-        slashes: Use slashes to directly create subdirectories.
-    un_mirror:
-      label: Un-mirror
-      text: If you un-mirror this repository, it won't get synchronized with the remote reposoitory any more. There is no possibility to synchronize it ever again.
+        slashes: Use slashes to directly create subdirectories.e. There is no possibility to synchronize it ever again.
   permission:
     delete_header: Are you sure you want to delete the permission?
     delete_desc: If you remove this %{role} permission, %{subject} won't be able to access the %{class} %{item} according to it.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,9 @@ en:
         name: Directory name
       hint:
         slashes: Use slashes to directly create subdirectories.
+    un_mirror:
+      label: Un-mirror
+      text: If you un-mirror this repository, it won't get synchronized with the remote reposoitory any more. There is no possibility to synchronize it ever again.
   permission:
     delete_header: Are you sure you want to delete the permission?
     delete_desc: If you remove this %{role} permission, %{subject} won't be able to access the %{class} %{item} according to it.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,7 +52,7 @@ en:
       text: A mirror will be synchronized periodically. A fork is just a one-time copy.
     un_mirror:
       label: Un-mirror
-      text: If you un-mirror this repository, it won't get synchronized with the remote reposoitory any mor
+      text: If you un-mirror this repository, it won't get synchronized with the remote reposoitory any more. There is no possibility to synchronize it ever again.
   repository_directory:
     create: Successfully created directory "%{name}".
     create_additional: "That is, the following directories have been created: %{directories}"
@@ -61,7 +61,7 @@ en:
       placeholder:
         name: Directory name
       hint:
-        slashes: Use slashes to directly create subdirectories.e. There is no possibility to synchronize it ever again.
+        slashes: Use slashes to directly create subdirectories.
   permission:
     delete_header: Are you sure you want to delete the permission?
     delete_desc: If you remove this %{role} permission, %{subject} won't be able to access the %{class} %{item} according to it.

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -2,6 +2,11 @@ en:
   simple_form:
     "yes": 'Yes'
     "no": 'No'
+    options:
+      repository:
+        remote_type:
+          fork: Fork
+          mirror: Mirror
     
     creating: "Creating..."
     updating: 'Updating...'
@@ -30,6 +35,8 @@ en:
       logic:
         extension: File extension
         mimetype: MIME-Type
+      repository:
+        remote_type: Remote Type
     hints:
       ontology_version:
     placeholders:

--- a/db/migrate/20140916084320_add_remote_type_to_repository.rb
+++ b/db/migrate/20140916084320_add_remote_type_to_repository.rb
@@ -1,0 +1,5 @@
+class AddRemoteTypeToRepository < ActiveRecord::Migration
+  def change
+    add_column :repositories, :remote_type, :string, null: true
+  end
+end

--- a/spec/controllers/files_controller_spec.rb
+++ b/spec/controllers/files_controller_spec.rb
@@ -156,13 +156,8 @@ describe FilesController do
     end
 
     context "signed in, on mirror repository" do
+      let(:repository) { create :repository_with_empty_remote }
       let(:user){ create(:permission, item: repository).subject }
-      before do
-        sign_in user
-        repository.source_address = 'http://some_source_address.example.com'
-        repository.source_type = 'git'
-        repository.save
-      end
 
       context "new" do
         before { get :new, repository_id: repository.to_param }

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -50,7 +50,47 @@ describe RepositoriesController do
       it { should respond_with :success }
       it { should render_template :show }
     end
-
   end
 
+  context 'creating a clone', :process_jobs_synchronously do
+    context 'signed in' do
+      let(:user) { create :user }
+      let(:git_repository) { create :git_repository }
+      before do
+        sign_in user
+      end
+
+      context 'mirror' do
+        before do
+          post :create, repository: { name: 'repo',
+            source_address: "file://#{git_repository.path}" },
+            remote_type: 'mirror'
+        end
+
+        after do
+          FileUtils.rm_rf(git_repository.path)
+        end
+
+        it { should respond_with :found }
+        it { response.should redirect_to Repository.find_by_path('repo') }
+        it 'should have created a mirrored repository' do
+          expect(Repository.find_by_path('repo').mirror?).to be_truthy
+        end
+      end
+
+      context 'fork' do
+        before do
+          post :create, repository: { name: 'repo',
+            source_address: "file://#{git_repository.path}" },
+            remote_type: 'fork'
+        end
+
+        it { should respond_with :found }
+        it { response.should redirect_to Repository.find_by_path('repo') }
+        it 'should have created a non-mirrored repository' do
+          expect(Repository.find_by_path('repo').mirror?).to be_falsy
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -63,8 +63,8 @@ describe RepositoriesController do
       context 'mirror' do
         before do
           post :create, repository: { name: 'repo',
-            source_address: "file://#{git_repository.path}" },
-            remote_type: 'mirror'
+            source_address: "file://#{git_repository.path}",
+            remote_type: 'mirror' }
         end
 
         after do
@@ -81,8 +81,8 @@ describe RepositoriesController do
       context 'fork' do
         before do
           post :create, repository: { name: 'repo',
-            source_address: "file://#{git_repository.path}" },
-            remote_type: 'fork'
+            source_address: "file://#{git_repository.path}",
+            remote_type: 'fork' }
         end
 
         it { should respond_with :found }

--- a/spec/controllers/ssh_access_controller_spec.rb
+++ b/spec/controllers/ssh_access_controller_spec.rb
@@ -51,7 +51,10 @@ describe SSHAccessController do
   end
 
   context 'should return false-permission on valid request with write to mirror' do
-    let(:repository) { create :repository, source_address: 'http://some_source_address.example.com', source_type: 'git' }
+    let(:repository) { create :repository,
+      source_address: 'http://some_source_address.example.com',
+      source_type: 'git',
+      remote_type: 'mirror' }
     let!(:key) { create :key, user: user }
     before do
       get :index, repository_id: repository.to_param, key_id: key.id.to_s, permission: 'write'

--- a/spec/controllers/ssh_access_controller_spec.rb
+++ b/spec/controllers/ssh_access_controller_spec.rb
@@ -51,10 +51,7 @@ describe SSHAccessController do
   end
 
   context 'should return false-permission on valid request with write to mirror' do
-    let(:repository) { create :repository,
-      source_address: 'http://some_source_address.example.com',
-      source_type: 'git',
-      remote_type: 'mirror' }
+    let(:repository) { create :repository_with_empty_remote }
     let!(:key) { create :key, user: user }
     before do
       get :index, repository_id: repository.to_param, key_id: key.id.to_s, permission: 'write'

--- a/spec/factories/repository_factory.rb
+++ b/spec/factories/repository_factory.rb
@@ -38,5 +38,10 @@ FactoryGirl.define do
         repository.source_address = path
       end
     end
+
+    factory :repository_git_mirror do
+      remote_type { 'mirror' }
+      source_type { 'git' }
+    end
   end
 end

--- a/spec/factories/repository_factory.rb
+++ b/spec/factories/repository_factory.rb
@@ -27,5 +27,14 @@ FactoryGirl.define do
         repository.source_address = path
       end
     end
+
+    factory :repository_with_empty_remote do |repository|
+      repository.after(:build) do |repository|
+        path = File.join(Ontohub::Application.config.git_root, 'repository')
+        git_repository = GitRepository.new(path)
+        repository.source_type = 'git'
+        repository.source_address = path
+      end
+    end
   end
 end

--- a/spec/factories/repository_factory.rb
+++ b/spec/factories/repository_factory.rb
@@ -23,6 +23,7 @@ FactoryGirl.define do
         commit_add2 = git_repository.commit_file(userinfo, File.read(File.join(fixture_path, filepath2)), filepath2, message)
         commit_add3 = git_repository.commit_file(userinfo, File.read(File.join(fixture_path, 'cat2.clif')), filepath1, message)
 
+        repository.remote_type ||= 'mirror'
         repository.source_type = 'git'
         repository.source_address = path
       end
@@ -32,6 +33,7 @@ FactoryGirl.define do
       repository.after(:build) do |repository|
         path = File.join(Ontohub::Application.config.git_root, 'repository')
         git_repository = GitRepository.new(path)
+        repository.remote_type ||= 'mirror'
         repository.source_type = 'git'
         repository.source_address = path
       end

--- a/spec/lib/repository/import/git_spec.rb
+++ b/spec/lib/repository/import/git_spec.rb
@@ -13,7 +13,8 @@ describe "git import" do
       user,
       "file://#{remote_repo.path}",
       'local import',
-      description: 'just an imported repo')
+      description: 'just an imported repo',
+      remote_type: 'mirror')
   end
 
   before { Worker.drain }

--- a/spec/lib/repository/import/svn_spec.rb
+++ b/spec/lib/repository/import/svn_spec.rb
@@ -29,7 +29,8 @@ describe "svn import" do
       user,
       bare_url,
       'local import',
-      description: 'just an imported repo')
+      description: 'just an imported repo',
+      remote_type: 'mirror')
   end
 
   before do

--- a/spec/lib/sidetiq_worker_spec.rb
+++ b/spec/lib/sidetiq_worker_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper'
 
 describe SidetiqWorker do
 
-  subject!{ create :repository, source_address: 'remote.git', source_type: 'git' }
+  subject! do
+    create :repository, source_address: 'remote.git', source_type: 'git',
+      remote_type: 'mirror'
+  end
   before{ Worker.clear }
 
   shared_examples 'perform' do |state, minutes, created_jobs_count|

--- a/spec/lib/sidetiq_worker_spec.rb
+++ b/spec/lib/sidetiq_worker_spec.rb
@@ -1,11 +1,7 @@
 require 'spec_helper'
 
 describe SidetiqWorker do
-
-  subject! do
-    create :repository, source_address: 'remote.git', source_type: 'git',
-      remote_type: 'mirror'
-  end
+  subject! { create :repository_with_empty_remote }
   before{ Worker.clear }
 
   shared_examples 'perform' do |state, minutes, created_jobs_count|
@@ -30,5 +26,4 @@ describe SidetiqWorker do
   include_examples 'perform', :done,        20, 1
   include_examples 'perform', :failed,     nil, 0
   include_examples 'perform', :failed,      20, 0
-
 end

--- a/spec/lib/ssh_access_spec.rb
+++ b/spec/lib/ssh_access_spec.rb
@@ -58,6 +58,7 @@ describe SSHAccess do
 
     it 'should raise error on write to mirror repository' do
       repository.source_address = 'http://some_source_address.example.com'
+      repository.source_type = 'git'
       expect { described_class.determine_permission('write', nil, repository) }.
         to raise_error(SSHAccess::InvalidAccessOnMirrorError)
     end
@@ -83,6 +84,7 @@ describe SSHAccess do
 
       it 'should raise error on write to mirror repository' do
         repository.source_address = 'http://some_source_address.example.com'
+        repository.source_type = 'git'
         expect { described_class.determine_permission('write', permission, repository) }.
           to raise_error(SSHAccess::InvalidAccessOnMirrorError)
       end
@@ -105,6 +107,7 @@ describe SSHAccess do
 
       it 'should raise error on write to mirror repository' do
         repository.source_address = 'http://some_source_address.example.com'
+        repository.source_type = 'git'
         expect { described_class.determine_permission('write', permission, repository) }.
           to raise_error(SSHAccess::InvalidAccessOnMirrorError)
       end
@@ -160,6 +163,7 @@ describe SSHAccess do
 
     it 'should raise error on write to mirror repository' do
       repository.source_address = 'http://some_source_address.example.com'
+      repository.source_type = 'git'
       expect { described_class.determine_permission('write', permission, repository) }.
         to raise_error(SSHAccess::InvalidAccessOnMirrorError)
     end

--- a/spec/lib/ssh_access_spec.rb
+++ b/spec/lib/ssh_access_spec.rb
@@ -59,6 +59,7 @@ describe SSHAccess do
     it 'should raise error on write to mirror repository' do
       repository.source_address = 'http://some_source_address.example.com'
       repository.source_type = 'git'
+      repository.remote_type = 'mirror'
       expect { described_class.determine_permission('write', nil, repository) }.
         to raise_error(SSHAccess::InvalidAccessOnMirrorError)
     end
@@ -85,6 +86,7 @@ describe SSHAccess do
       it 'should raise error on write to mirror repository' do
         repository.source_address = 'http://some_source_address.example.com'
         repository.source_type = 'git'
+        repository.remote_type = 'mirror'
         expect { described_class.determine_permission('write', permission, repository) }.
           to raise_error(SSHAccess::InvalidAccessOnMirrorError)
       end
@@ -108,6 +110,7 @@ describe SSHAccess do
       it 'should raise error on write to mirror repository' do
         repository.source_address = 'http://some_source_address.example.com'
         repository.source_type = 'git'
+        repository.remote_type = 'mirror'
         expect { described_class.determine_permission('write', permission, repository) }.
           to raise_error(SSHAccess::InvalidAccessOnMirrorError)
       end
@@ -164,6 +167,7 @@ describe SSHAccess do
     it 'should raise error on write to mirror repository' do
       repository.source_address = 'http://some_source_address.example.com'
       repository.source_type = 'git'
+      repository.remote_type = 'mirror'
       expect { described_class.determine_permission('write', permission, repository) }.
         to raise_error(SSHAccess::InvalidAccessOnMirrorError)
     end

--- a/spec/models/repository/git_mv_spec.rb
+++ b/spec/models/repository/git_mv_spec.rb
@@ -12,10 +12,9 @@ describe 'git mv', :process_jobs_synchronously do
   end
 
   let(:remote_repository) { create :git_repository_with_moved_ontologies }
-  let(:repository) { create :repository,
-    source_address: remote_repository.path,
-    source_type: 'git',
-    remote_type: 'mirror' }
+  let(:repository) do
+    create :repository_git_mirror, source_address: remote_repository.path
+  end
 
   before do
     stub_hets_for(hets_out_file('Px'), with: 'Px')

--- a/spec/models/repository/git_mv_spec.rb
+++ b/spec/models/repository/git_mv_spec.rb
@@ -13,7 +13,9 @@ describe 'git mv', :process_jobs_synchronously do
 
   let(:remote_repository) { create :git_repository_with_moved_ontologies }
   let(:repository) { create :repository,
-    source_address: remote_repository.path, source_type: 'git' }
+    source_address: remote_repository.path,
+    source_type: 'git',
+    remote_type: 'mirror' }
 
   before do
     stub_hets_for(hets_out_file('Px'), with: 'Px')

--- a/spec/models/repository/git_spec.rb
+++ b/spec/models/repository/git_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Repository do
   setup_hets
 
-  let(:repository) { create :repository_with_remote }
+  let(:repository) { create :repository_with_remote, remote_type: 'mirror' }
 
   context 'when ontohub clones a remote repository' do
 

--- a/spec/models/repository/remote_spec.rb
+++ b/spec/models/repository/remote_spec.rb
@@ -16,6 +16,10 @@ describe 'Repository Remote' do
       it 'should become a non-mirrored repository' do
         expect(repository.mirror?).to be_falsy
       end
+
+      it 'should become a forked repository' do
+        expect(repository.fork?).to be_truthy
+      end
     end
   end
 
@@ -29,6 +33,10 @@ describe 'Repository Remote' do
 
     it 'should be a non-mirrored repository' do
       expect(repository.mirror?).to be_falsy
+    end
+
+    it 'should be a forked repository' do
+      expect(repository.fork?).to be_truthy
     end
   end
 end

--- a/spec/models/repository/remote_spec.rb
+++ b/spec/models/repository/remote_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Repository Remote' do
   context 'converting' do
-    let(:repository) { create :repository_with_remote }
+    let(:repository) { create :repository_with_remote, remote_type: 'mirror' }
 
     it 'should be a mirrored reppository' do
       expect(repository.mirror?).to be_truthy
@@ -24,12 +24,7 @@ describe 'Repository Remote' do
   end
 
   context 'forking', :process_jobs_synchronously do
-    let!(:repository) do
-      r = build :repository_with_remote
-      r.remote_type = 'fork'
-      r.save!
-      r.reload
-    end
+    let!(:repository) { create :repository_with_remote, remote_type: 'fork' }
 
     it 'should be a non-mirrored repository' do
       expect(repository.mirror?).to be_falsy
@@ -37,6 +32,22 @@ describe 'Repository Remote' do
 
     it 'should be a forked repository' do
       expect(repository.fork?).to be_truthy
+    end
+  end
+
+  context 'remote_type' do
+    context 'without source address' do
+      let(:repository) { create :repository, remote_type: 'fork' }
+      it 'should not have a remote type after saving' do
+        expect(repository.remote_type?).to be_falsy
+      end
+    end
+
+    context 'with source address' do
+      let(:repository) { create :repository_with_remote, remote_type: 'fork' }
+      it 'should have a remote type after saving' do
+        expect(repository.remote_type?).to be_truthy
+      end
     end
   end
 end

--- a/spec/models/repository/remote_spec.rb
+++ b/spec/models/repository/remote_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'Repository Remote' do
+  let(:repository) { create :repository_with_remote }
+
+  it 'should be a mirrored reppository' do
+    expect(repository.mirror?).to be_truthy
+  end
+
+  context 'convert to local' do
+    before do
+      repository.convert_to_local!
+    end
+
+    it 'should become a non-mirrored repository' do
+      expect(repository.mirror?).to be_falsy
+    end
+  end
+end

--- a/spec/models/repository/remote_spec.rb
+++ b/spec/models/repository/remote_spec.rb
@@ -1,18 +1,33 @@
 require 'spec_helper'
 
 describe 'Repository Remote' do
-  let(:repository) { create :repository_with_remote }
+  context 'converting' do
+    let(:repository) { create :repository_with_remote }
 
-  it 'should be a mirrored reppository' do
-    expect(repository.mirror?).to be_truthy
-  end
-
-  context 'convert to local' do
-    before do
-      repository.convert_to_local!
+    it 'should be a mirrored reppository' do
+      expect(repository.mirror?).to be_truthy
     end
 
-    it 'should become a non-mirrored repository' do
+    context 'convert to local' do
+      before do
+        repository.convert_to_local!
+      end
+
+      it 'should become a non-mirrored repository' do
+        expect(repository.mirror?).to be_falsy
+      end
+    end
+  end
+
+  context 'forking', :process_jobs_synchronously do
+    let!(:repository) do
+      r = build :repository_with_remote
+      r.remote_type = 'fork'
+      r.save!
+      r.reload
+    end
+
+    it 'should be a non-mirrored repository' do
       expect(repository.mirror?).to be_falsy
     end
   end

--- a/spec/models/repository/remote_spec.rb
+++ b/spec/models/repository/remote_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Repository Remote' do
   context 'converting' do
-    let(:repository) { create :repository_with_remote, remote_type: 'mirror' }
+    let(:repository) { create :repository_with_empty_remote, remote_type: 'mirror' }
 
     it 'should be a mirrored reppository' do
       expect(repository.mirror?).to be_truthy
@@ -24,7 +24,7 @@ describe 'Repository Remote' do
   end
 
   context 'forking', :process_jobs_synchronously do
-    let!(:repository) { create :repository_with_remote, remote_type: 'fork' }
+    let!(:repository) { create :repository_with_empty_remote, remote_type: 'fork' }
 
     it 'should be a non-mirrored repository' do
       expect(repository.mirror?).to be_falsy
@@ -44,7 +44,7 @@ describe 'Repository Remote' do
     end
 
     context 'with source address' do
-      let(:repository) { create :repository_with_remote, remote_type: 'fork' }
+      let(:repository) { create :repository_with_empty_remote, remote_type: 'fork' }
       it 'should have a remote type after saving' do
         expect(repository.remote_type?).to be_truthy
       end


### PR DESCRIPTION
Shall fix both issues of #634 (and #351): Allowing to fork a repository and converting a mirror to a local repository.

This also improves the javascript in the new repository view as it now updates everytime the source address is changed (key press, click, cut, paste) and not only when its input field loses focus.