### PR TITLE
1022 hotfix_aborting_of_ontologies

### DIFF
--- a/lib/hets/error_handling.rb
+++ b/lib/hets/error_handling.rb
@@ -4,6 +4,8 @@ module Hets
     def handle_hets_execution_error(error, ontology_version)
       if error.message.lines.last =~ /\*\*\* Error: unknown XML format/
         mark_as_non_ontology(ontology_version.ontology)
+      else
+        raise error
       end
     end
 


### PR DESCRIPTION
Shall fix #1022 and (hopefully) #1110.
The commit should be cherry-picked to master and deployed to ontohub.org upon merging into staging.
