### PR TITLE
1250 use hets api and vcr for the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,10 +63,4 @@ config/environments/*.local.rb
 # Ignore output of SimpleCov
 /coverage
 
-spec/fixtures/ontologies/xml
-
-spec/fixtures/ontologies/hets-out/*
-!spec/fixtures/ontologies/hets-out/.gitkeep
-
-spec/fixtures/ontologies/hets-out/prove
-!spec/fixtures/ontologies/hets-out/prove/.gitkeep
+spec/fixtures/vcr/hets-out

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -9,86 +9,177 @@ namespace :test do
     Rake::Task['db:migrate:clean'].invoke
   end
 
-  def hets_path
-    `which hets`.strip
-  end
 
-  def hets_out_file_for(ontology_file)
-    basename = File.basename(ontology_file).sub(/\.[^.]+$/, '.xml')
-    File.join('spec/fixtures/ontologies/hets-out/', basename)
-  end
+  HETS_API_OPTIONS = '/auto'
+  HETS_BASE_IRI = 'http://localhost:8000'
+  HETS_PATH = `which hets`.strip
+  HETS_SERVER_ARGS = YAML.load(File.open('config/hets.yml'))['server_options']
 
-  def on_outdated_files(files, &block)
-    files.each do |file|
-      hets_file = hets_out_file_for(file)
-      out_of_date = !FileUtils.uptodate?(hets_file, Array(hets_path))
-      block.call(file) if out_of_date
-    end
-  end
-
-  def hets_args
-    YAML.load(File.open('config/hets.yml'))['cmd_line_options']
-  end
-
-  def perform_hets_on(file)
-    args = hets_args << '-O spec/fixtures/ontologies/hets-out'
-    system("hets #{args.join(' ')} #{file}")
+  def all_files_beneath(dir)
+    globbed_files = Dir.glob(File.join(dir, '**/*'))
+    globbed_files.select { |file| !File.directory?(file) }
   end
 
   def ontology_files
-    globbed_files = Dir.glob('spec/fixtures/ontologies/**/*')
-    globbed_files.select do |file|
-      !file.end_with?('proof.json') &&
-      !file.end_with?('xml') &&
-      !File.directory?(file)
+    all_files_beneath('spec/fixtures/ontologies').select do |file|
+      !file.end_with?('.xml')
     end
   end
 
   def prove_files
-    globbed_files = Dir.glob('spec/fixtures/ontologies/prove/**/*')
-    globbed_files.select do |file|
-      !file.end_with?('.proof.json') && !File.directory?(file)
+    all_files_beneath('spec/fixtures/ontologies/prove')
+  end
+
+  def absolute_filepath(file)
+    Rails.root.join(file)
+  end
+
+  def cassette_file(file)
+    # remove spec/fixtures/ontologies/ for cassette name
+    cassette_filepath = file.split('/')[3..-1].join('/')
+  end
+
+  def hets_cassette_dir(subdir)
+    File.join('hets-out', subdir)
+  end
+
+  def cassette_path_in_fixtures(subdir, file)
+    File.join(hets_cassette_dir(subdir), cassette_file(file))
+  end
+
+  def recorded_file(subdir, file)
+    base = file.split('.')[0..-2].join('.')
+    old_extension = File.extname(file)[1..-1]
+    file = "#{base}_#{old_extension}.yml"
+    File.join('spec', 'fixtures', 'vcr', cassette_path_in_fixtures(subdir, file))
+  end
+
+  def outdated_cassettes(files, subdir)
+    files.select do |file|
+      cassette = recorded_file(subdir, file)
+      !FileUtils.uptodate?(cassette, Array(HETS_PATH))
     end
   end
 
-  def prove_with_hets(file)
-    puts "Calling hets prover for #{file}"
-
-    absolute_filepath = Rails.root.join(file)
-    escaped_iri = Rack::Utils.escape_path("file://#{absolute_filepath}")
-    command = %w(curl -s -X POST)
-    command += ['-H', %('Content-Type: application/json')]
-    command += ['-d', %('{"format": "json"}')]
-    command << "http://localhost:8000/prove/#{escaped_iri}"
-    command = command.join(' ')
-
-    filename = File.basename(file).split('.')[0..-2].join('.')
-    target_path = Rails.root.join('spec/fixtures/ontologies/hets-out/prove', filename)
-
-    File.write("#{target_path}.proof.json", `#{command}`)
-  end
-
-  desc 'Update all ontology fixtures'
-  task :freshen_ontology_fixtures do
-    on_outdated_files(ontology_files) do |file|
-      puts "Calling hets for: #{file}"
-      perform_hets_on(file)
+  def on_outdated_cassettes(files, subdir, &block)
+    outdated_cassettes(files, subdir).each do |file|
+      block.call(file, subdir)
     end
   end
 
