### PR TITLE
558 access token for private repositories

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -265,7 +265,7 @@ Style/IndentArray:
 
 Style/IndentHash:
   Description: 'Checks the indentation of the first key in a hash literal.'
-  Enabled: true
+  Enabled: false
 
 Style/Lambda:
   Description: 'Use the new lambda literal syntax for single-line blocks.'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,10 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  def current_ability
+      @current_ability ||= Ability.new(current_user, params[:"access-token"])
+  end
+
   def authenticate_admin!
     unless admin?
       flash[:error] = 'you need admin privileges for this action'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,7 +41,11 @@ class ApplicationController < ActionController::Base
   protected
 
   def current_ability
-      @current_ability ||= Ability.new(current_user, params[:"access-token"])
+    @current_ability ||= Ability.new(current_user, params[:'access-token'])
+  end
+
+  def params_to_pass_on_redirect
+    {:'access-token' => params[:'access-token']}
   end
 
   def authenticate_admin!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,8 @@ class ApplicationController < ActionController::Base
   include PathHelpers
   include ApplicationHelper
 
+  PARAMS_TO_PASS_ON_REDIRECT = %i(access-token)
+
   # CanCan Authorization
   rescue_from CanCan::AccessDenied do |exception|
     if request.format.html?
@@ -45,9 +47,7 @@ class ApplicationController < ActionController::Base
   end
 
   def params_to_pass_on_redirect
-    new_params = {}
-    %i(access-token).each { |key| new_params[key] = params[key] if params[key] }
-    new_params
+    params.select { |k, _v| PARAMS_TO_PASS_ON_REDIRECT.include?(k) }
   end
 
   def authenticate_admin!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,7 +45,9 @@ class ApplicationController < ActionController::Base
   end
 
   def params_to_pass_on_redirect
-    {:'access-token' => params[:'access-token']}
+    new_params = {}
+    %i(access-token).each { |key| new_params[key] = params[key] if params[key] }
+    new_params
   end
 
   def authenticate_admin!

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -55,7 +55,7 @@ class OntologiesController < InheritedResources::Base
     if !params[:repository_id]
       # redirect for legacy routing
       ontology = Ontology.find params[:id]
-      redirect_to [ontology.repository, ontology]
+      redirect_to [ontology.repository, ontology, params_to_pass_on_redirect]
       return
     end
 
@@ -63,9 +63,10 @@ class OntologiesController < InheritedResources::Base
       format.html do
         if !resource.distributed?
           default_kind = resource.symbols.groups_by_kind.first.kind
-          redirect_to locid_for(resource, :symbols, kind: default_kind)
+          redirect_to locid_for(resource, :symbols,
+            params_to_pass_on_redirect.merge(kind: default_kind))
         else
-          redirect_to locid_for(resource, :children)
+          redirect_to locid_for(resource, :children, params_to_pass_on_redirect)
         end
       end
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,7 +1,7 @@
 class Ability
   include CanCan::Ability
 
-  def initialize(user)
+  def initialize(user, access_token)
     # Define abilities for the passed in user here.
 
     user ||= User.new # guest user (not logged in)
@@ -17,7 +17,10 @@ class Ability
         elsif subject.is_private
           subject.permission?(:reader, user) ||
           subject.permission?(:editor, user) ||
-          subject.permission?(:owner, user)
+          subject.permission?(:owner, user) ||
+          subject.access_tokens.unexpired.any? do |token|
+            token.to_s == access_token
+          end
         else
           true
         end
@@ -122,7 +125,10 @@ class Ability
       can :read, Category
     else
       can :show, Repository do |subject|
-        !subject.is_private && !subject.is_destroying
+        !subject.is_destroying && (!subject.is_private ||
+        subject.access_tokens.unexpired.any? do |token|
+          token.to_s == access_token
+        end)
       end
 
       can :read, Project

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -12,15 +12,21 @@ class AccessToken < ActiveRecord::Base
     Time.now > expiration
   end
 
-  def self.build_for(repository)
-    AccessToken.new({repository: repository,
-      expiration: fresh_expiration_date,
-      token: SecureRandom.hex(LENGTH)}, {without_protection: true})
+  def self.create_for(repository)
+    a = insecure_build_for(repository) until !a.nil? && a.valid?
+    a.save!
+    a
   end
 
   protected
 
   def self.fresh_expiration_date
     Settings.access_token.expiration_minutes.minutes.from_now
+  end
+
+  def self.insecure_build_for(repository)
+    AccessToken.new({repository: repository,
+      expiration: fresh_expiration_date,
+      token: SecureRandom.hex(LENGTH)}, {without_protection: true})
   end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,0 +1,36 @@
+class AccessToken < ActiveRecord::Base
+  LENGTH = 20
+
+  belongs_to :repository
+  attr_accessible :expiration, :token
+
+  def to_s
+    token
+  end
+
+  def expired?
+    Time.now > expiration
+  end
+
+  def refresh!
+    self.expiration = self.class.fresh_expiration_date
+    save!
+  end
+
+  def replace
+    self.destroy
+    self.class.build_for(repository)
+  end
+
+  def self.build_for(repository)
+    AccessToken.new({repository: repository,
+      expiration: fresh_expiration_date,
+      token: SecureRandom.hex(LENGTH)}, {without_protection: true})
+  end
+
+  protected
+
+  def self.fresh_expiration_date
+    Settings.access_token.expiration_minutes.minutes.from_now
+  end
+end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -12,16 +12,6 @@ class AccessToken < ActiveRecord::Base
     Time.now > expiration
   end
 
