### PR TITLE
Add reasonable errors for hets instances

### DIFF
--- a/app/controllers/filetypes_controller.rb
+++ b/app/controllers/filetypes_controller.rb
@@ -9,7 +9,7 @@ class FiletypesController < ApplicationController
   protected
 
   def filetype
-    @filetype ||= Hets::FiletypeCaller.new(HetsInstance.choose).
+    @filetype ||= Hets::FiletypeCaller.new(HetsInstance.choose!).
       call(params[:iri])
   end
 

--- a/app/models/hets_instance.rb
+++ b/app/models/hets_instance.rb
@@ -1,10 +1,36 @@
 class HetsInstance < ActiveRecord::Base
+  class Error < ::StandardError; end
+  class NoRegisteredHetsInstanceError < Error
+    DEFAULT_MSG = 'There is no registered HetsInstance for this application'
+
+    def initialize(msg = DEFAULT_MSG)
+      super
+    end
+  end
+
+  class NoSelectableHetsInstanceError < Error
+    DEFAULT_MSG = <<-MSG
+There is no HetsInstance which is reachable and
+has a minimal Hets version of #{Hets.minimal_version_string}
+    MSG
+
+    def initialize(msg = DEFAULT_MSG)
+      super
+    end
+  end
+
   attr_accessible :name, :uri
 
   before_save :set_up_state
 
+  scope :active_instances, -> do
+    where(up: true).where('version >= ?', Hets.minimal_version_string)
+  end
+
   def self.choose
-    where(up: true).where('version >= ?', Hets.minimal_version_string).first
+    raise NoRegisteredHetsInstanceError.new unless any?
+    instance = active_instances.first
+    instance or raise NoSelectableHetsInstanceError.new
   end
 
   # will result in 0.99 for <v0.99, something or other>

--- a/app/models/hets_instance.rb
+++ b/app/models/hets_instance.rb
@@ -27,7 +27,7 @@ has a minimal Hets version of #{Hets.minimal_version_string}
     where(up: true).where('version >= ?', Hets.minimal_version_string)
   end
 
-  def self.choose
+  def self.choose!
     raise NoRegisteredHetsInstanceError.new unless any?
     instance = active_instances.first
     instance or raise NoSelectableHetsInstanceError.new

--- a/lib/hets.rb
+++ b/lib/hets.rb
@@ -117,14 +117,14 @@ we expected it to be matchable by this regular expression:
   def self.parse_via_api(resource, url_catalog = [], structure_only: false)
     mode = structure_only ? :fast_run : :default
 
-    parse_caller = Hets::ParseCaller.new(HetsInstance.choose, url_catalog)
+    parse_caller = Hets::ParseCaller.new(HetsInstance.choose!, url_catalog)
 
     parse_caller.call(qualified_loc_id_for(resource), with_mode: mode)
   end
 
   def self.filetype(resource)
     iri = qualified_loc_id_for(resource)
-    filetype_caller = Hets::FiletypeCaller.new(HetsInstance.choose)
+    filetype_caller = Hets::FiletypeCaller.new(HetsInstance.choose!)
 
     response_iri, filetype = filetype_caller.call(iri).split(': ')
     if response_iri == iri

--- a/lib/hets.rb
+++ b/lib/hets.rb
@@ -94,8 +94,20 @@ we expected it to be matchable by this regular expression:
 
   end
 
+  def self.config
+    @config ||= Hets::Config.new
+  end
+
   def self.minimal_version_string
-    Hets::Config.new.minimal_version_string
+    config.minimal_version_string
+  end
+
+  def self.minimum_revision
+    config.minimum_revision
+  end
+
+  def self.minimum_version
+    config.minimum_version
   end
 
   def self.qualified_loc_id_for(resource)

--- a/lib/hets/parse_caller.rb
+++ b/lib/hets/parse_caller.rb
@@ -15,7 +15,7 @@ module Hets
     def initialize(hets_instance, url_catalog = [])
       self.url_catalog = url_catalog
       msg = "<#{hets_instance}> not up."
-      raise Hets::InactiveInstanceError, msg unless hets_instance.up?
+      raise Hets::InactiveInstanceError, msg unless hets_instance.try(:up?)
       super(hets_instance)
     end
 

--- a/spec/controllers/filetypes_controller_spec.rb
+++ b/spec/controllers/filetypes_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe FiletypesController do
+  setup_hets
 
   context 'should return valid json on correct request' do
     let(:iri) { 'http://ontohub.org/non-existence/foobar.clif' }

