### PR TITLE
617 handle file deletion

### DIFF
--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -49,11 +49,18 @@ class FilesController < InheritedResources::Base
   def update
     @repository_file = resource_class.create(params.merge(user: current_user))
     if resource.valid?
-      flash[:success] = "Successfully changed the file."
+      flash[:success] = "Successfully changed the file #{params[:path]}."
       redirect_to fancy_repository_path(repository, path: resource.target_path)
     else
       render :show
     end
+  end
+
+  def destroy
+    repository.delete_file(params[:path], current_user)
+    flash[:success] = "Successfully deleted the file #{params[:path]}."
+    redirect_to(fancy_repository_path(repository,
+      path: repository.deepest_existing_dir(params[:path])))
   end
 
   protected

--- a/app/helpers/files_helper.rb
+++ b/app/helpers/files_helper.rb
@@ -71,4 +71,8 @@ module FilesHelper
     RepositoryDirectory.new(params.merge(
       repository_directory: {target_directory: dirpath(repository)}))
   end
+
+  def can_change_file?
+    can?(:write, repository) && resource.file? && !in_ref_path?
+  end
 end

--- a/app/helpers/ontology_helper.rb
+++ b/app/helpers/ontology_helper.rb
@@ -56,7 +56,8 @@ module OntologyHelper
   end
 
   def last_file_path(resource)