-  def refresh!
-    self.expiration = self.class.fresh_expiration_date
-    save!
-  end
-
-  def replace
-    self.destroy
-    self.class.build_for(repository)
-  end
-
   def self.build_for(repository)
     AccessToken.new({repository: repository,
       expiration: fresh_expiration_date,

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -4,12 +4,14 @@ class AccessToken < ActiveRecord::Base
   belongs_to :repository
   attr_accessible :expiration, :token
 
+  scope :unexpired, ->() { where('expiration > ?', Time.now) }
+
   def to_s
     token
   end
 
   def expired?
-    Time.now > expiration
+    expiration <= Time.now
   end
 
   def self.create_for(repository)

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -2,6 +2,7 @@ class AccessToken < ActiveRecord::Base
   belongs_to :repository
   attr_accessible :expiration, :token
 
+  scope :expired, ->() { where('expiration <= ?', Time.now) }
   scope :unexpired, ->() { where('expiration > ?', Time.now) }
 
   def to_s
@@ -10,6 +11,10 @@ class AccessToken < ActiveRecord::Base
 
   def expired?
     expiration <= Time.now
+  end
+
+  def self.destroy_expired
+    expired.find_each(&:destroy)
   end
 
   def self.create_for(ontology_version)

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -23,18 +23,20 @@ class AccessToken < ActiveRecord::Base
     a
   end
 
-  protected
-
   def self.fresh_expiration_date
     Settings.access_token.expiration_minutes.minutes.from_now
   end
 
   def self.insecure_build_for(ontology_version)
     repository = ontology_version.repository
-    id = [repository.to_param, ontology_version.path,
-      Time.now.strftime("%Y-%m-%d-%H-%M-%S-%6N")].join("|")
-    AccessToken.new({repository: repository,
-      expiration: fresh_expiration_date,
-      token: Digest::SHA2.hexdigest(id)}, {without_protection: true})
+    id = [
+      repository.to_param, ontology_version.path,
+      Time.now.strftime('%Y-%m-%d-%H-%M-%S-%6N')
+    ].join('|')
+    AccessToken.new(
+      {repository: repository,
+       expiration: fresh_expiration_date,
+       token: Digest::SHA2.hexdigest(id)},
+      {without_protection: true})
   end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -21,15 +21,19 @@ class AccessToken < ActiveRecord::Base
 
   def self.insecure_build_for(ontology_version)
     repository = ontology_version.repository
+    AccessToken.new(
+      {repository: repository,
+       expiration: fresh_expiration_date,
+       token: generate_token_string(ontology_version, repository)},
+      {without_protection: true})
+  end
+
+  def self.generate_token_string(ontology_version, repository)
     id = [
       repository.to_param, ontology_version.path,
       Time.now.strftime('%Y-%m-%d-%H-%M-%S-%6N')
     ].join('|')
-    AccessToken.new(
-      {repository: repository,
-       expiration: fresh_expiration_date,
-       token: Digest::SHA2.hexdigest(id)},
-      {without_protection: true})
+    Digest::SHA2.hexdigest(id)
   end
 
   def to_s

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -13,7 +13,7 @@ class AccessToken < ActiveRecord::Base
     # Although unlikely, the token could clash with another one. Generate tokens
     # until there is no conflict. This should converge extremely fast.
     access_token = nil
-    while access_token.nil? || access_token.invalid? do
+    while access_token.nil? || access_token.invalid?
       access_token = build_for(ontology_version)
     end
     access_token.save!

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -26,10 +26,10 @@ class AccessToken < ActiveRecord::Base
 
   def self.build_for(ontology_version)
     repository = ontology_version.repository
-    AccessToken.new(
-      {repository: repository,
-       expiration: fresh_expiration_date,
-       token: generate_token_string(ontology_version, repository)},
+    AccessToken.new({
+      repository: repository,
+      expiration: fresh_expiration_date,
+      token: generate_token_string(ontology_version, repository)},
       {without_protection: true})
   end
 

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,6 +1,4 @@
 class AccessToken < ActiveRecord::Base
-  LENGTH = 20
-
   belongs_to :repository
   attr_accessible :expiration, :token
 
@@ -14,8 +12,8 @@ class AccessToken < ActiveRecord::Base
     expiration <= Time.now
   end
 
-  def self.create_for(repository)
-    a = insecure_build_for(repository) until !a.nil? && a.valid?
+  def self.create_for(ontology_version)
+    a = insecure_build_for(ontology_version) until !a.nil? && a.valid?
     a.save!
     a
   end
@@ -26,9 +24,12 @@ class AccessToken < ActiveRecord::Base
     Settings.access_token.expiration_minutes.minutes.from_now
   end
 
-  def self.insecure_build_for(repository)
+  def self.insecure_build_for(ontology_version)
+    repository = ontology_version.repository
+    id = [repository.to_param, ontology_version.path,
+      Time.now.strftime("%Y-%m-%d-%H-%M-%S-%6N")].join("|")
     AccessToken.new({repository: repository,
       expiration: fresh_expiration_date,
-      token: SecureRandom.hex(LENGTH)}, {without_protection: true})
+      token: Digest::SHA2.hexdigest(id)}, {without_protection: true})
   end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -17,6 +17,7 @@ class AccessToken < ActiveRecord::Base
       access_token = build_for(ontology_version)
     end
     access_token.save!
+    AccessTokenDeletionWorker.perform_at(access_token.expiration)
     access_token
   end
 

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -9,12 +9,12 @@ class AccessToken < ActiveRecord::Base
     expired.find_each(&:destroy)
   end
 
-  def self.create_for(ontology_version)
+  def self.create_for(repository)
     # Although unlikely, the token could clash with another one. Generate tokens
     # until there is no conflict. This should converge extremely fast.
     access_token = nil
     while access_token.nil? || access_token.invalid?
-      access_token = build_for(ontology_version)
+      access_token = build_for(repository)
     end
     access_token.save!
     AccessTokenDeletionWorker.perform_at(access_token.expiration)
@@ -25,18 +25,17 @@ class AccessToken < ActiveRecord::Base
     Settings.access_token.expiration_minutes.minutes.from_now
   end
 
-  def self.build_for(ontology_version)
-    repository = ontology_version.repository
+  def self.build_for(repository)
     AccessToken.new({
       repository: repository,
       expiration: fresh_expiration_date,
-      token: generate_token_string(ontology_version, repository)},
+      token: generate_token_string(repository)},
       {without_protection: true})
   end
 
-  def self.generate_token_string(ontology_version, repository)
+  def self.generate_token_string(repository)
     id = [
-      repository.to_param, ontology_version.path,
+      repository.to_param,
       Time.now.strftime('%Y-%m-%d-%H-%M-%S-%6N')
     ].join('|')
     Digest::SHA2.hexdigest(id)

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -5,14 +5,6 @@ class AccessToken < ActiveRecord::Base
   scope :expired, ->() { where('expiration <= ?', Time.now) }
   scope :unexpired, ->() { where('expiration > ?', Time.now) }
 
-  def to_s
-    token
-  end
-
-  def expired?
-    expiration <= Time.now
-  end
-
   def self.destroy_expired
     expired.find_each(&:destroy)
   end
@@ -38,5 +30,13 @@ class AccessToken < ActiveRecord::Base
        expiration: fresh_expiration_date,
        token: Digest::SHA2.hexdigest(id)},
       {without_protection: true})
+  end
+
+  def to_s
+    token
+  end
+
+  def expired?
+    expiration <= Time.now
   end
 end

--- a/app/models/ontology_version/parsing.rb
+++ b/app/models/ontology_version/parsing.rb
@@ -52,12 +52,13 @@ module OntologyVersion::Parsing
   end
 
   def generate_access_token
-    return unless repository.is_private
-    access_token = AccessToken.create_for(self)
-    repository.access_tokens << access_token
-    repository.save!
+    if !repository.is_private
+      access_token = AccessToken.create_for(self)
+      repository.access_tokens << access_token
+      repository.save!
 
-    access_token
+      access_token
+    end
   end
 
   def parse_full

--- a/app/models/ontology_version/parsing.rb
+++ b/app/models/ontology_version/parsing.rb
@@ -44,7 +44,8 @@ module OntologyVersion::Parsing
   # generate XML by passing the raw ontology to Hets
   def generate_xml(structure_only: false)
     hets_options =
-      Hets::HetsOptions.new(:'url-catalog' => ontology.repository.url_maps)
+      Hets::HetsOptions.new(:'url-catalog' => ontology.repository.url_maps,
+                            :'access-token' => ontology.repository.access_token_get_or_generate)
     input_io = Hets.parse_via_api(ontology, hets_options,
                                   structure_only: structure_only)
     [:all_is_well, input_io]

--- a/app/models/ontology_version/parsing.rb
+++ b/app/models/ontology_version/parsing.rb
@@ -45,7 +45,7 @@ module OntologyVersion::Parsing
   def generate_xml(structure_only: false)
     hets_options =
       Hets::HetsOptions.new(:'url-catalog' => ontology.repository.url_maps,
-                            :'access-token' => ontology.repository.access_token_get_or_generate)
+                            :'access-token' => ontology.repository.generate_access_token)
     input_io = Hets.parse_via_api(ontology, hets_options,
                                   structure_only: structure_only)
     [:all_is_well, input_io]

