### PR TITLE
re-enqueue only specific container if not terminal

### DIFF
--- a/app/assets/javascripts/ontology_version-state.js.coffee
+++ b/app/assets/javascripts/ontology_version-state.js.coffee
@@ -12,7 +12,7 @@ update = (container) ->
       state = data.state
 
       if state == current_state && !_.contains(final_states, state)
-        enqueue()
+        enqueue(container)
       else
         current_state = state
 


### PR DESCRIPTION
If the ontology state is not terminal (a final state), then we should
only re-enqueue the particular container instead of all (which would
lead to a lot more jobs being created).