### PR TITLE
Add stylecheck script

### DIFF
--- a/script/stylecheck
+++ b/script/stylecheck
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+require 'tempfile'
+
+RAILS_ROOT = File.expand_path('../..', __FILE__)
+CONFIG_FILE_PATH = File.join(RAILS_ROOT, '.hound.yml')
+
+config = File.read(CONFIG_FILE_PATH)
+config = config.sub(/$\s+ShowCopNames:.*?\n/, '')
+
+customized_config_file = Tempfile.new('rubocop.yml')
+customized_config_file.write(config)
+customized_config_file.close
+
+command = %W(rubocop --rails --config #{customized_config_file.path})
+command += ARGV
+
+system(*command)
+
+customized_config_file.unlink


### PR DESCRIPTION
This script runs rubocop with a suitable config generated from the
`.hound.yml`. The hound config includes a key that's not compatible with
rubocop. The config is copied to a tempfile without that key.

#### Usage
You can check your code for compliance with the style guide by running
```
script/stylecheck
```
in the ontohub directory. You can also specify a list of files and folders to go
through with
```
script/stylecheck app/models/ontology.rb app/models/ontology/
```