### PR TITLE
Improve ontology list display

### DIFF
--- a/app/assets/images/icons/single_ontology.svg
+++ b/app/assets/images/icons/single_ontology.svg
@@ -25,8 +25,8 @@
     id="image"
     >
     <!-- Border -->
-    <circle cx="32" cy="32" r="12" stroke="black" stroke-width="1" fill="none" />
+    <circle cx="32" cy="32" r="18" stroke="black" stroke-width="1" fill="none" />
     <!-- Ontology -->
-    <circle cx="32" cy="32" r="8" fill="black" stroke="black" />
+    <circle cx="32" cy="32" r="12" fill="black" stroke="black" />
     </g>
 </svg>

--- a/app/assets/stylesheets/data_type.css.sass
+++ b/app/assets/stylesheets/data_type.css.sass
@@ -62,12 +62,19 @@ a[data-type]
   padding-left: 20px !important
   padding-right: 5px
 
+ol.ontology-list
+  list-display-style: none
+
+li.ontology-list-item
+  margin-top: 3px
+  margin-bottom: 3px
+
 a[data-ontologyclass]
   background-position: 0px center
   padding-left: 26px !important
-  padding-right: 5px
-  padding-top: 9px
-  padding-bottom: 3px
+  padding-right: 8px
+  padding-top: 5px
+  padding-bottom: 5px
 
 span.ontology_title
   a[data-ontologyclass]

--- a/app/views/files/_show_dir.html.haml
+++ b/app/views/files/_show_dir.html.haml
@@ -23,7 +23,7 @@
               - unless entry.dir? || entry.ontologies.empty?
                 %ul.ontology-list
                   - entry.ontologies.each do |ontology|
-                    %li
+                    %li.ontology-list-item
                       = fancy_link ontology
                       - if ontology.state=='failed'
                         %i.icon-bolt{ title: "processing #{ontology.state}" }

--- a/app/views/home/_versions.html.haml
+++ b/app/views/home/_versions.html.haml
@@ -14,9 +14,10 @@
   = link_to "Browse #{Settings.OMS.pluralize.capitalize}", ontologies_path, class: 'btn btn-primary', type: 'button'
 
 - @versions.each do |version|
-  %div
-    = fancy_link version.ontology
-    - if version.user
-      by
-      = fancy_link version.user
-    = timestamp version
+  %ol.ontology-list
+    %li.ontology-list-item
+      = fancy_link version.ontology
+      - if version.user
+        by
+        = fancy_link version.user
+      = timestamp version

--- a/app/views/logics/_distributed.html.haml
+++ b/app/views/logics/_distributed.html.haml
@@ -1,6 +1,6 @@
 %h3 homogeneous distributed #{Settings.OMS.pluralize}
 %h5 with children which use this logic
 
-%ol.latest
+%ol.latest.ontology-list
   - Ontology.distributed_in(resource).each do |ontology|
-    %li= fancy_link(ontology)
+    %li.ontology-list-item= fancy_link(ontology)

--- a/app/views/logics/_heterogeneous_distributed.html.haml
+++ b/app/views/logics/_heterogeneous_distributed.html.haml
@@ -1,6 +1,6 @@
 %h3 heterogeneous distributed #{Settings.OMS.pluralize}
 %h5 with children which use this logic
 
-%ol.latest
+%ol.latest.ontology-list
   - Ontology.also_distributed_in(resource).each do |ontology|
-    %li= fancy_link(ontology)
+    %li.ontology-list-item= fancy_link(ontology)

--- a/app/views/logics/_ontologies.html.haml
+++ b/app/views/logics/_ontologies.html.haml
@@ -1,4 +1,4 @@
 %h3 #{Settings.OMS.pluralize.capitalize} using this logic
-%ol.latest
+%ol.latest.ontology-list
   - @ontologies.each do |ontology|
-    %li= fancy_link(ontology)
+    %li.ontology-list-item= fancy_link(ontology)


### PR DESCRIPTION
Should basically be as advertised: Improves spacing for ontology-fancy-link (the svg-icons) in specific lists. This should remove the overlap between multiple heterogeneous-ontology icons.