### PR TITLE
fix directory not displayed error

### DIFF
--- a/app/models/repository_file.rb
+++ b/app/models/repository_file.rb
@@ -95,13 +95,17 @@ class RepositoryFile < FakeRecord
     ungrouped = content.each_with_index { |entry,i| entry.index = i }
     intermediate_grouped = ungrouped.group_by { |e| {type: e.type, name: basename(e.name)} }
     @grouped = intermediate_grouped.reduce({}) do |hash, (key, value)|
-      hash[key[:name]] = value
+      hash[key] = value
       hash
     end
   end
 
   def basename(name)
-    name.split('.')[0..-2].join('.')
+    if name.length > 0 && name[1..-1].include?('.')
+      name.split('.')[0..-2].join('.')
+    else
+      name
+    end
   end
 
 


### PR DESCRIPTION
This should fix #1041 by cherry-picking 7a6e8ca0d5de14eca99188bc28666d003c467de5 from 961-folder_creation. I tested it on my local machine with spaceportal. It seems to work: 11 folders/files are displayed instead of only 4.
