### PR TITLE
Delete repositories and other data after a spec

### DIFF
--- a/config/database_cleaner.rb
+++ b/config/database_cleaner.rb
@@ -23,9 +23,11 @@ module DatabaseCleanerConfig
       config.after(:each) do
         DatabaseCleaner.clean
 
-        # Remove repositories
-        dir = Rails.root.join("tmp","repositories")
-        dir.rmtree if dir.exist?
+        # Remove repositories and other data created in a test
+        %w(data test).each do |d|
+          dir = Rails.root.join('tmp', d)
+          dir.rmtree if dir.exist?
+        end
       end
     end
   end


### PR DESCRIPTION
This shall fix #1058.

Specs create different data, mostly in the `tmp/data/repositories` (bare git repositories) directory, but also in 
- `tmp/data/commits` (checked out ontology files)
- `tmp/data/git_daemon` (symlinks) and 
- `tmp/repositories` (remote repositories)

Those are deleted after every spec now.