--- a/app/models/ontology_version/parsing.rb
+++ b/app/models/ontology_version/parsing.rb
@@ -43,22 +43,13 @@ module OntologyVersion::Parsing
 
   # generate XML by passing the raw ontology to Hets
   def generate_xml(structure_only: false)
+    repo = ontology.repository
     hets_options =
-      Hets::HetsOptions.new(:'url-catalog' => ontology.repository.url_maps,
-                            :'access-token' => generate_access_token)
+      Hets::HetsOptions.new(:'url-catalog' => repo.url_maps,
+                            :'access-token' => repo.generate_access_token)
     input_io = Hets.parse_via_api(ontology, hets_options,
                                   structure_only: structure_only)
     [:all_is_well, input_io]
-  end
-
-  def generate_access_token
-    if repository.is_private
-      access_token = AccessToken.create_for(self)
-      repository.access_tokens << access_token
-      repository.save!
-
-      access_token
-    end
   end
 
   def parse_full
@@ -79,8 +70,10 @@ module OntologyVersion::Parsing
   end
 
   def retrieve_available_provers
+    repo = ontology.repository
     hets_options =
-      Hets::ProversOptions.new(:'url-catalog' => ontology.repository.url_maps,
+      Hets::ProversOptions.new(:'url-catalog' => repo.url_maps,
+                               :'access-token' => repo.generate_access_token,
                                ontology: ontology)
     provers_io = Hets.provers_via_api(ontology, hets_options)
     Hets::Provers::Importer.new(self, provers_io).import

--- a/app/models/ontology_version/parsing.rb
+++ b/app/models/ontology_version/parsing.rb
@@ -52,7 +52,7 @@ module OntologyVersion::Parsing
   end
 
   def generate_access_token
-    if !repository.is_private
+    if repository.is_private
       access_token = AccessToken.create_for(self)
       repository.access_tokens << access_token
       repository.save!

--- a/app/models/ontology_version/parsing.rb
+++ b/app/models/ontology_version/parsing.rb
@@ -45,10 +45,19 @@ module OntologyVersion::Parsing
   def generate_xml(structure_only: false)
     hets_options =
       Hets::HetsOptions.new(:'url-catalog' => ontology.repository.url_maps,
-                            :'access-token' => ontology.repository.generate_access_token)
+                            :'access-token' => generate_access_token)
     input_io = Hets.parse_via_api(ontology, hets_options,
                                   structure_only: structure_only)
     [:all_is_well, input_io]
+  end
+
+  def generate_access_token
+    return unless repository.is_private
+    access_token = AccessToken.create_for(self)
+    repository.access_tokens << access_token
+    repository.save!
+
+    access_token
   end
 
   def parse_full

--- a/app/models/ontology_version/proving.rb
+++ b/app/models/ontology_version/proving.rb
@@ -2,7 +2,9 @@ module OntologyVersion::Proving
   extend ActiveSupport::Concern
 
   def prove_options
