### PR TITLE
Introduce hets options

### DIFF
--- a/app/models/ontology_version/parsing.rb
+++ b/app/models/ontology_version/parsing.rb
@@ -43,7 +43,9 @@ module OntologyVersion::Parsing
 
   # generate XML by passing the raw ontology to Hets
   def generate_xml(structure_only: false)
-    input_io = Hets.parse_via_api(ontology, ontology.repository.url_maps,
+    hets_options =
+      Hets::HetsOptions.new(:'url-catalog' => ontology.repository.url_maps)
+    input_io = Hets.parse_via_api(ontology, hets_options,
                                   structure_only: structure_only)
     [:all_is_well, input_io]
   rescue Hets::ExecutionError => e

--- a/app/models/ontology_version/proving.rb
+++ b/app/models/ontology_version/proving.rb
@@ -28,7 +28,10 @@ module OntologyVersion::Proving
 
   # generate XML by passing the raw ontology to Hets
   def execute_proof
-    input_io = Hets.prove_via_api(ontology, ontology.repository.url_maps)
+    hets_options =
+      Hets::ProveOptions.new(:'url-catalog' => ontology.repository.url_maps,
+                             ontology: ontology)
+    input_io = Hets.prove_via_api(ontology, hets_options)
     [:all_is_well, input_io]
   rescue Hets::ExecutionError => e
     handle_hets_execution_error(e, self)

--- a/lib/hets.rb
+++ b/lib/hets.rb
@@ -121,11 +121,9 @@ we expected it to be matchable by this regular expression:
     parse_caller.call(qualified_loc_id_for(resource), with_mode: mode)
   end
 
-  def self.prove_via_api(resource, url_catalog = [])
-    options = {}
-    options[:node] = resource.name if resource.in_distributed?
-    prove_caller = Hets::ProveCaller.new(HetsInstance.choose!, url_catalog)
-    prove_caller.call(resource.versioned_iri, options)
+  def self.prove_via_api(resource, prove_options)
+    prove_caller = Hets::ProveCaller.new(HetsInstance.choose!, prove_options)
+    prove_caller.call(resource.versioned_iri)
   end
 
   def self.filetype(resource)

--- a/lib/hets.rb
+++ b/lib/hets.rb
@@ -115,11 +115,9 @@ we expected it to be matchable by this regular expression:
     "http://#{Settings.hostname}#{locid}"
   end
 
-  def self.parse_via_api(resource, url_catalog = [], structure_only: false)
+  def self.parse_via_api(resource, hets_options, structure_only: false)
     mode = structure_only ? :fast_run : :default
-
-    parse_caller = Hets::ParseCaller.new(HetsInstance.choose!, url_catalog)
-
+    parse_caller = Hets::ParseCaller.new(HetsInstance.choose!, hets_options)
     parse_caller.call(qualified_loc_id_for(resource), with_mode: mode)
   end
 

--- a/lib/hets/action_caller.rb
+++ b/lib/hets/action_caller.rb
@@ -1,18 +1,16 @@
 module Hets
   class ActionCaller < Caller
-    attr_accessor :url_catalog
+    attr_accessor :hets_options
 
-    def initialize(hets_instance, url_catalog = [])
-      self.url_catalog = url_catalog
+    def initialize(hets_instance, hets_options)
+      self.hets_options = hets_options
       msg = "<#{hets_instance}> not up."
       raise Hets::InactiveInstanceError, msg unless hets_instance.try(:up?)
       super(hets_instance)
     end
 
     def build_query_string
-      query_hash = {}
-      query_hash[:"url-catalog"] = url_catalog.join(',') if url_catalog.present?
-      query_hash
+      hets_options.options
     end
 
     def handle_possible_hets_error(error)

--- a/lib/hets/caller.rb
+++ b/lib/hets/caller.rb
@@ -18,7 +18,11 @@ module Hets
       query_part =
         if query_string && !query_string.empty?
           query_string.reduce('?') do |str, (key, val)|
-            str << "#{key}=#{val};"
+            if val.is_a?(Array)
+              str << "#{key}=#{val.join(',')};"
+            else
+              str << "#{key}=#{val};"
+            end
           end
         end
       api_uri = hierarchy + query_part.to_s

--- a/lib/hets/hets_options.rb
+++ b/lib/hets/hets_options.rb
@@ -1,0 +1,38 @@
+module Hets
+  class HetsOptions
+    attr_reader :options
+
+    def self.from_hash(hash)
+      new(hash['options'])
+    end
+
+    def initialize(opts = {})
+      @options = opts.dup
+      prepare
+    end
+
+    def add(**opts)
+      @options.merge!(opts.dup)
+      prepare
+    end
+
+    protected
+
+    def prepare
+      remove_nil_fields
+      prepare_url_catalog
+    end
+
+    def remove_nil_fields
+      nil_valued_keys = @options.keys.select { |key| @options[key].nil? }
+      nil_valued_keys.each { |key| @options.delete(key) }
+    end
+
+    def prepare_url_catalog
+      @options[:'url-catalog'].try(:compact!)
+      if @options[:'url-catalog'].blank?
+        @options.delete(:'url-catalog')
+      end
+    end
+  end
+end

--- a/lib/hets/prove_caller.rb
+++ b/lib/hets/prove_caller.rb
@@ -6,13 +6,17 @@ module Hets
 
     PROVE_OPTIONS = {format: 'json', include: 'true'}
 
-    def call(iri, options = {})
+    def call(iri)
       escaped_iri = Rack::Utils.escape_path(iri)
       arguments = [escaped_iri, *COMMAND_LIST]
       api_uri = build_api_uri(CMD, arguments, build_query_string)
-      perform(api_uri, PROVE_OPTIONS.merge(options), METHOD)
+      perform(api_uri, PROVE_OPTIONS.merge(hets_options.options), METHOD)
     rescue UnfollowableResponseError => error
       handle_possible_hets_error(error)
+    end
+
+    def build_query_string
+      {}
     end
   end
 end

--- a/lib/hets/prove_options.rb
+++ b/lib/hets/prove_options.rb
@@ -1,0 +1,38 @@
+module Hets
+  class ProveOptions < HetsOptions
+    protected
+
+    def prepare
+      super
+      prepare_node
+      prepare_axioms
+      prepare_theorems
+    end
+
+    def prepare_node
+      ontology = @options[:ontology]
+      if ontology.is_a?(Ontology)
+        @options[:node] = ontology.name if ontology.in_distributed?
+        @options.delete(:ontology)
+      end
+    end
+
+    def prepare_axioms
+      prepare_sentences(:axioms)
+    end
+
+    def prepare_theorems
+      prepare_sentences(:theorems)
+    end
+
+    def prepare_sentences(field)
+      if @options[field].is_a?(Array)
+        @options[field].map! do |sentence|
+          if sentence.is_a?(Sentence)
+            sentence.name
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/hets/hets_options_spec.rb
+++ b/spec/lib/hets/hets_options_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+describe Hets::HetsOptions do
+  let(:options) { {key1: 'value1', key2: 'value2'} }
+
+  context 'initialize' do
+    it 'sets options' do
+      expect(Hets::HetsOptions.new(options).options).to eq(options)
+    end
+
+    it 'removes nil valued options' do
+      options_new = {**options, key3: nil}
+      expect(Hets::HetsOptions.new(options_new).options).to eq(options)
+    end
+  end
+
+  context 'from_hash' do
+    it 'sets options' do
+      hash = {'options' => options}
+      expect(Hets::HetsOptions.from_hash(hash).options).to eq(options)
+    end
+
+    it 'removes nil valued options' do
+      options_new = {**options, key3: nil}
+      hash = {'options' => options_new}
+      expect(Hets::HetsOptions.from_hash(hash).options).to eq(options)
+    end
+  end
+
+  context 'add' do
+    let(:hets_options) { Hets::HetsOptions.new(options) }
+    let(:additional_options) { {key3: 'value3', key4: 'value4'} }
+
+    it 'adds options' do
+      hets_options.add(additional_options)
+      expect(hets_options.options).to eq(options.merge(additional_options))
+    end
+
+    it 'removes nil valued options' do
+      additional_options_new = {**additional_options, key5: nil}
+      hets_options.add(additional_options_new)
+      expect(hets_options.options).to eq(options.merge(additional_options))
+    end
+  end
+
+  context 'url-catalog' do
+    context 'empty' do
+      let(:catalog_options) { {**options, :'url-catalog' => %w()} }
+      let(:hets_options) { Hets::HetsOptions.new(catalog_options) }
+
+      it "removes the key :'url-catalog'" do
+        expect(hets_options.options.has_key?(:'url-catalog')).to be(false)
+      end
+    end
+
+    context 'only with nil values' do
+      let(:catalog_options) { {**options, :'url-catalog' => [nil, nil]} }
+      let(:hets_options) { Hets::HetsOptions.new(catalog_options) }
+
+      it "removes the key :'url-catalog'" do
+        expect(hets_options.options.has_key?(:'url-catalog')).to be(false)
+      end
+    end
+
+    context 'with a nil value' do
+      let(:catalog_options) do
+        {**options, :'url-catalog' => ['a=b', nil, 'c=d']}
+      end
+      let(:hets_options) { Hets::HetsOptions.new(catalog_options) }
+
+      it "removes the nil value from  :'url-catalog'" do
+        expect(hets_options.options[:'url-catalog']).to eq(%w(a=b c=d))
+      end
+    end
+
+    context 'without nil values' do
+      let(:catalog_options) { {**options, :'url-catalog' => %w(a=b c=d)} }
+      let(:hets_options) { Hets::HetsOptions.new(catalog_options) }
+
+      it "has the same :'url-catalog'" do
+        expect(hets_options.options[:'url-catalog']).to eq(%w(a=b c=d))
+      end
+    end
+  end
+end

--- a/spec/lib/hets/prove_options_spec.rb
+++ b/spec/lib/hets/prove_options_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe Hets::ProveOptions do
+  let(:theorem) { create :theorem }
+  let(:ontology) { theorem.ontology }
+  let(:axiom) { create :axiom, ontology: ontology }
+  let(:parent_ontology) { ontology.parent }
+
+  context 'with strings' do
+    let(:options) { {node: ontology.name,
+                     axioms: [axiom.name],
+                     theorems: [theorem.name]} }
+    let(:prove_options) { Hets::ProveOptions.new(options) }
+
+    it 'does not change the options' do
+      expect(prove_options.options).to eq(options)
+    end
+  end
+
+  context 'with general objects' do
+    let(:options) { {ontology: ontology,
+                     axioms: [axiom],
+                     theorems: [theorem]} }
+    let!(:axiom_names) { options[:axioms].map(&:name) }
+    let!(:theorem_names) { options[:theorems].map(&:name) }
+    let(:prove_options) { Hets::ProveOptions.new(options) }
+
+    it "removes the key 'ontology'" do
+      expect(prove_options.options.has_key?(:ontology)).to be(false)
+    end
+
+    it 'sets :node to the ontology name' do
+      expect(prove_options.options[:node]).to eq(ontology.name)
+    end
+
+    it 'sets :axioms to the axioms names' do
+      expect(prove_options.options[:axioms]).to eq(axiom_names)
+    end
+
+    it 'sets :theorems to the theorems names' do
+      expect(prove_options.options[:theorems]).to eq(theorem_names)
+    end
+  end
+
+  context 'using the parent ontology' do
+    let(:options) { {ontology: parent_ontology} }
+    let(:prove_options) { Hets::ProveOptions.new(options) }
+
+    it 'it does not set :node' do
+      expect(prove_options.options.has_key?(:node)).to be(false)
+    end
+
+    it "removes the key 'ontology'" do
+      expect(prove_options.options.has_key?(:ontology)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
This branch introduces `HetsOptions` and `ProveOptions` which allows to easily pass a whole bunch of options to the `ActionCaller`/the Hets API. In #1136, there is already something with this purpose, but it will be replaced by this implementation because this one is tailored to be used with the `ActionCaller` and the Hets API instead of the Hets command line interface.

This pull request is based on the branch of #1261 (**1250-use_hets_api_and_vcr_for_the_tests**) instead of **staging**. It might be easier to review that one first.