### PR TITLE
fix default branch in history

### DIFF
--- a/app/models/history_entries_page.rb
+++ b/app/models/history_entries_page.rb
@@ -45,7 +45,7 @@ class HistoryEntriesPage < FakeRecord
   end
 
   def compute_ref(repository, ref)
-    repository.commit_id(ref || DEFAULT_BRANCH)
+    repository.commit_id(ref || Settings.git.default_branch)
   end
 
   # This ensures that the 'next' button always exists in the view.


### PR DESCRIPTION
When moving the constant `DEFAULT_BRANCH` to the yml, I must have forgotten to actually use the settings variable.