-    Hets::ProveOptions.new(:'url-catalog' => ontology.repository.url_maps,
+    repo = ontology.repository
+    Hets::ProveOptions.new(:'url-catalog' => repo.url_maps,
+                           :'access-token' => repo.generate_access_token,
                            ontology: ontology)
   end
 end

--- a/app/models/repository/access.rb
+++ b/app/models/repository/access.rb
@@ -4,15 +4,6 @@ module Repository::Access
   OPTIONS = %w[public_r public_rw private_r private_rw]
   DEFAULT_OPTION = OPTIONS[0]
 
-  def generate_access_token
-    return unless is_private
-    access_token = AccessToken.create_for(self)
-    self.access_tokens << access_token
-    save
-
-    access_token
-  end
-
   def destroy_expired_access_tokens
     access_tokens.select(&:expired?).map(&:destroy)
   end

--- a/app/models/repository/access.rb
+++ b/app/models/repository/access.rb
@@ -5,13 +5,12 @@ module Repository::Access
   DEFAULT_OPTION = OPTIONS[0]
 
   def generate_access_token
-    if is_private
-      access_token = AccessToken.create_for(self)
-      self.access_token << access_token
-      save
+    return unless is_private
+    access_token = AccessToken.create_for(self)
+    self.access_tokens << access_token
+    save
 
-      access_token
-    end
+    access_token
   end
 
   def destroy_expired_access_tokens

--- a/app/models/repository/access.rb
+++ b/app/models/repository/access.rb
@@ -4,6 +4,24 @@ module Repository::Access
   OPTIONS = %w[public_r public_rw private_r private_rw]
   DEFAULT_OPTION = OPTIONS[0]
 
+  def access_token_get_or_generate
+    if is_private
+      if access_token
+        if access_token.expired?
+          self.access_token = access_token.replace
+          save
+        else
+          access_token.refresh!
+        end
+      else
+        self.access_token = AccessToken.build_for(self)
+        save
+      end
+
+      access_token
+    end
+  end
+
   def is_private
     access.start_with?('private')
   end

--- a/app/models/repository/access.rb
+++ b/app/models/repository/access.rb
@@ -4,22 +4,18 @@ module Repository::Access
   OPTIONS = %w[public_r public_rw private_r private_rw]
   DEFAULT_OPTION = OPTIONS[0]
 
-  def access_token_get_or_generate
+  def generate_access_token
     if is_private
-      if access_token
-        if access_token.expired?
-          self.access_token = access_token.replace
-          save
-        else
-          access_token.refresh!
-        end
-      else
-        self.access_token = AccessToken.build_for(self)
-        save
-      end
+      access_token = AccessToken.build_for(self)
+      self.access_token << access_token
+      save
 
       access_token
     end
+  end
+
+  def destroy_expired_access_tokens
+    access_tokens.select(&:expired?).map(&:destroy)
   end
 
   def is_private

--- a/app/models/repository/access.rb
+++ b/app/models/repository/access.rb
@@ -5,7 +5,7 @@ module Repository::Access
   DEFAULT_OPTION = OPTIONS[0]
 
   def self.as_read_only(access)
-    access.split('_').first + '_r'
+    access.split('_', 2).first + '_r'
   end
 
   def destroy_expired_access_tokens

--- a/app/models/repository/access.rb
+++ b/app/models/repository/access.rb
@@ -6,7 +6,7 @@ module Repository::Access
 
   def generate_access_token
     if is_private
-      access_token = AccessToken.build_for(self)
+      access_token = AccessToken.create_for(self)
       self.access_token << access_token
       save
 

--- a/app/models/repository/access.rb
+++ b/app/models/repository/access.rb
@@ -12,6 +12,16 @@ module Repository::Access
     access_tokens.select(&:expired?).map(&:destroy)
   end
 
+  def generate_access_token
+    if is_private
+      access_token = AccessToken.create_for(self)
+      access_tokens << access_token
+      save!
+
+      access_token
+    end
+  end
+
   def is_private
     access.start_with?('private')
   end

--- a/app/models/repository/access.rb
+++ b/app/models/repository/access.rb
@@ -9,7 +9,7 @@ module Repository::Access
   end
 
   def destroy_expired_access_tokens
-    access_tokens.select(&:expired?).map(&:destroy)
+    access_tokens.select(&:expired?).each(&:destroy)
   end
 
   def generate_access_token

--- a/app/models/repository/access.rb
+++ b/app/models/repository/access.rb
@@ -4,6 +4,10 @@ module Repository::Access
   OPTIONS = %w[public_r public_rw private_r private_rw]
   DEFAULT_OPTION = OPTIONS[0]
 
+  def self.as_read_only(access)
+    access.split('_').first + '_r'
+  end
+
   def destroy_expired_access_tokens
     access_tokens.select(&:expired?).map(&:destroy)
   end
@@ -26,10 +30,6 @@ module Repository::Access
 
   def public_r?
     access == 'public_r'
-  end
-
-  def self.as_read_only(access)
-    access.split('_').first + '_r'
   end
 
   private

--- a/app/models/repository/associations_and_attributes.rb
+++ b/app/models/repository/associations_and_attributes.rb
@@ -5,8 +5,7 @@ module Repository::AssociationsAndAttributes
       has_many :ontologies, dependent: :destroy
       has_many :url_maps, dependent: :destroy
       has_many :commits, dependent: :destroy
-
-      has_one :access_token
+      has_many :access_tokens, dependent: :destroy
 
       attr_accessible :name,
                       :description,

--- a/app/models/repository/associations_and_attributes.rb
+++ b/app/models/repository/associations_and_attributes.rb
@@ -6,6 +6,8 @@ module Repository::AssociationsAndAttributes
       has_many :url_maps, dependent: :destroy
       has_many :commits, dependent: :destroy
 
+      has_one :access_token
+
       attr_accessible :name,
                       :description,
                       :source_type,

--- a/app/models/theorem.rb
+++ b/app/models/theorem.rb
@@ -29,7 +29,9 @@ class Theorem < Sentence
   end
 
   def prove_options
-    Hets::ProveOptions.new(:'url-catalog' => ontology.repository.url_maps,
+    repo = ontology.repository
+    Hets::ProveOptions.new(:'url-catalog' => repo.url_maps,
+                           :'access-token' => repo.generate_access_token,
                            ontology: ontology,
                            theorems: [self])
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -101,6 +101,9 @@ git:
 # saved.
 external_repository_name: 'External'
 
+access_token:
+  expiration_minutes: 360
+
 allowed_iri_schemes:
   - http
   - https

--- a/db/migrate/20140820120712_create_access_tokens.rb
+++ b/db/migrate/20140820120712_create_access_tokens.rb
@@ -1,0 +1,16 @@
+class CreateAccessTokens < ActiveRecord::Migration
+  def change
+    create_table :access_tokens do |t|
+      t.string :token, unique: true
+      t.references :repository, null: false
+      t.datetime :expiration, null: false
+
+      t.timestamps
+    end
+
+    change_table :access_tokens do |t|
+      t.foreign_key :repositories
+      t.index :token
+    end
+  end
+end

--- a/lib/access_token_deletion_worker.rb
+++ b/lib/access_token_deletion_worker.rb
@@ -1,0 +1,13 @@
+require 'sidekiq/worker'
+
+# This worker deletes expired access tokens
+class AccessTokenDeletionWorker
+  include Sidekiq::Worker
+  include Sidetiq::Schedulable
+
+  recurrence { daily }
+
+  def perform
+    AccessToken.destroy_expired
+  end
+end

--- a/lib/access_token_deletion_worker.rb
+++ b/lib/access_token_deletion_worker.rb
@@ -1,11 +1,5 @@
-require 'sidekiq/worker'
-
-# This worker deletes expired access tokens
-class AccessTokenDeletionWorker
-  include Sidekiq::Worker
-  include Sidetiq::Schedulable
-
-  recurrence { daily }
+class AccessTokenDeletionWorker < BaseWorker
+  sidekiq_options queue: 'default'
 
   def perform
     AccessToken.destroy_expired

--- a/lib/hets/hets_options.rb
+++ b/lib/hets/hets_options.rb
@@ -47,9 +47,13 @@ module Hets
     end
 
     def prepare_url_catalog
-      @options[:'url-catalog'].try(:compact!)
-      if @options[:'url-catalog'].blank?
-        @options.delete(:'url-catalog')
+      if @options[:'url-catalog'].is_a?(Array)
+        @options[:'url-catalog'].try(:compact!)
+        if @options[:'url-catalog'].blank?
+          @options.delete(:'url-catalog')
+        else
+          @options[:'url-catalog'] = @options[:'url-catalog'].join(',')
+        end
       end
     end
 

--- a/lib/hets/hets_options.rb
+++ b/lib/hets/hets_options.rb
@@ -58,7 +58,7 @@ module Hets
     end
 
     def prepare_access_token
-      if @options[:'access-token'].is_a?(AccessToken)
+      if @options[:'access-token']
         @options[:'access-token'] = @options[:'access-token'].to_s
       end
     end

--- a/lib/hets/hets_options.rb
+++ b/lib/hets/hets_options.rb
@@ -38,6 +38,7 @@ module Hets
     def prepare
       remove_nil_fields
       prepare_url_catalog
+      prepare_access_token
     end
 
     def remove_nil_fields
@@ -49,6 +50,12 @@ module Hets
       @options[:'url-catalog'].try(:compact!)
       if @options[:'url-catalog'].blank?
         @options.delete(:'url-catalog')
+      end
+    end
+
+    def prepare_access_token
+      if @options[:'access-token'].is_a?(AccessToken)
+        @options[:'access-token'] = @options[:'access-token'].to_s
       end
     end
   end

--- a/lib/router_constraints.rb
+++ b/lib/router_constraints.rb
@@ -130,17 +130,9 @@ end
 
 class RefIRIRouterConstraint < IRIRouterConstraint
   def matches?(request)
-    regex = %r{
-      (\?[^=]+$) # matches a lone MMT-argument
-      |
-      \?([^=;&]+)[&;].*$ # splits a lone MMT-arg from normal query-string
-      |
-      \?.*$ # drops a the whole standard query-string
-    }x
     # remove the ref/:version_number portion from path
     path = Journey::Router::Utils.unescape_uri(request.original_fullpath).
-      sub(%r{\A/ref/\d+/}, '').
-      sub(regex, '\1')
+      sub(%r{\A/ref/\d+/}, '')
 
     super(request, path)
   end

--- a/lib/router_constraints.rb
+++ b/lib/router_constraints.rb
@@ -130,9 +130,18 @@ end
 
 class RefIRIRouterConstraint < IRIRouterConstraint
   def matches?(request)
+    regex = %r{
+      (\?[^=]+$) # matches a lone MMT-argument
+      |
+      \?([^=;&]+)[&;].*$ # splits a lone MMT-arg from normal query-string
+      |
+      \?.*$ # drops a the whole standard query-string
+    }x
     # remove the ref/:version_number portion from path
     path = Journey::Router::Utils.unescape_uri(request.original_fullpath).
-      sub(%r{\A/ref/\d+/}, '')
+      sub(%r{\A/ref/\d+/}, '').
+      sub(regex, '\1')
+
     super(request, path)
   end
 end

--- a/lib/settings_validation_wrapper.rb
+++ b/lib/settings_validation_wrapper.rb
@@ -71,6 +71,7 @@ class SettingsValidationWrapper
               yml__allow_unconfirmed_access_for_days
               yml__git__push_priority__commits
               yml__git__push_priority__changed_files_per_commit
+              yml__access_token__expiration_minutes
               yml__hets__version_minimum_revision)
 
   FLOAT = %i(yml__hets__version_minimum_version)
@@ -155,6 +156,8 @@ class SettingsValidationWrapper
   validates :yml__git__push_priority__commits,
             numericality: {greater_than_or_equal_to: 1}
   validates :yml__git__push_priority__changed_files_per_commit,
+            numericality: {greater_than_or_equal_to: 1}
+  validates :yml__access_token__expiration_minutes,
             numericality: {greater_than_or_equal_to: 1}
 
   validates :yml__footer, elements_have_keys: {keys: %i(text)}

--- a/spec/lib/access_token_deletion_worker_spec.rb
+++ b/spec/lib/access_token_deletion_worker_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe AccessTokenDeletionWorker do
+  before do
+    Worker.clear
+    [-2, -1, 1].map { |h| h.hours.from_now }.each do |expiration|
+      create :access_token, expiration: expiration
+    end
+  end
+
+  it 'before perfoming there should be 3 tokens' do
+    expect(AccessToken.count).to eq(3)
+  end
+
+  context 'after perfoming' do
+    before { AccessTokenDeletionWorker.new.perform }
+
+    it 'there should be only 1 token' do
+      expect(AccessToken.count).to eq(1)
+    end
+  end
+end

--- a/spec/lib/hets/hets_options_spec.rb
+++ b/spec/lib/hets/hets_options_spec.rb
@@ -90,7 +90,7 @@ describe Hets::HetsOptions do
       let(:hets_options) { Hets::HetsOptions.new(catalog_options) }
 
       it "removes the nil value from  :'url-catalog'" do
-        expect(hets_options.options[:'url-catalog']).to eq(%w(a=b c=d))
+        expect(hets_options.options[:'url-catalog']).to eq('a=b,c=d')
       end
     end
 
@@ -99,7 +99,7 @@ describe Hets::HetsOptions do
       let(:hets_options) { Hets::HetsOptions.new(catalog_options) }
 
       it "has the same :'url-catalog'" do
-        expect(hets_options.options[:'url-catalog']).to eq(%w(a=b c=d))
+        expect(hets_options.options[:'url-catalog']).to eq('a=b,c=d')
       end
     end
   end

--- a/spec/lib/hets/hets_options_spec.rb
+++ b/spec/lib/hets/hets_options_spec.rb
@@ -43,6 +43,27 @@ describe Hets::HetsOptions do
     end
   end
 
+  context 'access token' do
+    context 'access token is nil' do
+      let(:access_token_options) { {**options, :'access-token' => nil} }
+      let(:hets_options) { Hets::HetsOptions.new(access_token_options) }
+
+      it 'has no access token key' do
+        expect(hets_options.options.has_key?(:'access-token')).to be(false)
+      end
+    end
+
+    context 'access token exists' do
+      let(:access_token) { create :access_token }
+      let(:access_token_options) { {**options, :'access-token' => access_token} }
+      let(:hets_options) { Hets::HetsOptions.new(access_token_options) }
+
+      it 'has the correct access token' do
+        expect(hets_options.options[:'access-token']).to eq(access_token.to_s)
+      end
+    end
+  end
+
   context 'url-catalog' do
     context 'empty' do
       let(:catalog_options) { {**options, :'url-catalog' => %w()} }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -20,7 +20,7 @@ describe Ability do
       subject(:ability){ Ability.new(User.new, nil) }
 
       it 'not be allowed: new, create' do
-        [:new, :create].each do |perm|
+        %i(new create).each do |perm|
           should_not be_able_to(perm, Repository.new)
         end
       end
@@ -30,7 +30,7 @@ describe Ability do
       end
 
       it 'not be allowed some actions' do
-        [:edit, :update, :destroy, :write].each do |perm|
+        %i(edit update destroy write).each do |perm|
           should_not be_able_to(perm, item)
         end
       end
@@ -40,13 +40,13 @@ describe Ability do
       subject(:ability){ Ability.new(reader, nil) }
 
       it 'be allowed: new, create' do
-        [:new, :create].each do |perm|
+        %i(new create).each do |perm|
           should be_able_to(perm, Repository.new)
         end
       end
 
       it 'not be allowed some actions' do
-        [:edit, :update, :destroy, :write].each do |perm|
+        %i(edit update destroy write).each do |perm|
           should_not be_able_to(perm, item)
         end
       end
@@ -60,19 +60,19 @@ describe Ability do
       subject(:ability){ Ability.new(owner, nil) }
 
       it 'be allowed: new, create' do
-        [:new, :create].each do |perm|
+        %i(new create).each do |perm|
           should be_able_to(perm, Repository.new)
         end
       end
 
       it 'be allowed: edit, update, destroy, permissions, write' do
-        [:show, :edit, :update, :destroy, :permissions].each do |perm|
+        %i(show edit update destroy permissions).each do |perm|
           should be_able_to(perm, item)
         end
       end
 
       it 'not be allowed on other: edit, update, destroy, permissions' do
-        [:edit, :update, :destroy, :permissions].each do |perm|
+        %i(edit update destroy permissions).each do |perm|
           should_not be_able_to(perm, create(:repository))
         end
       end
@@ -82,13 +82,13 @@ describe Ability do
       subject(:ability){ Ability.new(editor, nil) }
 
       it 'be allowed: write' do
-        [:show, :write].each do |perm|
+        %i(show write).each do |perm|
           should be_able_to(perm, item)
         end
       end
 
       it 'not be allowed: edit, update, destroy, permissions' do
-        [:edit, :update, :destroy, :permissions].each do |perm|
+        %i(edit update destroy permissions).each do |perm|
           should_not be_able_to(perm, item)
         end
       end
@@ -114,7 +114,7 @@ describe Ability do
       subject(:ability){ Ability.new(User.new, nil) }
 
       it 'not be allowed: anything' do
-        [:show, :update, :write].each do |perm|
+        %i(show update write).each do |perm|
           should_not be_able_to(perm, item)
         end
       end
@@ -124,7 +124,7 @@ describe Ability do
 
 
         it 'not be allowed: change' do
-          [:update, :write].each do |perm|
+          %i(update write).each do |perm|
             should_not be_able_to(perm, item)
           end
         end
@@ -139,7 +139,7 @@ describe Ability do
       subject(:ability){ Ability.new(reader, nil) }
 
       it 'not be allowed: to manage' do
-        [:update, :write].each do |perm|
+        %i(update write).each do |perm|
           should_not be_able_to(perm, item)
         end
       end
@@ -153,7 +153,7 @@ describe Ability do
       subject(:ability){ Ability.new(editor, nil) }
 
       it 'be allowed: to read and manage' do
-        [:show, :write].each do |perm|
+        %i(show write).each do |perm|
           should be_able_to(perm, item)
         end
       end
@@ -163,7 +163,7 @@ describe Ability do
       subject(:ability){ Ability.new(owner, nil) }
 
       it 'be allowed: everything' do
-        [:show, :update, :write].each do |perm|
+        %i(show update write).each do |perm|
           should be_able_to(perm, item)
         end
       end
@@ -184,7 +184,7 @@ describe Ability do
       subject(:ability){ Ability.new(User.new, nil) }
 
       it 'not be allowed: anything' do
-        [:show, :update, :write].each do |perm|
+        %i(show update write).each do |perm|
           should_not be_able_to(perm, item)
         end
       end
@@ -228,7 +228,7 @@ describe Ability do
 
     context 'admin' do
       it 'be allowed: edit, update, destroy' do
-        [:edit, :update, :destroy].each do |perm|
+        %i(edit update destroy).each do |perm|
           should be_able_to(perm, create(:team_user, user: user).team)
         end
       end
@@ -236,19 +236,19 @@ describe Ability do
 
     context 'member' do
       it 'be allowed: create, show, index' do
-        [:create, :show, :index].each do |perm|
+        %i(create show index).each do |perm|
           should be_able_to(perm, Team.new)
         end
       end
 
       it 'not be allowed: edit, update, destroy (without admin on team)' do
-        [:edit, :update, :destroy].each do |perm|
+        %i(edit update destroy).each do |perm|
           should_not be_able_to(perm, @memberteam)
         end
       end
 
       it 'not be allowed: edit, update, destroy (without being on team)' do
-        [:edit, :update, :destroy].each do |perm|
+        %i(edit update destroy).each do |perm|
           should_not be_able_to(perm, otherteam)
         end
       end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -102,8 +102,6 @@ describe Ability do
     let(:item) do
       repo = access_token.repository
       create(:permission, subject: owner, role: 'owner', item: repo)
-      repo.access = 'private_rw'
-      repo.save
       repo
     end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -7,9 +7,9 @@ describe Ability do
   let(:owner){  create :user } # owner
 
   context 'Repository' do
-    let(:editor){ create :user } # editor
-    let(:reader){ create :user } # reader
-    let(:item){   create(:permission, subject: owner, role: 'owner').item }
+    let(:editor) { create :user } # editor
+    let(:reader) { create :user } # reader
+    let(:item) { create(:permission, subject: owner, role: 'owner').item }
 
     before do
       create(:permission, subject: editor, role: 'editor', item: item)
@@ -17,7 +17,7 @@ describe Ability do
     end
 
     context 'guest' do
-      subject(:ability){ Ability.new(User.new) }
+      subject(:ability){ Ability.new(User.new, nil) }
 
       it 'not be allowed: new, create' do
         [:new, :create].each do |perm|
@@ -37,7 +37,7 @@ describe Ability do
     end
 
     context 'reader' do
-      subject(:ability){ Ability.new(reader) }
+      subject(:ability){ Ability.new(reader, nil) }
 
       it 'be allowed: new, create' do
         [:new, :create].each do |perm|
@@ -57,7 +57,7 @@ describe Ability do
     end
 
     context 'owner' do
-      subject(:ability){ Ability.new(owner) }
+      subject(:ability){ Ability.new(owner, nil) }
 
       it 'be allowed: new, create' do
         [:new, :create].each do |perm|
@@ -79,7 +79,7 @@ describe Ability do
     end
 
     context 'editor' do
-      subject(:ability){ Ability.new(editor) }
+      subject(:ability){ Ability.new(editor, nil) }
 
       it 'be allowed: write' do
         [:show, :write].each do |perm|
@@ -98,7 +98,14 @@ describe Ability do
   context 'Private Repository' do
     let(:editor){ create :user } # editor
     let(:reader){ create :user } # reader
-    let(:item){   create(:repository, access: 'private_rw', user: owner) }
+    let!(:access_token) { create :access_token }
+    let(:item) do
+      repo = access_token.repository
+      create(:permission, subject: owner, role: 'owner', item: repo)
+      repo.access = 'private_rw'
+      repo.save
+      repo
+    end
 
     before do
       create(:permission, subject: editor, role: 'editor', item: item)
@@ -106,17 +113,32 @@ describe Ability do
     end
 
     context 'guest' do
-      subject(:ability){ Ability.new(User.new) }
+      subject(:ability){ Ability.new(User.new, nil) }
 
       it 'not be allowed: anything' do
         [:show, :update, :write].each do |perm|
           should_not be_able_to(perm, item)
         end
       end
+
+      context 'with access token' do
+        subject(:ability){ Ability.new(User.new, access_token.to_s) }
+
+
+        it 'not be allowed: change' do
+          [:update, :write].each do |perm|
+            should_not be_able_to(perm, item)
+          end
+        end
+
+        it 'be allowed: read' do
+          should be_able_to(:show, item)
+        end
+      end
     end
 
     context 'reader' do
-      subject(:ability){ Ability.new(reader) }
+      subject(:ability){ Ability.new(reader, nil) }
 
       it 'not be allowed: to manage' do
         [:update, :write].each do |perm|
@@ -130,7 +152,7 @@ describe Ability do
     end
 
     context 'editor' do
-      subject(:ability){ Ability.new(editor) }
+      subject(:ability){ Ability.new(editor, nil) }
 
       it 'be allowed: to read and manage' do
         [:show, :write].each do |perm|
@@ -140,7 +162,7 @@ describe Ability do
     end
 
     context 'owner' do
-      subject(:ability){ Ability.new(owner) }
+      subject(:ability){ Ability.new(owner, nil) }
 
       it 'be allowed: everything' do
         [:show, :update, :write].each do |perm|
@@ -161,7 +183,7 @@ describe Ability do
     end
 
     context 'guest' do
-      subject(:ability){ Ability.new(User.new) }
+      subject(:ability){ Ability.new(User.new, nil) }
 
       it 'not be allowed: anything' do
         [:show, :update, :write].each do |perm|
@@ -173,13 +195,13 @@ describe Ability do
     context 'reader, editor, owner' do
       it 'not be allowed: to write' do
         [reader, editor, owner].each do |role|
-          Ability.new(role).should_not be_able_to(:write, item)
+          Ability.new(role, nil).should_not be_able_to(:write, item)
         end
       end
 
       it 'be allowed: to read' do
         [reader, editor, owner].each do |role|
-          Ability.new(role).should be_able_to(:show, item)
+          Ability.new(role, nil).should be_able_to(:show, item)
         end
       end
     end
@@ -187,12 +209,12 @@ describe Ability do
     context 'update:' do
       it 'reader, editor should be allowed' do
         [reader, editor].each do |role|
-          Ability.new(role).should_not be_able_to(:update, item)
+          Ability.new(role, nil).should_not be_able_to(:update, item)
         end
       end
 
       it 'owner should not be allowed' do
-        Ability.new(owner).should be_able_to(:update, item)
+        Ability.new(owner, nil).should be_able_to(:update, item)
       end
     end
   end
@@ -202,7 +224,7 @@ describe Ability do
     let(:memberteam){ create(:team_user, user: other).team }
     let(:otherteam){  create(:team_user, user: other).team }
 
-    subject(:ability){ Ability.new(user) }
+    subject(:ability){ Ability.new(user, nil) }
 
     before { memberteam.users << user }
 
@@ -239,7 +261,7 @@ describe Ability do
     let(:comment){ create :comment }
 
     context 'author' do
-      subject(:ability){ Ability.new(comment.user) }
+      subject(:ability){ Ability.new(comment.user, nil) }
 
       it 'destroy his own comment' do
         should be_able_to(:destroy, comment)
@@ -251,7 +273,7 @@ describe Ability do
     end
 
     context 'admin' do
-      subject(:ability){ Ability.new(create :admin) }
+      subject(:ability){ Ability.new(create(:admin), nil) }
 
       it 'destroy others comment' do
         should be_able_to(:destroy, comment)
@@ -259,7 +281,7 @@ describe Ability do
     end
 
     context 'comments repository owner' do
-      subject(:ability){ Ability.new(owner) }
+      subject(:ability){ Ability.new(owner, nil) }
 
       before do
         create(:permission, subject: owner, role: 'owner', item: comment.commentable.repository)
@@ -271,7 +293,7 @@ describe Ability do
     end
 
     context 'comments repository editor' do
-      subject(:ability){ Ability.new(owner) }
+      subject(:ability){ Ability.new(owner, nil) }
       before do
         create(:permission, subject: owner, role: 'editor', item: comment.commentable.repository)
       end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -123,9 +123,11 @@ describe Ability do
         subject(:ability){ Ability.new(User.new, access_token.to_s) }
 
 
-        it 'not be allowed: change' do
+        context 'not be allowed: change' do
           %i(update write).each do |perm|
-            should_not be_able_to(perm, item)
+            it "via #{perm}" do
+              should_not be_able_to(perm, item)
+            end
           end
         end
 

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe AccessToken do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -1,5 +1,54 @@
 require 'spec_helper'
 
 describe AccessToken do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:access_token) { create :access_token }