-  desc 'Update all prove fixtures'
-  task :freshen_prove_fixtures do
-    hets_pid = fork { exec('hets -X') }
+  def call_hets_dg(file, subdir)
+    puts "Calling hets/dg on #{file.inspect}"
+    hets_api_options = "#{HETS_API_OPTIONS}/full-signatures/full-theories"
+    escaped_iri = Rack::Utils.escape_path("file://#{absolute_filepath(file)}")
+    hets_iri = "#{HETS_BASE_IRI}/dg/#{escaped_iri}#{hets_api_options}"
+
+    FileUtils.rm_f(recorded_file(subdir, file))
+    VCR.use_cassette(cassette_path_in_fixtures(subdir, file)) do
+      Net::HTTP.get_response(URI(hets_iri))
+    end
+  end
+
+  def call_hets_provers(file, subdir)
+    puts "Calling hets/provers on #{file.inspect}"
+    options = 'format=json'
+    escaped_iri = Rack::Utils.escape_path("file://#{absolute_filepath(file)}")
+    hets_iri = "#{HETS_BASE_IRI}/provers/#{escaped_iri}#{HETS_API_OPTIONS}"
+    hets_iri << "?#{options}"
+
+    FileUtils.rm_f(recorded_file(subdir, file))
+    VCR.use_cassette(cassette_path_in_fixtures(subdir, file)) do
+      Net::HTTP.get_response(URI(hets_iri))
+    end
+  end
+
+  def call_hets_prove(file, subdir)
+    puts "Calling hets/prove on #{file.inspect}"
+    escaped_iri = Rack::Utils.escape_path("file://#{absolute_filepath(file)}")
+    hets_iri = "#{HETS_BASE_IRI}/prove/#{escaped_iri}#{HETS_API_OPTIONS}"
+    header = {'Content-Type' => 'application/json'}
+    data = {format: 'json', include: 'true'}
+
+    FileUtils.rm_f(recorded_file(subdir, file))
+    VCR.use_cassette(cassette_path_in_fixtures(subdir, file)) do
+      uri = URI(hets_iri)
+      Net::HTTP.start(uri.hostname, uri.port) do |http|
+        http.request_post(uri, data.to_json, header)
+      end
+    end
+  end
+
+  def freshen_ontology_fixtures
+    on_outdated_cassettes(ontology_files, 'dg') do |file, subdir|
+      call_hets_dg(file, subdir)
+    end
+  end
+
+  def freshen_provers_fixtures
+    on_outdated_cassettes(ontology_files, 'provers') do |file, subdir|
+      call_hets_provers(file, subdir)
+    end
+  end
+
+  def freshen_proof_fixtures
+    on_outdated_cassettes(prove_files, 'prove') do |file, subdir|
+      call_hets_prove(file, subdir)
+    end
+  end
+
+  def setup_vcr
+    require 'vcr'
+    VCR.configure do |c|
+      c.cassette_library_dir = 'spec/fixtures/vcr'
+      c.hook_into :webmock
+    end
+  end
+
+  def with_running_hets(&block)
+    hets_pid = fork { exec("hets --server #{HETS_SERVER_ARGS.join(' ')}") }
     # hets server needs some startup time
     sleep 1
-    prove_files.each { |file| prove_with_hets(file) }
+    block.call
+  ensure
     puts 'Stopping hets server.'
     Process.kill('TERM', hets_pid)
   end
 
-  desc 'Update all hets dependent fixtures'
+  desc 'Update all fixtures'
   task :freshen_fixtures do
