### PR TITLE
Basic provisioning working with Chef and Vagrant; much left to do

### DIFF
--- a/provisioning/Cheffile
+++ b/provisioning/Cheffile
@@ -1,0 +1,9 @@
+site "http://community.opscode.com/api/v1"
+
+cookbook 'apt'
+cookbook 'ruby'
+cookbook 'rvm'
+cookbook 'postgresql'
+cookbook 'hets', :path => 'hets'
+cookbook 'ontohub', :path => 'ontohub'
+

--- a/provisioning/README.md
+++ b/provisioning/README.md
@@ -1,0 +1,42 @@
+# Ontohub Provisioning
+
+This directory contains scripts to help install Ontohub on a variety of target systems. We use three main tools: [VirtualBox](https://www.virtualbox.org) and [Vagrant](http://www.vagrantup.com) for setting up virtual machines (optional), and [Chef](https://www.getchef.com) for installing software. They work particularly well together.
+
+NOTE: This system is not complete. The database and service configuration have not been started yet.
+
+
+# Virtual Box
+
+Ontohub development focuses on deployment to [Ubuntu](http://www.ubuntu.com) Linux. But this guide was developed on a laptop running Mac OS X using VirtualBox to host Ubuntu virtual machines. This is particularly convenient for testing, because a new virtual machine can easily be set up from scratch and deleted when finished. VirtualBox is meant for development, not deployment.
+
+Install VirtualBox and the Extension Pack from: <https://www.virtualbox.org/wiki/Downloads>. Version 4.3.16 was used for this guide.
+
+
+# Vagrant
+
+Vagrant is very useful for scripting VirtualBox virtual machines, but also works with various cloud hosting providers -- collectively called "boxes". Version 1.6.5 was used for this guide, along with some critical plugins. Install Vagrant from <http://www.vagrantup.com/downloads.html> and install these two plugins:
+
+    vagrant plugin install vagrant-vbguest
+    vagrant plugin install vagrant-librarian-chef
+
+Another nice thing about Vagrant is that it will automatically run Chef to provision software on the new box. But you can also use Chef by itself.
+
+In a terminal, change to this directory, then use these commands to start, log in to, then destroy a box:
+
+    vagrant up
+    vagrant ssh
+    vagrant destroy
+
+The `Vagrantfile` contains all the configuration.
+
+
+# Chef
+
+Chef is a tool for provisioning software. It abstract away from many of the differences between systems and allows for repeatable, predictable installations. Chef "cookbooks" contain instructions for installing and configuring a particular application. We define two cookbooks, for hets and ontohub, and use [Librarian-Chef](https://github.com/applicationsonline/librarian-chef) to fetch some other cookbooks that ours depend on.
+
+The main Librarian-Chef configuration is in the `Cheffile`, which gives a source for cookbooks to fetch into the `cookbooks`. Our own cookbooks have separate directories with a `metadata.rb` and `recipes/default.rb` file. The `metadata.rb` file provides information and specified dependencies, while the `defalt.rb` file contains the instructions for Chef.
+
+TODO: code for running Chef by itself, without Vagrant.
+
+
+

--- a/provisioning/Vagrantfile
+++ b/provisioning/Vagrantfile
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Every Vagrant virtual environment requires a box to build off of.
+  # We are using the cloud server version of Ubuntu 14.04 Trusy Tahr.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Configurate the virtual machine to use 2GB of RAM
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
+  end
+
+  # Add i386 architecture to support the udrawgraph package.
+  config.vm.provision :shell, privileged: true, 
+    :inline => "dpkg --add-architecture i386"
+ 
+  # Use Chef Solo to provision our virtual machine
+  config.vm.provision :chef_solo do |chef|
+    chef.cookbooks_path = ["cookbooks"]
+    chef.add_recipe "ontohub"
+  end
+end

--- a/provisioning/hets/metadata.rb
+++ b/provisioning/hets/metadata.rb
@@ -1,0 +1,12 @@
+name             "hets"
+maintainer       "James A. Overton"
+maintainer_email "james@overton.ca"
+license          "MIT"
+description      "Installs Hets"
+long_description "TODO"
+version          "0.0.1"
+
+supports "ubuntu"
+supports "debian"
+
+depends "apt", ">= 1.9.0"

--- a/provisioning/hets/recipes/default.rb
+++ b/provisioning/hets/recipes/default.rb
@@ -1,0 +1,24 @@
+execute 'add-apt-repository ppa:hets/hets' do
+  user 'root'
+end
+
+execute 'apt-get update' do
+  user 'root'
+end
+
+apt_repository 'hets' do
+  uri          'http://ppa.launchpad.net/hets/hets/ubuntu'
+  distribution 'trusty'
+  components   ['main']
+  keyserver    'keyserver.ubuntu.com'
+  key          '2A2314D8'
+end
+
+package 'hets' do
+  action :install
+end
+
+execute 'hets -update' do
+  user 'root'
+end
+

--- a/provisioning/ontohub/metadata.rb
+++ b/provisioning/ontohub/metadata.rb
@@ -1,0 +1,16 @@
+name             "ontohub"
+maintainer       "James A. Overton"
+maintainer_email "james@overton.ca"
+license          "MIT"
+description      "Installs Ontohub"
+long_description "TODO"
+version          "0.0.1"
+
+supports "ubuntu"
+supports "debian"
+
+depends "apt", ">= 1.9.0"
+depends "hets", ">= 0.0.1"
+depends "ruby"
+depends "rvm"
+depends "postgresql"

--- a/provisioning/ontohub/recipes/default.rb
+++ b/provisioning/ontohub/recipes/default.rb
@@ -1,0 +1,57 @@
+# Ontohub install recipe, based on:
+# https://github.com/ontohub/ontohub/blob/staging/script/install-on-ubuntu
+
+
+### Dependencies
+# Some are covered elsewhere: hets, postgresql
+%w{build-essential openssl libreadline6 libreadline6-dev
+   curl git-core zlib1g zlib1g-dev libssl-dev libyaml-dev
+   libsqlite3-0 libsqlite3-dev sqlite3 libxml2-dev libxslt-dev
+   autoconf libc6-dev ncurses-dev automake libtool bison
+   subversion libpq-dev redis-server libqtwebkit-dev}.each do |pkg|
+  package pkg do
+    action :install
+  end
+end
+
+# Dependency debugging (can be merged with the list above)
+# Fix for `require': cannot load such file -- mkmf (LoadError)
+# http://stackoverflow.com/questions/7645918/require-no-such-file-to-load-mkmf-loaderror
+# Fix ERROR: CMake is required to build Rugged
+# Fix ERROR: pkg-config is required to build Rugged.
+%w{ruby-dev cmake pkg-config}.each do |pkg|
+  package pkg do
+    action :install
+  end
+end
+
+
+### Install Ontohub
+# TODO: Workarounds
+# sudo ln -s /lib/x86_64-linux-gnu/libpng12.so.0 /lib/x86_64-linux-gnu/libpng14.so.14
+
+user 'ontohub'
+
+directory '/opt/ontohub' do
+  owner 'ontohub'
+end
+
+git '/opt/ontohub' do
+  repository 'git://github.com/ontohub/ontohub.git'
+  revision 'master'
+  action :sync
+  user 'ontohub'
+end
+
+gem_package 'bundler'
+
+execute 'bundle-install' do
+  cwd '/opt/ontohub'
+  user 'ontohub'
+  command '/usr/local/bin/bundle install --path /opt/ontohub/.bundler'
+end
+
+
+### Configure Ontohub
+# TODO
+


### PR DESCRIPTION
Here are some scripts and documentation for using Chef (and optionally Vagrant) to install Ontohub. See issue #785.

The system is not yet complete. It installs all the dependencies and runs "bundle install" but does not configure the database or do many of the other things in the deployment guide. Still, I hope it's helpful.