### PR TITLE
Make god listen again

### DIFF
--- a/config/god/app.rb
+++ b/config/god/app.rb
@@ -8,6 +8,14 @@ HIGH_LOAD_WORKERS_COUNT = 2
 
 God.pid_file_directory = File.join(RAILS_ROOT, 'tmp/pids/')
 
+def hets_workers_count
+  yaml = YAML.load_file(File.join(RAILS_ROOT, 'config', 'settings.yml'))
+
+  min_workers = 1
+  max_workers = [`nproc`.to_i - HIGH_LOAD_WORKERS_COUNT, min_workers].max
+  [yaml['workers']['hets'], max_workers].min
+end
+
 SidekiqWorkers.configure do
   if ENV['RAILS_ENV']=='production'
     # one worker per core
@@ -30,10 +38,4 @@ end
 
 HetsWorkers.configure do
   watch
-end
-
-def hets_workers_count
-  min_workers = 1
-  max_workers = [`nproc`.to_i - HIGH_LOAD_WORKERS_COUNT, min_workers].max
-  [Settings.workers.hets, max_workers].min
 end


### PR DESCRIPTION
This shall fix #1151. God didn't start because it failed while reading the configuration.

First, the method `hets_workers_count` was not visible in the configure
block. Moving it up fixes this.

Second, the Rails environment is not available. Loading the yml file
manually fixes this.