-    Rake::Task['test:freshen_ontology_fixtures'].invoke
-    Rake::Task['test:freshen_prove_fixtures'].invoke
+    outdated_exist = outdated_cassettes(ontology_files, 'dg').any?
+    outdated_exist ||= outdated_cassettes(ontology_files, 'provers').any?
+    outdated_exist ||= outdated_cassettes(prove_files, 'prove').any?
+    if outdated_exist
+      setup_vcr
+      with_running_hets do
+        freshen_ontology_fixtures
+        freshen_provers_fixtures
+        freshen_proof_fixtures
+      end
+    end
+  end
+
+  desc 'Update all ontology fixtures'
+  task :freshen_ontology_fixtures do
+    if outdated_cassettes(ontology_files, 'dg').any?
+      setup_vcr
+      with_running_hets { freshen_ontology_fixtures }
+    end
+  end
+
+  desc 'Update all provers fixtures'
+  task :freshen_provers_fixtures do
+    if outdated_cassettes(ontology_files, 'provers').any?
+      setup_vcr
+      with_running_hets { freshen_provers_fixtures }
+    end
+  end
+
+  desc 'Update all proof fixtures'
+  task :freshen_proof_fixtures do
+    if outdated_cassettes(prove_files, 'prove').any?
+      setup_vcr
+      with_running_hets { freshen_proof_fixtures }
+    end
   end
 end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -150,15 +150,15 @@ namespace :test do
   end
 
   def with_running_hets(&block)
-    hets_was_already_running = !port_open?('127.0.0.1', 8000)
-    if hets_was_already_running
+    need_to_start_hets = !port_open?('127.0.0.1', 8000)
+    if need_to_start_hets
       hets_pid = fork { exec("hets --server #{HETS_SERVER_ARGS.join(' ')}") }
       # hets server needs some startup time
       sleep 1
     end
     block.call
   ensure
-    if hets_was_already_running
+    if need_to_start_hets
       puts 'Stopping hets server.'
       Process.kill('TERM', hets_pid)
     end

--- a/spec/controllers/ontology_versions_controller_spec.rb
+++ b/spec/controllers/ontology_versions_controller_spec.rb
@@ -10,7 +10,7 @@ describe OntologyVersionsController do
     let(:repository) { ontology.repository }
 
     before do
-      parse_this(user, ontology, hets_out_file('test2'))
+      parse_ontology(user, ontology, 'casl/test2.casl')
     end
 
     context 'on GET to index of a child' do

--- a/spec/hets_helper.rb
+++ b/spec/hets_helper.rb
@@ -1,0 +1,53 @@
+# In this file, 'ontology_fixture' is always the path to the ontology file
+# relative to Rails.root.join('spec/fixtures/ontologies/')
+
+def hets_vcr_file(subdir, ontology_fixture)
+  # Replace last occurence of '.' by '_' in the filepath (VCR convention).
+  portions = ontology_fixture.split('.')
+  path = portions[0..-2].join('.')
+  extension = portions[-1]
+
+  fixture_file(File.join('vcr', 'hets-out', subdir, "#{path}_#{extension}.yml"))
+end
+
+def hets_ontology_vcr_file(ontology_fixture)
+  hets_vcr_file('dg', ontology_fixture)
+end
+
+def hets_proof_vcr_file(ontology_fixture)
+  hets_vcr_file('proof', ontology_fixture)
+end
+
+def hets_provers_vcr_file(ontology_fixture)
+  hets_vcr_file('provers', ontology_fixture)
+end
+
+
+def hets_out_body(subdir, ontology_fixture)
+  yaml = YAML.load(File.open(hets_vcr_file(subdir, ontology_fixture)))
+  yaml['http_interactions'].first['response']['body']['string']
+end
+
+def hets_out_body_ontology(ontology_fixture)
+  hets_out_body('dg', ontology_fixture)
+end
+
+def hets_out_body_proof(ontology_fixture)
+  hets_out_body('proof', ontology_fixture)
+end
+
+def hets_out_body_provers(ontology_fixture)
+  hets_out_body('provers', ontology_fixture)
+end
+
+
+def parse_ontology_hets_out(user, ontology, io)
+  evaluator = Hets::DG::Evaluator.new(user, ontology, io: io)
+  evaluator.import
+  io.close unless io.closed?
+end
+
+def parse_ontology(user, ontology, ontology_fixture)
+  io = StringIO.new(hets_out_body_ontology(ontology_fixture))
+  parse_ontology_hets_out(user, ontology, io)
+end

--- a/spec/hets_helper.rb
+++ b/spec/hets_helper.rb
@@ -62,11 +62,12 @@ def setup_hets
   end
 end
 
-def stub_hets_for(fixture_file, command: 'dg', with: nil, with_version: nil, method: :get)
+def stub_hets_for(ontology_fixture,
+                  command: 'dg', with: nil, with_version: nil, method: :get)
   stub_request(:get, 'http://localhost:8000/version').
     to_return(body: Hets.minimal_version_string)
   stub_request(method, hets_uri(command, with, with_version)).