+  let(:repository) { create :repository, access_token: access_token }
+
+  context 'expired?' do
+    it 'should not be expired when the expiration date is in the future' do
+      expect(access_token.expired?).to be_falsy
+    end
+
+    it 'should be expired when the expiration date is in the past' do
+      access_token.expiration = (-1).minutes.from_now
+      expect(access_token.expired?).to be_truthy
+    end
+  end
+
+  context 'refresh' do
+    let!(:old_access_token) { access_token.dup }
+    before do
+      access_token.expiration = (-1).minutes.from_now
+    end
+
+    it 'should be expired before refresh' do
+      expect(access_token.expired?).to be_truthy
+    end
+
+    context 'after refresh' do
+      before do
+        access_token.refresh!
+      end
+
+      it 'should not be expired' do
+        expect(access_token.expired?).to be_falsy
+      end
+
+      it 'should have the same token' do
+        expect(access_token.token).to eq(old_access_token.token)
+      end
+    end
+  end
+
+  context 'replacement' do
+    let!(:replacement) { access_token.replace }
+
+    it 'should delete the old token' do
+      expect(access_token.persisted?).to be_falsy
+    end
+
+    it 'should generate another token' do
+      expect(replacement.token).not_to eq(access_token.token)
+    end
+  end
 end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -2,7 +2,12 @@ require 'spec_helper'
 
 describe AccessToken do
   let(:access_token) { create :access_token }
