### PR TITLE
Put the current ontology-version into the array

### DIFF
--- a/lib/hets/evaluator.rb
+++ b/lib/hets/evaluator.rb
@@ -52,7 +52,7 @@ module Hets
     def initialize_handling
       self.parser = Parser.new(io || path)
       self.concurrency = ConcurrencyBalancer.new
-      self.versions = []
+      self.versions = Array(version)
       self.dgnode_stack = []
       self.ontology_aliases = {}
       self.now = Time.now


### PR DESCRIPTION
In order to fix the all_end hook, we need to put the
'current' ontology-version into the versions array, which
will then result in ontologies containing the ontology.