-    to_return(body: fixture_file.read)
+    to_return(body: hets_out_body(command, ontology_fixture))
 end
 
 def hets_uri(command = 'dg', portion = nil, version = nil)

--- a/spec/lib/hets_spec.rb
+++ b/spec/lib/hets_spec.rb
@@ -33,7 +33,8 @@ describe Hets, :needs_hets do
       end
 
       it 'have generated importable output' do
-        expect { parse_this(user, ontology, @xml_path) }.not_to raise_error
+        expect { parse_ontology_hets_out(user, ontology, File.open(@xml_path)) }.
+          not_to raise_error
       end
     end
   end

--- a/spec/lib/ontology_batch_parse_worker_spec.rb
+++ b/spec/lib/ontology_batch_parse_worker_spec.rb
@@ -19,7 +19,7 @@ describe OntologyBatchParseWorker do
       balancer.mark_as_processing_or_complain(ontology.iri)
       OntologyVersion.any_instance.stubs(:raw_path!).returns(
         ontology_file('clif/sequential_parse'))
-      stub_hets_for(hets_out_file('sequential_parse'))
+      stub_hets_for('clif/sequential_parse.clif')
     end
 
     after do

--- a/spec/lib/tarjan_spec.rb
+++ b/spec/lib/tarjan_spec.rb
@@ -7,7 +7,7 @@ describe TarjanTree do
       let(:user) { create :user }
 
       before do
-        parse_this(user, ontology, hets_out_file('cycle'))
+        parse_ontology(user, ontology, 'owl/cycle.owl')
         ontology.reload
       end
 

--- a/spec/lib/worker_spec.rb
+++ b/spec/lib/worker_spec.rb
@@ -19,7 +19,7 @@ describe Worker do
       balancer.mark_as_processing_or_complain(ontology.iri)
       OntologyVersion.any_instance.stubs(:raw_path!).returns(
         ontology_file('clif/sequential_parse'))
-      stub_hets_for(hets_out_file('sequential_parse'))
+      stub_hets_for('clif/sequential_parse.clif')
     end
 
     after do

--- a/spec/models/category.rb
+++ b/spec/models/category.rb
@@ -36,7 +36,7 @@ describe Category do
     before do
       @user = create :user
       @ontology = create :single_ontology
-      parse_this(@user, @ontology, fixture_file('Domain_Fields_Core.xml'), fixture_file('Domain_Fields_Core.pp.xml'))
+      parse_ontology(@user, @ontology, 'owl/Domain_Fields_Core.owl')
       @ontology.create_categories
     end
 

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -24,7 +24,7 @@ describe Mapping do
           let(:mapping) { dist_ontology.mappings.first }
 
           before do
-            parse_this(user, dist_ontology, hets_out_file('reference'))
+            parse_ontology(user, dist_ontology, 'dol/reference.dol')
           end
 
           it 'should have the mapping-source set correctly' do

--- a/spec/models/ontology_spec.rb
+++ b/spec/models/ontology_spec.rb
@@ -218,7 +218,7 @@ describe Ontology do
       let(:repository) { create :repository, user: user }
 
       before do
-        stub_hets_for(hets_out_file('partial_order'))
+        stub_hets_for('casl/partial_order.casl')
       end
 
       it 'should have logic DOL' do
@@ -242,7 +242,7 @@ describe Ontology do
     context 'the logically translated ontology' do
 
       before do
-        stub_hets_for(hets_out_file('double_mapped_logic_translated_blendoid'))
+        stub_hets_for('dol/double_mapped_logic_translated_blendoid.dol')
       end
       it 'should contain imported sentences' do
         expect(ontology.imported_sentences).to_not be_empty

--- a/spec/models/ontology_spec.rb
+++ b/spec/models/ontology_spec.rb
@@ -313,7 +313,7 @@ describe Ontology do
     let(:ontology) { create :single_ontology }
 
     before do
-      parse_this(user, ontology, hets_out_file('test1'))
+      parse_ontology(user, ontology, 'casl/test1.casl')
     end
 
     it 'should save the logic' do
@@ -366,7 +366,7 @@ describe Ontology do
     let(:ontology) { create :distributed_ontology }
 
     before do
-      parse_this(user, ontology, hets_out_file('test2'))
+      parse_ontology(user, ontology, 'casl/test2.casl')
     end
 
     it 'should create all single ontologies' do
@@ -421,7 +421,7 @@ describe Ontology do
     let(:combined) { ontology.children.where(name: 'VAlignedOntology').first }
 
     before do
