### PR TITLE
Fix brittle catalog test

### DIFF
--- a/spec/lib/hets_spec.rb
+++ b/spec/lib/hets_spec.rb
@@ -47,6 +47,7 @@ describe Hets, :needs_hets do
       'https://colore.oor.net=https://develop.ontohub.org/colore/ontologies']
     end
     let(:catalog_args) do
+      # any_args is a "don't care which and how many arguments" in rspeck mocks.
       [any_args, '-C', url_catalog.join('/'), any_args]
     end
 


### PR DESCRIPTION
The old test actually made an HTTP request to an external service.
The new test stubs (only) the subprocess call of hets with a catalog.

The test failed because of a http 301 status code. The imported document has moved and hets couldn't retrieve it.
