### PR TITLE
1159 create mirror of private GitHub repository

### DIFF
--- a/app/models/repository/importing.rb
+++ b/app/models/repository/importing.rb
@@ -117,11 +117,12 @@ module Repository::Importing
 
   def detect_source_type
     if source_address?
-      if GitRepository.is_git_repository?(source_address)
-        self.source_type = 'git'
-      elsif GitRepository.is_svn_repository?(source_address)
-        self.source_type = 'svn'
-      end
+      self.source_type =
+        if GitRepository.is_git_repository?(source_address)
+          'git'
+        elsif GitRepository.is_svn_repository?(source_address)
+          'svn'
+        end
     end
   end
 end

--- a/app/models/repository/importing.rb
+++ b/app/models/repository/importing.rb
@@ -116,10 +116,12 @@ module Repository::Importing
   end
 
   def detect_source_type
-    if GitRepository.is_git_repository?(source_address)
-      self.source_type = 'git'
-    elsif GitRepository.is_svn_repository?(source_address)
-      self.source_type = 'svn'
+    if source_address?
+      if GitRepository.is_git_repository?(source_address)
+        self.source_type = 'git'
+      elsif GitRepository.is_svn_repository?(source_address)
+        self.source_type = 'svn'
+      end
     end
   end
 end

--- a/app/models/repository/validations.rb
+++ b/app/models/repository/validations.rb
@@ -120,7 +120,7 @@ module Repository::Validations
     def validate(record)
       if record.mirror? && !record.source_type.present?
         record.errors[:source_address] = 'not a valid remote repository '\
-          "(types supported: #{Repository::Importing::SOURCE_TYPES.join(', ')})"
+          "or not accessible (types supported: #{SOURCE_TYPES.join(', ')})"
         record.errors[:source_type] = 'not present'
       end
     end

--- a/lib/git_repository/cloning.rb
+++ b/lib/git_repository/cloning.rb
@@ -65,7 +65,7 @@ module GitRepository::Cloning
 
   module ClassMethods
     def is_git_repository?(address)
-      !!(exec 'git', 'ls-remote', address)
+      !!(exec 'git', 'ls-remote', '-h', address)
     rescue Subprocess::Error => e
       if e.status == 128
         false

--- a/lib/git_repository/cloning.rb
+++ b/lib/git_repository/cloning.rb
@@ -65,7 +65,9 @@ module GitRepository::Cloning
 
   module ClassMethods
     def is_git_repository?(address)
-      !!(exec 'git', 'ls-remote', '-h', address)
+      # GIT_ASKPASS is set to the 'true' executable. It simply returns
+      # successfully. This way, no credentials are supplied.
+      !!(exec 'git', 'ls-remote', '-h', address, 'GIT_ASKPASS' => 'true')
     rescue Subprocess::Error => e
       if e.status == 128
         false

--- a/lib/git_repository/cloning.rb
+++ b/lib/git_repository/cloning.rb
@@ -7,7 +7,7 @@ module GitRepository::Cloning
   Ref = Struct.new(:previous, :current)
 
   def clone(url)
-    set_section %w( remote origin ),
+    set_section %w(remote origin),
       url:    url,
       fetch:  '+refs/*:refs/*',
       mirror: 'true'
@@ -16,7 +16,7 @@ module GitRepository::Cloning
   end
 
   def clone_svn(url)
-    options = { url: url }
+    options = {url: url}
 
     # Do we have a standard layout?
     if self.class.svn_ls(url).split("\n") == %w( branches/ tags/ trunk/ )
@@ -29,25 +29,25 @@ module GitRepository::Cloning
         fetch:    ':refs/remotes/git-svn'
     end
 
-    set_section %w( svn-remote svn ), options
+    set_section %w(svn-remote svn), options
     pull_svn
   end
 
   def pull
     with_head_change head_oid do
-      git_exec 'remote', 'update'
+      git_exec('remote', 'update')
     end
   end
 
   # Fetches the latest commits and resets the local master
   def pull_svn
     old_head_oid = head_oid
-    git_exec 'svn', 'fetch'
+    git_exec('svn', 'fetch')
 
     if svn_has_trunk?
-      reset_branch old_head_oid, 'master', "remotes/trunk"
+      reset_branch(old_head_oid, 'master', "remotes/trunk")
     else
-      reset_branch old_head_oid, 'master', "remotes/git-svn"
+      reset_branch(old_head_oid, 'master', "remotes/git-svn")
     end
 
   end
@@ -58,8 +58,8 @@ module GitRepository::Cloning
 
   # Sets the reference of a local branch
   def reset_branch(old_head_oid, branch, ref)
-    with_head_change old_head_oid do
-      git_exec 'branch', '-f', branch, ref
+    with_head_change(old_head_oid) do
+      git_exec('branch', '-f', branch, ref)
     end
   end
 
@@ -67,7 +67,7 @@ module GitRepository::Cloning
     def is_git_repository?(address)
       # GIT_ASKPASS is set to the 'true' executable. It simply returns
       # successfully. This way, no credentials are supplied.
-      !!(exec 'git', 'ls-remote', '-h', address, 'GIT_ASKPASS' => 'true')
+      !! exec('git', 'ls-remote', '-h', address, 'GIT_ASKPASS' => 'true')
     rescue Subprocess::Error => e
       if e.status == 128
         false
@@ -77,7 +77,7 @@ module GitRepository::Cloning
     end
 
     def svn_ls(address)
-      exec 'svn', 'ls', address
+      exec('svn', 'ls', address)
     end
 
     def is_svn_repository?(address)


### PR DESCRIPTION
### Updated message
This fixes #1159 and a few other git/cloning related bugs (see first commits).
When a private git repository is supposed to be cloned, git usually asks for credentials. This prompt is prevented by asking `/bin/true` for them. Of course, `true` doesn't supply any, but exits with code `SUCCESS`, so git thinks they are supplied and fails because the credentials don't fit to the repository.

*I removed the previous workaround-commits by rebase (see original message).*

### Original message
This is more of a workaround than a fix for #1159.

I don't see any fast way to check if something is a git repository than `git ls-remote`. However, this asks for credentials when calling it on a github private repository.

I tried to read the login prompt of `git ls-remote` in `Subprocess.run`, but I could not get my hands on the prompt lines. Neither with `IO.popen` nor with `Open3.popen2e`.

The best solution would be to read those login prompt lines and abort if they are present, but I can't figure out how to do this, because they are not printed to stdout nor stderr of the child process.