-      parse_this(user, ontology, hets_out_file('align'))
+      parse_ontology(user, ontology, 'dol/align.dol')
     end
 
     it 'should create single ontologies' do
@@ -455,18 +455,18 @@ describe Ontology do
     end
 
     it 'should propagate the error' do
-      expect { parse_this(user, ontology, hets_out_file('test1')) }.
+      expect { parse_ontology(user, ontology, 'casl/test1.casl') }.
         to raise_error(Exception, error_text)
     end
 
     it 'should be possible to parse it again (no AlreadyProcessingError)' do
       begin
-        parse_this(user, ontology, hets_out_file('test1'))
+        parse_ontology(user, ontology, 'casl/test1.casl')
       rescue Exception => e
         allow_any_instance_of(Hets::DG::NodeEvaluator).
           to receive(:ontology_end).and_call_original
 
-        expect { parse_this(user, ontology, hets_out_file('test1')) }.
+        expect { parse_ontology(user, ontology, 'casl/test1.casl') }.
           not_to raise_error
       end
     end
@@ -480,7 +480,7 @@ describe Ontology do
     end
 
     before do
-      parse_this(user, ontology, hets_out_file('partial_order'))
+      parse_ontology(user, ontology, 'casl/partial_order.casl')
     end
 
     context 'theorem count' do
@@ -504,7 +504,7 @@ describe Ontology do
     end
 
     before do
-      parse_this(user, ontology, hets_out_file('CompetencyQuestion'))
+      parse_ontology(user, ontology, 'dol/CompetencyQuestion.dol')
     end
 
     context 'theorems count' do

--- a/spec/models/ontology_version/proving_spec.rb
+++ b/spec/models/ontology_version/proving_spec.rb
@@ -7,7 +7,8 @@ describe 'OntologyVersion - Proving' do
 
   before do
     parse_ontology(user, parent_ontology, 'prove/Simple_Implications.casl')
-    stub_hets_for(prove_out_file('Simple_Implications'), command: 'prove', method: :post)
+    stub_hets_for('prove/Simple_Implications.casl',
+                  command: 'prove', method: :post)
   end
 
   let(:ontology) { parent_ontology.children.find_by_name('Group') }

--- a/spec/models/ontology_version/proving_spec.rb
+++ b/spec/models/ontology_version/proving_spec.rb
@@ -6,7 +6,7 @@ describe 'OntologyVersion - Proving' do
   let(:parent_ontology) { create :distributed_ontology }
 
   before do
-    parse_this(user, parent_ontology, hets_out_file('Simple_Implications'))
+    parse_ontology(user, parent_ontology, 'prove/Simple_Implications.casl')
     stub_hets_for(prove_out_file('Simple_Implications'), command: 'prove', method: :post)
   end
 

--- a/spec/models/ontology_version_spec.rb
+++ b/spec/models/ontology_version_spec.rb
@@ -31,7 +31,7 @@ describe OntologyVersion do
     before do
       # Clear Jobs
       Worker.jobs.clear
-      stub_hets_for(hets_out_file('pizza'))
+      stub_hets_for('owl/pizza.owl')
     end
 
     context 'in subdirectory' do

--- a/spec/models/repository/git_mv_spec.rb
+++ b/spec/models/repository/git_mv_spec.rb
@@ -17,9 +17,9 @@ describe 'git mv', :process_jobs_synchronously do
   end
 
   before do
-    stub_hets_for(hets_out_file('Px'), with: 'Px')
-    stub_hets_for(hets_out_file('Qy'), with: 'Qy')
-    stub_hets_for(hets_out_file('Rz'), with: 'Rz')
+    stub_hets_for('clif/Px.clif', with: 'Px')
+    stub_hets_for('clif/Qy.clif', with: 'Qy')
+    stub_hets_for('clif/Rz.clif', with: 'Rz')
   end
 
   after do

--- a/spec/models/repository/git_spec.rb
+++ b/spec/models/repository/git_spec.rb
@@ -8,9 +8,9 @@ describe Repository do
   context 'when ontohub clones a remote repository' do
 
     before do
-      stub_hets_for(hets_out_file('cat1'), with: 'cat', with_version: 1)
-      stub_hets_for(hets_out_file('cat2'), with: 'cat', with_version: 2)
-      stub_hets_for(hets_out_file('Px'), with: 'Px')
+      stub_hets_for('clif/cat1.clif', with: 'cat', with_version: 1)
+      stub_hets_for('clif/cat2.clif', with: 'cat', with_version: 2)
+      stub_hets_for('clif/Px.clif', with: 'Px')
     end
 
     it 'should create a bulk job on a queue' do

