### PR TITLE
Fix failing link spec due to hets error

### DIFF
--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -18,7 +18,12 @@ describe Link do
       let(:target_ontology) { dist_ontology.children.find_by_name('Features') }
 
       context 'and imports another ontology' do
-        let(:source_ontology) { external_repository.ontologies.find_by_name('path:features.owl') }
+        let(:source_ontology) do
+          o = external_repository.ontologies.find_by_name('path:features.owl')
+          # This is a workaround for a hets error.
+          # See https://github.com/spechub/Hets/issues/1433 for details.
+          o || external_repository.ontologies.find_by_name('path:')
+        end
 
         context 'which is not part of the distributed ontology' do
           let(:link) { dist_ontology.links.first }


### PR DESCRIPTION
This commit fixes the failing link_spec caused by https://github.com/spechub/Hets/issues/1433.
It allows for old and new hets versions to pass this test.

It is supposed to be reverted as soon as the hets issue is resolved.