### PR TITLE
Colorize the output, if the environment says so.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -121,6 +121,8 @@ RSpec.configure do |config|
   # config.mock_with :rr
   config.mock_with :rspec
 
+  config.tty ||= ENV["SPEC_OPTS"].include?('--color') if ENV["SPEC_OPTS"]
+
   config.before(:suite) do
     FactoryGirl.create :proof_statuses
   end


### PR DESCRIPTION
This enables colorized rspec output in jenkins.