-    repository_ref_path(repository_id: resource.repository.to_param,
+    repository_ref_path(
+      repository_id: resource.repository.to_param,
       ref: resource.current_version.commit_oid,
       path: resource.current_version.path,
       action: :show)

--- a/app/helpers/ontology_helper.rb
+++ b/app/helpers/ontology_helper.rb
@@ -13,4 +13,52 @@ module OntologyHelper
   def show_evaluate?
     show_oops? #|| show_foo?
   end
+
+  def status_tag(resource)
+    version = resource.is_a?(Ontology) ? resource.current_version : resource
+    uri = repository_ontology_ontology_version_url(
+      version.ontology.repository, version.ontology, version)
+    html_opts = {
+      class: 'ontology-version-state',
+      data: {
+        ontology_version_id: version.id,
+        uri: uri,
+        state: version.state,
+      }
+    }
+    content_tag(:small, html_opts) do
+      status(version)
+    end
+  end
+
+  def status(resource)
+    html = content_tag :span, resource.state
+
+    if %w(pending fetching processing).include? resource.state
+      html << " " << image_tag('spinner-16x16.gif', class: 'spinner')
+    end
+
+    if resource.state == 'failed' and resource.is_a? Ontology
+      version = resource.versions.last
+
+      link = ' ('
+      link << link_to('error',
+        [resource.repository, resource, :ontology_versions],
+        :'data-original-title' => version.last_error,
+        class: 'help'
+      )
+      link << ')'
+
+      html << content_tag(:span, link.html_safe, class: 'error')
+    end
+
+    html
+  end
+
+  def last_file_path(resource)
+    repository_ref_path(repository_id: resource.repository.to_param,
+      ref: resource.current_version.commit_oid,
+      path: resource.current_version.path,
+      action: :show)
+  end
 end

--- a/app/helpers/ontology_helper.rb
+++ b/app/helpers/ontology_helper.rb
@@ -14,47 +14,6 @@ module OntologyHelper
     show_oops? #|| show_foo?
   end
 
-  def status_tag(resource)
-    version = resource.is_a?(Ontology) ? resource.current_version : resource
-    uri = repository_ontology_ontology_version_url(
-      version.ontology.repository, version.ontology, version)
-    html_opts = {
-      class: 'ontology-version-state',
-      data: {
-        ontology_version_id: version.id,
-        uri: uri,
-        state: version.state,
-      }
-    }
-    content_tag(:small, html_opts) do
-      status(version)
-    end
-  end
-
-  def status(resource)
-    html = content_tag :span, resource.state
-
-    if %w(pending fetching processing).include? resource.state
-      html << " " << image_tag('spinner-16x16.gif', class: 'spinner')
-    end
-
-    if resource.state == 'failed' and resource.is_a? Ontology
-      version = resource.versions.last
-
-      link = ' ('
-      link << link_to('error',
-        [resource.repository, resource, :ontology_versions],
-        :'data-original-title' => version.last_error,
-        class: 'help'
-      )
-      link << ')'
-
-      html << content_tag(:span, link.html_safe, class: 'error')
-    end
-
-    html
-  end
-
   def last_file_path(resource)
     repository_ref_path(
       repository_id: resource.repository.to_param,

--- a/app/models/ontology.rb
+++ b/app/models/ontology.rb
@@ -195,6 +195,14 @@ class Ontology < ActiveRecord::Base
     current_version.locid
   end
 
+  def has_file(commit_oid = nil)
+    if !repository.is_head?(commit_oid)
+      repository.path_exists?(path, commit_oid)
+    else
+      read_attribute(:has_file)
+    end
+  end
+
   protected
 
   def import_mappings

--- a/app/models/ontology.rb
+++ b/app/models/ontology.rb
@@ -206,7 +206,7 @@ class Ontology < ActiveRecord::Base
 
   def has_file(commit_oid = nil)
     if repository.is_head?(commit_oid)
-      read_attribute(:has_file)
+      self[:has_file]
     else
       repository.path_exists?(path, commit_oid)
     end

--- a/app/models/ontology.rb
+++ b/app/models/ontology.rb
@@ -195,6 +195,7 @@ class Ontology < ActiveRecord::Base
     current_version.locid
   end
 
+  # Checks if a file at the given commit (HEAD if nil) doesn't exist.
   def file_deleted?(commit_oid = nil)
     !has_file?(commit_oid)
   end

--- a/app/models/ontology.rb
+++ b/app/models/ontology.rb
@@ -195,11 +195,20 @@ class Ontology < ActiveRecord::Base
     current_version.locid
   end
 
+  def file_deleted?(commit_oid = nil)
+    !has_file?(commit_oid)
+  end
+
+  # alias_method doesn't work for this one.
+  def has_file?(commit_oid = nil)
+    has_file(commit_oid)
+  end
+
   def has_file(commit_oid = nil)
-    if !repository.is_head?(commit_oid)
-      repository.path_exists?(path, commit_oid)
-    else
+    if repository.is_head?(commit_oid)
       read_attribute(:has_file)
+    else
+      repository.path_exists?(path, commit_oid)
     end
   end
 

--- a/app/models/ontology/associations_and_attributes.rb
+++ b/app/models/ontology/associations_and_attributes.rb
@@ -37,6 +37,7 @@ module Ontology::AssociationsAndAttributes
 
     attr_accessible :iri, :locid
     attr_accessible :name, :description, :acronym, :documentation,
+                    :has_file,
                     :logic_id,
                     :category_ids,
                     :acronym,

--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -5,7 +5,8 @@ module Repository::Git
 
   delegate :commit_id, :dir?, :empty?, :get_file, :has_changed?,
            :is_head?, :path_exists?, :paths_starting_with,
-           :points_through_file?, :deepest_existing_dir, to: :git
+           :points_through_file?, :deepest_existing_dir,
+           to: :git
 
   included do
     after_create  :create_and_init_git

--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -40,7 +40,7 @@ module Repository::Git
   def delete_file(filepath, user, message = nil, &block)
     commit_oid = git.delete_file(user_info(user), filepath, &block)
     commit_for!(commit_oid).commit_oid
-    mark_ontology_as_having_file(filepath, false)
+    mark_ontology_as_having_file(filepath, has_file: false)
   end
 
   def save_file(tmp_file, filepath, message, user, do_not_parse: false)
@@ -177,7 +177,7 @@ module Repository::Git
       git.changed_files(commit.oid).each { |f|
         current_file_count += 1
         if f.added? || f.modified?
-          mark_ontology_as_having_file(f.path, true)
+          mark_ontology_as_having_file(f.path, has_file: true)
           ontology_version_options = OntologyVersionOptions.new(
             f.path,
             options.delete(:user),
@@ -193,7 +193,7 @@ module Repository::Git
             previous_filepath: f.delta.old_file[:path])
           versions << save_ontology(commit.oid, ontology_version_options)
         elsif f.deleted?
-          mark_ontology_as_having_file(f.path, false)
+          mark_ontology_as_having_file(f.path, has_file: false)
         end
       }
       highest_change_file_count = [highest_change_file_count,
@@ -225,7 +225,7 @@ module Repository::Git
     @priority_settings ||= OpenStruct.new(Settings.git[:push_priority])
   end
 
-  def mark_ontology_as_having_file(path, has_file)
+  def mark_ontology_as_having_file(path, has_file: false)
     ontos = ontologies.with_path(path)
     return unless ontos.any? { |onto| onto.has_file != has_file }
     ontos.each do |onto|

--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -40,6 +40,7 @@ module Repository::Git
   def delete_file(filepath, user, message = nil, &block)
     commit_oid = git.delete_file(user_info(user), filepath, &block)
     commit_for!(commit_oid).commit_oid
+    mark_ontology_as_having_file(filepath, false)
   end
 
   def save_file(tmp_file, filepath, message, user, do_not_parse: false)

--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -4,8 +4,8 @@ module Repository::Git
   extend ActiveSupport::Concern
 
   delegate :commit_id, :dir?, :empty?, :get_file, :has_changed?,
-    :is_head?, :path_exists?, :paths_starting_with, :points_through_file?,
-    :deepest_existing_dir, to: :git
+           :is_head?, :path_exists?, :paths_starting_with,
+           :points_through_file?, :deepest_existing_dir, to: :git
 
   included do
     after_create  :create_and_init_git

--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -5,7 +5,7 @@ module Repository::Git
 
   delegate :commit_id, :dir?, :empty?, :get_file, :has_changed?,
     :is_head?, :path_exists?, :paths_starting_with, :points_through_file?,
-    to: :git
+    :deepest_existing_dir, to: :git
 
   included do
     after_create  :create_and_init_git

--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -227,11 +227,10 @@ module Repository::Git
 
   def mark_ontology_as_having_file(path, has_file)
     ontos = ontologies.with_path(path)
-    if ontos.any?{ |onto| onto.has_file != has_file }
-      ontos.each do |onto|
-        onto.has_file = has_file
-        onto.save
-      end
+    return unless ontos.any? { |onto| onto.has_file != has_file }
+    ontos.each do |onto|
+      onto.has_file = has_file
+      onto.save
     end
   end
 

--- a/app/models/repository/importing.rb
+++ b/app/models/repository/importing.rb
@@ -80,7 +80,7 @@ module Repository::Importing
     suspended_save_ontologies \
       start_oid:  range.current,
       stop_oid:   range.previous,
-      walk_order: Rugged::SORT_REVERSE
+      walk_order: :reverse
   end
 
   module ClassMethods

--- a/app/views/files/show.html.haml
+++ b/app/views/files/show.html.haml
@@ -22,7 +22,7 @@
   - if can? :write, repository
     - if resource.dir?
       .btn.btn-default.btn-sm#create_subdirectory Create Subdirectory
-    - if resource.file? && !in_ref_path? && display_file?
+    - if can_change_file? && display_file?
       = link_to 'Edit file', '#', id: 'codemirror-btn-edit', class: 'hide-when-editing btn btn-default btn-sm'
     = link_to new_repository_file_path(repository, {'repository_file[target_directory]' => dirpath(repository)}.merge(update_file)), class: 'btn btn-default btn-sm' do
       = resource.dir? ? 'Upload file' : 'Update file'
@@ -30,6 +30,11 @@
     = link_to 'Download file', fancy_repository_path(repository, path: path, ref: oid, action: :download), class: 'btn btn-default btn-sm'
   = link_to fancy_repository_path(repository, action: :history, path: path, ref: ref), class: 'btn btn-default btn-sm' do
     = resource.file? ? 'History of this file' : 'History of this directory'
+  - if can_change_file?
+    = modal_button(t('files.delete.button_text'), btn_class: 'btn btn-danger btn-sm')
+
+- if can_change_file?
+  = modal_body(t('files.delete.header_text'), t('files.delete.body_text', path: resource.path), fancy_repository_path(repository, path: path), t('files.delete.button_text'))
 
 = render partial: 'files/breadcrumbs'
 

--- a/app/views/ontologies/_info.html.haml
+++ b/app/views/ontologies/_info.html.haml
@@ -6,6 +6,9 @@
     - if resource.logic
       = link_to resource.logic.to_s, resource.logic
   = resource.acronym
+  - if resource.file_deleted?
+    %small
+      %span.label.label-warning= t 'ontology.deleted.label'
 
 - if resource.ontology_type
   %small
@@ -19,13 +22,12 @@
       This #{Settings.OMS} is a child of
       %span= fancy_link(resource.parent)
   %p
-    - if resource.has_file
+    - if resource.has_file?
       #{Settings.OMS} defined in the file
       = fancy_link repository_tree_path(resource.repository, resource.path)
     - else
-      The defining file
-      = resource.path
-      of this #{Settings.OMS} was deleted.
+      = t 'ontology.deleted.info', path: resource.path, oms: Settings.OMS
+      = raw "#{link_to t('ontology.deleted.last_file_version'), last_file_path(resource)}."
   - if resource.documentation
     See for detailed documentation
     = link_to resource.documentation, resource.documentation

--- a/app/views/ontologies/_info.html.haml
+++ b/app/views/ontologies/_info.html.haml
@@ -14,12 +14,18 @@
       = fancy_link resource.ontology_type
 
 %small
-  #{Settings.OMS} defined
   - if resource.parent
-    by
-    %span= fancy_link(resource.parent)
-  in the file
-  = fancy_link repository_tree_path(resource.repository, resource.path)
+    %p
+      This #{Settings.OMS} is a child of
+      %span= fancy_link(resource.parent)
+  %p
+    - if resource.has_file
+      #{Settings.OMS} defined in the file
+      = fancy_link repository_tree_path(resource.repository, resource.path)
+    - else
+      The defining file
+      = resource.path
+      of this #{Settings.OMS} was deleted.
   - if resource.documentation
     See for detailed documentation
     = link_to resource.documentation, resource.documentation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,12 @@ en:
         it would leave the %{item} with too few owners.
         The threshold level is: %{minimal_count}.
   files:
+    delete:
+      button_text: Delete File
+      header_text: Are you sure about deleting the file?
+      body_text:
+        If you delete the file %{path}, only the file is deleted from the repository.
+        The containing ontologies will still be accessible, but the file cannot be referenced any more from other ontology files.
     discard: Discard
     discard_confirmation: You made changes to the code. Are you sure you want to discard them?
     discard_desc: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,10 @@ en:
       hint:
         slashes: Use slashes to directly create subdirectories.
   ontology:
+    deleted:
+      label: File deleted
+      info: The defining file %{path} of this %{oms} was deleted. However, you can check the
+      last_file_version: last version of that file
     delete: Delete
     delete_error: Can't delete an %{oms} that's imported by another one.
     delete_confirm:
@@ -104,11 +108,6 @@ en:
       If you discard the changes, the textarea on the left will be reset to the previous state.
 
       This action is irreversible!
-  ontology:
-    deleted:
-      label: File deleted
-      info: The defining file %{path} of this %{oms} was deleted. However, you can check the
-      last_file_version: last version of that file
   sentences:
     sentence:
       defined_in:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,11 @@ en:
       If you discard the changes, the textarea on the left will be reset to the previous state.
 
       This action is irreversible!
+  ontology:
+    deleted:
+      label: File deleted
+      info: The defining file %{path} of this %{oms} was deleted. However, you can check the
+      last_file_version: last version of that file
   sentences:
     sentence:
       defined_in:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -690,6 +690,12 @@ is determined according to its path, which is considered as
     as:          :repository_tree,
     constraints: { path: /.*/ }
 
+  delete ':repository_id/*path',
+    controller: :files,
+    action:     :destroy,
+    as:         :repository_tree,
+    constraints: FilesRouterConstraint.new
+
   get ':repository_id(/*path)',
     controller: :files,
     action:     :show,

--- a/db/migrate/20141008133828_add_has_file_to_ontology.rb
+++ b/db/migrate/20141008133828_add_has_file_to_ontology.rb
@@ -1,0 +1,5 @@
+class AddHasFileToOntology < ActiveRecord::Migration
+  def change
+    add_column :ontologies, :has_file, :boolean, default: true, null: false
+  end
+end

--- a/lib/git_repository.rb
+++ b/lib/git_repository.rb
@@ -91,6 +91,21 @@ class GitRepository
     path.split("/")[0..-2].join("/")
   end
 
+  def deepest_existing_dir(path, commit_oid = nil)
+    path ||= '/'
+    dirs = path.split('/')
+
+    dir = nil
+    Array(0..dirs.length-1).reverse.each do |i|
+      if dir.nil?
+        path = dirs[0..i].join('/')
+        dir = path if dir?(path, commit_oid)
+      end
+    end
+
+    dir
+  end
+
   # Given a commit oid or a branch name, commit_id returns a hash of oid and
   # branch name if existent.
   def commit_id(ref)

--- a/lib/git_repository.rb
+++ b/lib/git_repository.rb
@@ -96,7 +96,7 @@ class GitRepository
     dirs = path.split('/')
 
     dir = nil
-    Array(0..dirs.length-1).reverse.each do |i|
+    Array(0..dirs.length - 1).reverse.each do |i|
       if dir.nil?
         path = dirs[0..i].join('/')
         dir = path if dir?(path, commit_oid)

--- a/lib/git_repository/commit.rb
+++ b/lib/git_repository/commit.rb
@@ -22,10 +22,10 @@ module GitRepository::Commit
     end
 
     index = repo.index
+    index.read_tree(repo.head.target.tree) unless repo.empty?
     if file_contents.nil?
       index.remove(target_path)
     else
-      index.read_tree(repo.head.target.tree) unless repo.empty?
       blob_oid = repo.write(file_contents, :blob)
       index.add(path: target_path, oid: blob_oid, mode: 0100644)
     end

--- a/lib/git_repository/history.rb
+++ b/lib/git_repository/history.rb
@@ -2,6 +2,8 @@ module GitRepository::History
   # depends on GitRepository
   extend ActiveSupport::Concern
 
+  WALK_ORDER = {reverse: Rugged::SORT_REVERSE, topo: Rugged::SORT_TOPO}
+
   class Commit
     attr_reader :rugged_commit, :path, :commits_to_diff
 
@@ -59,7 +61,7 @@ module GitRepository::History
     stop_oid = nil if stop_oid =~ /\A0+\z/
 
     walker = Rugged::Walker.new(@repo)
-    if rwo = rugged_walk_order(walk_order)
+    if rwo = WALK_ORDER[walk_order]
       walker.sorting(rwo)
     end
     walker.push(start_oid)
@@ -69,17 +71,6 @@ module GitRepository::History
       commits_path(walker, limit, offset, path, &block)
     else
       commits_all(walker, limit, offset, &block)
-    end
-  end
-
-  def rugged_walk_order(walk_order)
-    case walk_order
-    when :reverse
-      Rugged::SORT_REVERSE
-    when :topo
-      Rugged::SORT_TOPO
-    else
-      nil
     end
   end
 

--- a/lib/repository_update_worker.rb
+++ b/lib/repository_update_worker.rb
@@ -14,7 +14,7 @@ class RepositoryUpdateWorker < Worker
       .suspended_save_ontologies \
         start_oid: newrev,
         stop_oid:  oldrev,
-        walk_order: Rugged::SORT_REVERSE
+        walk_order: :reverse
   end
 
 end

--- a/spec/models/repository/save_and_delete_file_spec.rb
+++ b/spec/models/repository/save_and_delete_file_spec.rb
@@ -103,7 +103,7 @@ describe 'Repository saving a file' do
     context 'that already exists' do
       it 'create a job' do
         expect { repository.save_file(file_path, target_path, message, user) }.
-          to(change { Worker.jobs.count }.by(1))
+          to change { Worker.jobs.count }.by(1)
       end
     end
   end

--- a/spec/models/repository/save_and_delete_file_spec.rb
+++ b/spec/models/repository/save_and_delete_file_spec.rb
@@ -75,8 +75,8 @@ describe 'Repository saving a file' do
 
       it 'create a new ontology version' do
         expect(repository.ontologies.
-          where(basepath: File.basepath(target_path)).first!.versions.count).
-          to eq(2)
+               where(basepath: File.basepath(target_path)).
+               first!.versions.count).to eq(2)
       end
     end
   end

--- a/spec/routing/files_routing_spec.rb
+++ b/spec/routing/files_routing_spec.rb
@@ -17,4 +17,5 @@ describe 'FilesControllerRouting' do
   it { should     route(:post, 'repositories/repopath/files'                ).to(repository_id: 'repopath', controller: :files, action: :create ) }
   it { should     route(:get,  'repositories/repopath/12ab/action'          ).to(repository_id: 'repopath', controller: :files, action: :action, ref: '12ab' ) }
   it { should     route(:get,  'repositories/repopath/12ab/files/some/path' ).to(repository_id: 'repopath', controller: :files, action: :show, ref: '12ab', path: 'some/path' ) }
+  it { should     route(:delete, 'repopath/some/path'                       ).to(repository_id: 'repopath', controller: :files, action: :destroy, path: 'some/path') }
 end


### PR DESCRIPTION
This shall fix #617 and #958.

Files in the repository can be deleted now via the web interface. 
Then, their ontologies will be marked as 'not having a file' (`has_file`).
This flag is stored in the database, but only for the head-version of an ontology (as a cache).
One can still ask for a specific commit, if an ontology has a file (`has_file(commit_oid)`), which then accesses the hard drive.

Deletion via ssh is detected and the flag is set in that case.

In the view (ontology#show), the nonexistence of a corresponding file is indicated by text and the absence of a link to the file.