--- a/spec/models/hets_instance_spec.rb
+++ b/spec/models/hets_instance_spec.rb
@@ -1,12 +1,50 @@
 require 'spec_helper'
 
 describe HetsInstance do
-  context 'when creating a hets instance' do
-    context 'and it has a reachable uri' do
-      let(:general_version) { '0.99' }
-      let(:specific_version) { '1409043198' }
+  let(:general_version) { Hets.minimum_version.to_s }
+  let(:specific_version) { Hets.minimum_revision.to_s }
+  let(:hets_instance) { create :local_hets_instance }
+
+  context 'when choosing a hets instance' do
+    context 'and there is no hets instance recorded' do
+      it 'should raise the appropriate error' do
+        expect { HetsInstance.choose }.
+          to raise_error(HetsInstance::NoRegisteredHetsInstanceError)
+      end
+    end
+
+    context 'and there is no acceptable hets instance' do
       let(:hets_instance) { create :local_hets_instance }
 
+      before do
+        stub_request(:get, "http://localhost:8000/version").
+          to_return(status: 500, body: "", headers: {})
+        hets_instance
+      end
+
+      it 'should raise the appropriate error' do
+        expect { HetsInstance.choose }.
+          to raise_error(HetsInstance::NoSelectableHetsInstanceError)
+      end
+    end
+
+    context 'and there is an acceptable hets instance' do
+      before do
+        stub_request(:get, "http://localhost:8000/version").
+          to_return(status: 200,
+                    body: "v#{general_version}, #{specific_version}",
+                    headers: {})
+        hets_instance
+      end
+
+      it 'should return that hets instance' do
+        expect(HetsInstance.choose).to eq(hets_instance)
+      end
+    end
+  end
+
+  context 'when creating a hets instance' do
+    context 'and it has a reachable uri' do
       before do
         stub_request(:get, "http://localhost:8000/version").
           to_return(status: 200,
@@ -33,8 +71,6 @@ describe HetsInstance do
     end
 
     context 'and it has a non-reachable uri' do
-      let(:hets_instance) { create :local_hets_instance }
-
       before do
         stub_request(:get, "http://localhost:8000/version").
           to_return(status: 500, body: "", headers: {})

--- a/spec/models/hets_instance_spec.rb
+++ b/spec/models/hets_instance_spec.rb
@@ -8,7 +8,7 @@ describe HetsInstance do
   context 'when choosing a hets instance' do
     context 'and there is no hets instance recorded' do
       it 'should raise the appropriate error' do
-        expect { HetsInstance.choose }.
+        expect { HetsInstance.choose! }.
           to raise_error(HetsInstance::NoRegisteredHetsInstanceError)
       end
     end
@@ -23,7 +23,7 @@ describe HetsInstance do
       end
 
       it 'should raise the appropriate error' do
-        expect { HetsInstance.choose }.
+        expect { HetsInstance.choose! }.
           to raise_error(HetsInstance::NoSelectableHetsInstanceError)
       end
     end
@@ -38,7 +38,7 @@ describe HetsInstance do
       end
 
       it 'should return that hets instance' do
-        expect(HetsInstance.choose).to eq(hets_instance)
+        expect(HetsInstance.choose!).to eq(hets_instance)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,10 +58,10 @@ def hets_out_file(name, ext='xml')
 end
 
 def hets_uri(portion = nil, version = nil)
-  hets_instance = HetsInstance.choose
+  hets_instance = HetsInstance.choose!
   if hets_instance.nil?
     FactoryGirl.create(:local_hets_instance)
-    hets_instance = HetsInstance.choose
+    hets_instance = HetsInstance.choose!
   end
   specific = ''
   # %2F is percent-encoding for forward slash /

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,15 +59,17 @@ end
 
 def hets_uri(portion = nil, version = nil)
   hets_instance = HetsInstance.choose!
+rescue HetsInstance::NoRegisteredHetsInstanceError => e
   if hets_instance.nil?
     FactoryGirl.create(:local_hets_instance)
     hets_instance = HetsInstance.choose!
   end
+ensure
   specific = ''
   # %2F is percent-encoding for forward slash /
   specific << "ref%2F#{version}.*" if version
   specific << "#{portion}.*" if portion
-  %r{#{hets_instance.uri}/dg/.*#{specific}}
+  return %r{#{hets_instance.uri}/dg/.*#{specific}}
 end
 
 def stub_hets_for(fixture_file, with: nil, with_version: nil)


### PR DESCRIPTION
Produce a little bit more readable and reasonable errors when there is no (useable) hets instance registered.