-  let(:repository) { create :repository, access_token: access_token }
+  let(:repository) { create :repository }
+
+  before do
+    repository.access_token << access_token
+    repository.save
+  end
 
   context 'expired?' do
     it 'should not be expired when the expiration date is in the future' do
@@ -15,40 +20,9 @@ describe AccessToken do
     end
   end
 
-  context 'refresh' do
-    let!(:old_access_token) { access_token.dup }
-    before do
-      access_token.expiration = (-1).minutes.from_now
-    end
-
-    it 'should be expired before refresh' do
-      expect(access_token.expired?).to be_truthy
-    end
-
-    context 'after refresh' do
-      before do
-        access_token.refresh!
-      end
-
-      it 'should not be expired' do
-        expect(access_token.expired?).to be_falsy
-      end
-
-      it 'should have the same token' do
-        expect(access_token.token).to eq(old_access_token.token)
-      end
-    end
-  end
-
-  context 'replacement' do
-    let!(:replacement) { access_token.replace }
-
-    it 'should delete the old token' do
-      expect(access_token.persisted?).to be_falsy
-    end
-
-    it 'should generate another token' do
-      expect(replacement.token).not_to eq(access_token.token)
+  context 'to_s' do
+    it 'should have 2*LENGTH characters' do
+      expect(access_token.to_s.length).to eq(2*AccessToken::LENGTH)
     end
   end
 end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -5,7 +5,7 @@ describe AccessToken do
   let(:repository) { create :repository }
 
   before do