--- a/spec/models/sentence_spec.rb
+++ b/spec/models/sentence_spec.rb
@@ -63,9 +63,7 @@ describe Sentence do
       let(:sentence) { ontology.sentences.first }
 
 
-      before do
-        parse_this(user, ontology, hets_out_file('generations'))
-      end
+      before { parse_ontology(user, ontology, 'owl/generations.owl') }
 
       it 'should have display_text set' do
         expect(sentence.display_text).to_not be_nil

--- a/spec/models/symbol_mapping_spec.rb
+++ b/spec/models/symbol_mapping_spec.rb
@@ -8,7 +8,7 @@ describe SymbolMapping do
     let(:dist_ontology) { version.ontology }
 
     before do
-      stub_hets_for(hets_out_file('simple_mapping'))
+      stub_hets_for('dol/simple_mapping.dol')
     end
 
     context 'which has mapped symbols' do

--- a/spec/models/symbol_spec.rb
+++ b/spec/models/symbol_spec.rb
@@ -32,7 +32,7 @@ describe OntologyMember::Symbol do
     let(:ontology) { create :ontology }
     let(:user) { create :user }
 
-    before { parse_this(user, ontology, hets_out_file('pizza')) }
+    before { parse_ontology(user, ontology, 'owl/pizza.owl') }
 
     it 'should have the correct number of described symbols' do
       labeled_symbols = ontology.symbols.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,14 +54,6 @@ def ontology_file(path, ext=nil)
   fixture_file("ontologies/#{portion}")
 end
 
-def hets_out_file(name, ext='xml')
-  ontology_file("hets-out/#{name}.#{ext}")
-end
-
-def prove_out_file(name, ext='proof.json')
-  fixture_file("ontologies/hets-out/prove/#{name}.#{ext}")
-end
-
 def add_fixture_file(repository, relative_file)
   path = ontology_file(relative_file)
   version_for_file(repository, path)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ include SharedHelper
 use_simplecov
 
 require File.expand_path("../../config/environment", __FILE__)
+require File.expand_path("../hets_helper", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'
 require Rails.root.join('config', 'database_cleaner.rb')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -111,13 +111,6 @@ end
 # includes the convenience-method `define_ontology('name')`
 include OntologyUnited::Convenience
 
-def parse_this(user, ontology, fixture_file)
-  file = File.open(fixture_file)
-  evaluator = Hets::DG::Evaluator.new(user, ontology, io: file)
-  evaluator.import
-  file.close unless file.closed?
-end
-
 # Recording HTTP Requests
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/fixtures/vcr'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,37 +62,6 @@ def prove_out_file(name, ext='proof.json')
   fixture_file("ontologies/hets-out/prove/#{name}.#{ext}")
 end
 
-def hets_uri(command = 'dg', portion = nil, version = nil)
-  hets_instance = HetsInstance.choose!
-rescue HetsInstance::NoRegisteredHetsInstanceError => e
-  if hets_instance.nil?
-    FactoryGirl.create(:local_hets_instance)
-    hets_instance = HetsInstance.choose!
-  end
-ensure
-  specific = ''
-  # %2F is percent-encoding for forward slash /
-  specific << "ref%2F#{version}.*" if version
-  specific << "#{portion}.*" if portion
-  return %r{#{hets_instance.uri}/#{command}/.*#{specific}}
-end
-
-def stub_hets_for(fixture_file, command: 'dg', with: nil, with_version: nil, method: :get)
-  stub_request(:get, 'http://localhost:8000/version').
-    to_return(body: Hets.minimal_version_string)
-  stub_request(method, hets_uri(command, with, with_version)).
-    to_return(body: fixture_file.read)
-end
-
-def setup_hets
-  let(:hets_instance) { create(:local_hets_instance) }
-  before do
-    stub_request(:get, 'http://localhost:8000/version').
-      to_return(body: Hets.minimal_version_string)
-    hets_instance
-  end
-end
-
 def add_fixture_file(repository, relative_file)
   path = ontology_file(relative_file)
   version_for_file(repository, path)


### PR DESCRIPTION
This shall fix #1250.

If no hets server is running, it is started and the fixture files (VCR cassettes) are created. Those fixtures are then used in the specs.

This pull request is based on the branch of #1260 (**1257-introduce_axiom_model**) instead of **staging**. It might be easier to review that one first.