### PR TITLE
Add setting for hets workers count.

### DIFF
--- a/config/god/app.rb
+++ b/config/god/app.rb
@@ -3,12 +3,15 @@ require File.expand_path('../hets_workers',  __FILE__)
 
 RAILS_ROOT = ENV['RAILS_ROOT'] || File.dirname(__FILE__) + '/../..'
 
+# High load workers (except hets) are: sequential and priority_push.
+HIGH_LOAD_WORKERS_COUNT = 2
+
 God.pid_file_directory = File.join(RAILS_ROOT, 'tmp/pids/')
 
 SidekiqWorkers.configure do
   if ENV['RAILS_ENV']=='production'
     # one worker per core
-    `nproc`.to_i.times.each do
+    hets_workers_count.times.each do
       watch 'hets', 1
     end
 
@@ -27,4 +30,10 @@ end
 
 HetsWorkers.configure do
   watch
+end
+
+def hets_workers_count
+  min_workers = 1
+  max_workers = [`nproc`.to_i - HIGH_LOAD_WORKERS_COUNT, min_workers].max
+  [Settings.workers.hets, max_workers].min
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -53,6 +53,10 @@ exception_notifier:
   exception_recipients:
     - exception-recipient@example.com
 
+# Worker count
+workers:
+  hets: 4
+
 git:
   verify_url: http://localhost/
   default_branch: 'master'


### PR DESCRIPTION
This shall fix #1150.
Now the number of hets workers can be configured by the admin, but it is restricted to
* at least one
* at most "number of processors" minus "number of other high load workers" (2)