### PR TITLE
deactivate the hound-checker for multiline-lambda

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -269,7 +269,7 @@ Style/IndentHash:
 
 Style/Lambda:
   Description: 'Use the new lambda literal syntax for single-line blocks.'
-  Enabled: true
+  Enabled: false
 
 Style/LambdaCall:
   Description: 'Use lambda.call(...) instead of lambda.(...).'


### PR DESCRIPTION
As we want to use the 1.9 syntax (->(args)) for every lambda,
whether it is single-line or multi-line, we'll need to deactivate
the check, as it can't be configured.