-    repository.access_token << access_token
+    repository.access_tokens << access_token
     repository.save
   end
 

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -19,10 +19,4 @@ describe AccessToken do
       expect(access_token.expired?).to be_truthy
     end
   end
-
-  context 'to_s' do
-    it 'should have 2*LENGTH characters' do
-      expect(access_token.to_s.length).to eq(2*AccessToken::LENGTH)
-    end
-  end
 end

--- a/spec/models/ontology_version/proving_spec.rb
+++ b/spec/models/ontology_version/proving_spec.rb
@@ -16,6 +16,21 @@ describe 'OntologyVersion - Proving' do
       expect(prove_options.options[:theorems]).to be(nil)
     end
 
+    context 'on a private repository' do
+      before do
+        repository.access = 'private_rw'
+        repository.save!
+      end
+
+      it 'have an existing access-token parameter' do
+        expect(prove_options.options[:'access-token']).to be_present
+      end
+      it 'have the access token as access-token parameter' do
+        expect(prove_options.options[:'access-token']).
+          to eq(repository.access_tokens.first.to_s)
+      end
+    end
+
     context 'with url-maps' do
       let!(:url_maps) { [create(:url_map, repository: repository)] }
       it 'have the url-maps as url-catalog parameter' do

--- a/spec/models/ontology_version/proving_spec.rb
+++ b/spec/models/ontology_version/proving_spec.rb
@@ -19,7 +19,7 @@ describe 'OntologyVersion - Proving' do
     context 'with url-maps' do
       let!(:url_maps) { [create(:url_map, repository: repository)] }
       it 'have the url-maps as url-catalog parameter' do
-        expect(prove_options.options[:'url-catalog']).to eq(url_maps)
+        expect(prove_options.options[:'url-catalog']).to eq(url_maps.join(','))
       end
     end
 

--- a/spec/models/repository/access_spec.rb
+++ b/spec/models/repository/access_spec.rb
@@ -30,54 +30,25 @@ describe 'Repository Access' do
 
     context 'without access token' do
       it 'should not have a token yet' do
-        expect(repository.access_token).to be_nil
+        expect(repository.access_token).to be_empty
       end
     end
 
-    context 'after first access_token_get_or_generate' do
+    context 'after generate_access_token' do
       before do
-        @access_token = repository.access_token_get_or_generate
+        @access_token = repository.generate_access_token
       end
 
       it 'should generate a token' do
-        expect(repository.access_token).not_to be_nil
+        expect(repository.access_token).not_to be_empty
       end
 
       it 'should associate with the generated token' do
-        expect(repository.access_token).to eq(@access_token)
+        expect(repository.access_token.first).to eq(@access_token)
       end
 
       it 'should save the token' do
-        expect(repository.access_token.persisted?).to be_truthy
-      end
-    end
-
-    context 'when already having a valid access token' do
-      before do
-        @access_token = repository.access_token_get_or_generate
-        @access_token.expiration = 1.minutes.from_now
-        @old_expiration = @access_token.expiration
-        repository.access_token_get_or_generate
-      end
-
-      it 'should still be the same token' do
-        expect(repository.access_token.token).to eq(@access_token.token)
-      end
-
-      it 'should have a later expiration date' do
-        expect(@old_expiration < repository.access_token.expiration).to be_truthy
-      end
-    end
-
-    context 'when already having an expired access token' do
-      before do
-        @access_token = repository.access_token_get_or_generate
-        @access_token.expiration = (-1).minutes.from_now
-        repository.access_token_get_or_generate
-      end
-
-      it 'should generate a new token' do
-        expect(repository.access_token.token).not_to eq(@access_token.token)
+        expect(repository.access_token.first.persisted?).to be_truthy
       end
     end
   end

--- a/spec/models/repository/access_spec.rb
+++ b/spec/models/repository/access_spec.rb
@@ -30,25 +30,23 @@ describe 'Repository Access' do
 
     context 'without access token' do
       it 'should not have a token yet' do
-        expect(repository.access_token).to be_empty
+        expect(repository.access_tokens).to be_empty
       end
     end
 
     context 'after generate_access_token' do
-      before do
-        @access_token = repository.generate_access_token
-      end
+      let!(:access_token) { repository.generate_access_token }
 
       it 'should generate a token' do
-        expect(repository.access_token).not_to be_empty
+        expect(repository.access_tokens).not_to be_empty
       end
 
       it 'should associate with the generated token' do
-        expect(repository.access_token.first).to eq(@access_token)
+        expect(repository.access_tokens.first).to eq(access_token)
       end
 
       it 'should save the token' do
-        expect(repository.access_token.first.persisted?).to be_truthy
+        expect(repository.access_tokens.first.persisted?).to be_truthy
       end
     end
   end

--- a/spec/models/repository/access_spec.rb
+++ b/spec/models/repository/access_spec.rb
@@ -24,4 +24,61 @@ describe 'Repository Access' do
       end
     end
   end
+
+  context 'private repository' do
+    let(:repository) { create :repository, access: 'private_rw' }
+
+    context 'without access token' do
+      it 'should not have a token yet' do
+        expect(repository.access_token).to be_nil
+      end
+    end
+
+    context 'after first access_token_get_or_generate' do
+      before do
+        @access_token = repository.access_token_get_or_generate
+      end
+
+      it 'should generate a token' do
+        expect(repository.access_token).not_to be_nil
+      end
+
+      it 'should associate with the generated token' do
+        expect(repository.access_token).to eq(@access_token)
+      end
+
+      it 'should save the token' do
+        expect(repository.access_token.persisted?).to be_truthy
+      end
+    end
+
+    context 'when already having a valid access token' do
+      before do
+        @access_token = repository.access_token_get_or_generate
+        @access_token.expiration = 1.minutes.from_now
+        @old_expiration = @access_token.expiration
+        repository.access_token_get_or_generate
+      end
+
+      it 'should still be the same token' do
+        expect(repository.access_token.token).to eq(@access_token.token)
+      end
+
+      it 'should have a later expiration date' do
+        expect(@old_expiration < repository.access_token.expiration).to be_truthy
+      end
+    end
+
+    context 'when already having an expired access token' do
+      before do
+        @access_token = repository.access_token_get_or_generate
+        @access_token.expiration = (-1).minutes.from_now
+        repository.access_token_get_or_generate
+      end
+
+      it 'should generate a new token' do
+        expect(repository.access_token.token).not_to eq(@access_token.token)
+      end
+    end
+  end
 end

--- a/spec/models/repository/access_spec.rb
+++ b/spec/models/repository/access_spec.rb
@@ -26,7 +26,12 @@ describe 'Repository Access' do
   end
 
   context 'private repository' do
-    let(:repository) { create :repository, access: 'private_rw' }
+    let(:ontology_version) { create :ontology_version }
+    let(:repository) { ontology_version.repository }
+    before do
+      repository.access = 'private_rw'
+      repository.save
+    end
 
     context 'without access token' do
       it 'should not have a token yet' do
@@ -35,7 +40,7 @@ describe 'Repository Access' do
     end
 
     context 'after generate_access_token' do
-      let!(:access_token) { repository.generate_access_token }
+      let!(:access_token) { ontology_version.generate_access_token }
 
       it 'should generate a token' do
         expect(repository.access_tokens).not_to be_empty

--- a/spec/models/repository/access_spec.rb
+++ b/spec/models/repository/access_spec.rb
@@ -40,7 +40,7 @@ describe 'Repository Access' do
     end
 
     context 'after generate_access_token' do
-      let!(:access_token) { ontology_version.generate_access_token }
+      let!(:access_token) { repository.generate_access_token }
 
       it 'should generate a token' do
         expect(repository.access_tokens).not_to be_empty

--- a/spec/models/theorem_spec.rb
+++ b/spec/models/theorem_spec.rb
@@ -25,7 +25,7 @@ describe Theorem do
       context 'with url-maps' do
         let!(:url_maps) { [create(:url_map, repository: repository)] }
         it 'have the url-maps as url-catalog parameter' do
-          expect(prove_options.options[:'url-catalog']).to eq(url_maps)
+          expect(prove_options.options[:'url-catalog']).to eq(url_maps.join(','))
         end
       end
 

--- a/spec/models/theorem_spec.rb
+++ b/spec/models/theorem_spec.rb
@@ -22,6 +22,21 @@ describe Theorem do
         expect(prove_options.options[:theorems]).to eq([theorem.name])
       end
 
+      context 'on a private repository' do
+        before do
+          repository.access = 'private_rw'
+          repository.save!
+        end
+
+        it 'have an existing access-token parameter' do
+          expect(prove_options.options[:'access-token']).to be_present
+        end
+        it 'have the access token as access-token parameter' do
+          expect(prove_options.options[:'access-token']).
+            to eq(repository.access_tokens.first.to_s)
+        end
+      end
+
       context 'with url-maps' do
         let!(:url_maps) { [create(:url_map, repository: repository)] }
         it 'have the url-maps as url-catalog parameter' do

--- a/test/factories/access_token.rb
+++ b/test/factories/access_token.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :access_token do
+    token { SecureRandom.hex(AccessToken::LENGTH) }
+    expiration { 1.hours.from_now }
+    association :repository
+  end
+end

--- a/test/factories/access_token.rb
+++ b/test/factories/access_token.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :access_token do
-    token { SecureRandom.hex(AccessToken::LENGTH) }
+    token { SecureRandom.hex(20) }
     expiration { 1.hours.from_now }
     association :repository
   end

--- a/test/factories/access_token.rb
+++ b/test/factories/access_token.rb
@@ -2,6 +2,6 @@ FactoryGirl.define do
   factory :access_token do
     token { SecureRandom.hex(20) }
     expiration { 1.hours.from_now }
-    association :repository
+    association :repository, access: 'private_rw'
   end
 end


### PR DESCRIPTION
This shall fix #558. As soon as hets (https://github.com/spechub/Hets/issues/1422) can handle it completely, this should work. Now, it is working for non-owl files whose file type can be detected by hets' magic.

After merging, don't forget to put this line into the crontab for the expired tokens to be deleted daily:
```
0 0  * * *  ~/current/script/rails runner 'AccessTokenDeletionWorker.new.perform'
```