### PR TITLE
1237 let the user select a prover

### DIFF
--- a/app/controllers/proofs_controller.rb
+++ b/app/controllers/proofs_controller.rb
@@ -4,11 +4,6 @@ class ProofsController < InheritedResources::Base
   helper_method :ontology
 
   def new
-    resource
-    render template: 'proofs/new'
-  end
-
-  def new
     render template: 'proofs/new'
   end
 

--- a/app/controllers/proofs_controller.rb
+++ b/app/controllers/proofs_controller.rb
@@ -8,6 +8,10 @@ class ProofsController < InheritedResources::Base
     render template: 'proofs/new'
   end
 
+  def new
+    render template: 'proofs/new'
+  end
+
   def create
     if resource.valid?
       resource.save!

--- a/app/controllers/proofs_controller.rb
+++ b/app/controllers/proofs_controller.rb
@@ -1,4 +1,4 @@
-class ProveController < ApplicationController
+class ProofsController < ApplicationController
   before_filter :check_write_permissions
 
   def create

--- a/app/helpers/proofs_helper.rb
+++ b/app/helpers/proofs_helper.rb
@@ -1,0 +1,11 @@
+module ProofsHelper
+  def form_url_chain
+    chain = resource_chain
+    chain << resource.proof_obligation if resource.theorem?
+    chain << :proofs
+  end
+
+  def klass
+    t("proofs.new.klass.#{resource.proof_obligation.class.to_s.underscore}")
+  end
+end

--- a/app/models/ontology.rb
+++ b/app/models/ontology.rb
@@ -29,7 +29,6 @@ class Ontology < ActiveRecord::Base
   class Ontology::DeleteError < StandardError; end
 
   delegate :permission?, to: :repository
-  delegate :unproven_theorems, to: :current_version
 
   strip_attributes :only => [:name, :iri]
 

--- a/app/models/ontology_version.rb
+++ b/app/models/ontology_version.rb
@@ -41,6 +41,10 @@ class OntologyVersion < ActiveRecord::Base
     self.number
   end
 
+  def to_s
+    "#{ontology.name} (version #{number})"
+  end
+
   # Public URL to this version
   #
   # TODO: This returns a path without the commit id and filename for now,

--- a/app/models/ontology_version.rb
+++ b/app/models/ontology_version.rb
@@ -17,6 +17,8 @@ class OntologyVersion < ActiveRecord::Base
   belongs_to :user
   belongs_to :ontology, :counter_cache => :versions_count
   belongs_to :commit
+
+  # Provers that can be used for proving goals in this ontology.
   has_and_belongs_to_many :provers
 
 # before_validation :set_checksum

--- a/app/models/ontology_version.rb
+++ b/app/models/ontology_version.rb
@@ -17,6 +17,7 @@ class OntologyVersion < ActiveRecord::Base
   belongs_to :user
   belongs_to :ontology, :counter_cache => :versions_count
   belongs_to :commit
+  has_and_belongs_to_many :provers
 
 # before_validation :set_checksum
 # validate :raw_file_size_maximum

--- a/app/models/ontology_version/proving.rb
+++ b/app/models/ontology_version/proving.rb
@@ -6,15 +6,15 @@ module OntologyVersion::Proving
     @queue = 'hets'
   end
 
-  def async_prove(*_args)
-    async :prove
+  def async_prove(prove_options = nil)
+    async :prove, prove_options
   end
 
-  def prove
+  def prove(prove_options = nil)
     update_state! :processing
 
     do_or_set_failed do
-      cmd, input_io = execute_proof
+      cmd, input_io = execute_proof(prepared_prove_options(prove_options))
       return if cmd == :abort
 
       ontology.import_proof(self, user, input_io)
@@ -26,12 +26,21 @@ module OntologyVersion::Proving
     ontology.theorems.where(proof_status_id: Theorem::DEFAULT_STATUS)
   end
 
+  def prepared_prove_options(prove_options = nil)
+    prove_options ||= Hets::ProveOptions.new
+    # If the prove_options have gone through the async_prove call, they are now
+    # a Hash and need to be restored as a ProveOptions object.
+    if prove_options.is_a?(Hash)
+      prove_options = Hets::ProveOptions.from_hash(prove_options)
+    end
+    prove_options.add(:'url-catalog' => ontology.repository.url_maps,
+                      ontology: ontology)
+    prove_options
+  end
+
   # generate XML by passing the raw ontology to Hets
-  def execute_proof
-    hets_options =
-      Hets::ProveOptions.new(:'url-catalog' => ontology.repository.url_maps,
-                             ontology: ontology)
-    input_io = Hets.prove_via_api(ontology, hets_options)
+  def execute_proof(prove_options)
+    input_io = Hets.prove_via_api(ontology, prove_options)
     [:all_is_well, input_io]
   rescue Hets::ExecutionError => e
     handle_hets_execution_error(e, self)

--- a/app/models/ontology_version/proving.rb
+++ b/app/models/ontology_version/proving.rb
@@ -22,10 +22,6 @@ module OntologyVersion::Proving
     end
   end
 
-  def unproven_theorems
-    ontology.theorems.where(proof_status_id: Theorem::DEFAULT_STATUS)
-  end
-
   def prepared_prove_options(prove_options = nil)
     prove_options ||= Hets::ProveOptions.new
     # If the prove_options have gone through the async_prove call, they are now

--- a/app/models/proof_attempt.rb
+++ b/app/models/proof_attempt.rb
@@ -5,6 +5,7 @@ class ProofAttempt < ActiveRecord::Base
 
   belongs_to :theorem, foreign_key: 'sentence_id'
   belongs_to :proof_status
+  belongs_to :prover
   has_many :generated_axioms, dependent: :destroy
   has_and_belongs_to_many :used_axioms,
                           class_name: 'Axiom',
@@ -15,7 +16,10 @@ class ProofAttempt < ActiveRecord::Base
                           association_foreign_key: 'sentence_id',
                           join_table: 'used_axioms_proof_attempts'
 
-  attr_accessible :prover, :prover_output, :tactic_script, :time_taken, :number
+  attr_accessible :prover_output,
+                  :tactic_script,
+                  :time_taken,
+                  :number
 
   validates :theorem, presence: true
 
@@ -33,5 +37,13 @@ class ProofAttempt < ActiveRecord::Base
 
   def update_theorem_status
     theorem.update_proof_status(proof_status)
+  end
+
+  def associate_prover_with_ontology_version
+    ontology_version = theorem.ontology.current_version
+    unless ontology_version.provers.include?(prover)
+      ontology_version.provers << prover
+      ontology_version.save!
+    end
   end
 end

--- a/app/models/proof_attempt.rb
+++ b/app/models/proof_attempt.rb
@@ -7,7 +7,8 @@ class ProofAttempt < ActiveRecord::Base
   belongs_to :proof_status
   has_many :generated_axioms, dependent: :destroy
   has_and_belongs_to_many :used_axioms,
-                          class_name: 'Sentence',
+                          class_name: 'Axiom',
+                          association_foreign_key: 'sentence_id',
                           join_table: 'used_axioms_proof_attempts'
   has_and_belongs_to_many :used_theorems,
                           class_name: 'Theorem',

--- a/app/models/prover.rb
+++ b/app/models/prover.rb
@@ -1,0 +1,7 @@
+class Prover < ActiveRecord::Base
+  attr_accessible :name
+
+  def to_s
+    name
+  end
+end

--- a/app/views/proofs/_form.html.haml
+++ b/app/views/proofs/_form.html.haml
@@ -1,0 +1,3 @@
+= simple_form_for resource, url: form_url_chain do |f|
+  = f.input :provers, collection: ontology.current_version.provers, as: :check_boxes, hint: t('proofs.new.provers.none_is_default')
+  = f.button :submit, t('proofs.new.send'), class: 'btn btn-primary'

--- a/app/views/proofs/new.html.haml
+++ b/app/views/proofs/new.html.haml
@@ -1,0 +1,2 @@
+%h1= @page_title = t('proofs.new.title', klass: klass, resource: resource)
+= render partial: 'form'

--- a/app/views/theorems/index.html.haml
+++ b/app/views/theorems/index.html.haml
@@ -4,7 +4,7 @@
 
 - if can? :write, parent.repository
   - if ontology.unproven_theorems.present?
-    = link_to t('theorems.index.prove'), [*resource_chain, :prove], method: :post, class: 'btn btn-primary'
+    = link_to t('theorems.index.prove'), [*resource_chain, :proofs], method: :post, class: 'btn btn-primary'
   - else
     = t('theorems.index.all_proven', oms: Settings.OMS)
 

--- a/app/views/theorems/index.html.haml
+++ b/app/views/theorems/index.html.haml
@@ -4,7 +4,7 @@
 
 - if can? :write, parent.repository
   - if ontology.unproven_theorems.present?
-    = link_to t('theorems.index.prove'), [*resource_chain, :proofs], method: :post, class: 'btn btn-primary'
+    = link_to t('theorems.index.prove'), [*resource_chain, :proofs, :new], class: 'btn btn-primary'
   - else
     = t('theorems.index.all_proven', oms: Settings.OMS)
 

--- a/app/views/theorems/index.html.haml
+++ b/app/views/theorems/index.html.haml
@@ -3,10 +3,7 @@
 = ontology_nav @ontology, :theorems
 
 - if can? :write, parent.repository
-  - if ontology.unproven_theorems.present?
-    = link_to t('theorems.index.prove'), [*resource_chain, :proofs, :new], class: 'btn btn-primary'
-  - else
-    = t('theorems.index.all_proven', oms: Settings.OMS)
+  = link_to t('theorems.index.prove'), [*resource_chain, :proofs, :new], class: 'btn btn-primary'
 
 = pagination do
   %table.sentences

--- a/app/views/theorems/show.html.haml
+++ b/app/views/theorems/show.html.haml
@@ -7,6 +7,7 @@
   = render partial: 'proof_status', locals: {proof_status: resource.proof_status}
 
 %h4 Proof Attempts
+= link_to t('theorems.show.prove'), [*resource_chain, resource, :proofs, :new], class: 'btn btn-primary'
 - if resource.proof_attempts.empty?
   = t('theorems.show.proof_attemps_empty')
 - else

--- a/config/hets.yml
+++ b/config/hets.yml
@@ -27,7 +27,7 @@ hets_owl_tools:
   - /Applications/Hets.app/Contents/Resources/hets-owl-tools
 
 version_minimum_version: 0.99
-version_minimum_revision: 1418137071
+version_minimum_revision: 1425547964
 
 stack_size: 1G
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,7 +114,12 @@ en:
       all_proven: All theorems of this %{oms} have been proven.
     show:
       proof_attemps_empty: There are no proof attempts.
-  prove:
+  proofs:
+    new:
+      title: 'Attempt to prove %{resource}'
+      send: 'Prove'
+      provers:
+        none_is_default: Selecting none will result in using the default prover.
     create:
       starting_jobs: Proving jobs have been scheduled. Please come back in a few moments.
       nothing_to_do: All theorems have been proven.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,11 +112,15 @@ en:
     index:
       prove: Prove all theorems
     show:
+      prove: Prove this theorem
       proof_attemps_empty: There are no proof attempts.
   proofs:
     new:
-      title: 'Attempt to prove %{resource}'
+      title: 'Attempt to prove  %{klass} %{resource}'
       send: 'Prove'
+      klass:
+        theorem: 'theorem'
+        ontology_version: 'ontology'
       provers:
         none_is_default: Selecting none will result in using the default prover.
     create:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,7 +111,6 @@ en:
   theorems:
     index:
       prove: Prove all theorems
-      all_proven: All theorems of this %{oms} have been proven.
     show:
       proof_attemps_empty: There are no proof attempts.
   proofs:
@@ -122,7 +121,7 @@ en:
         none_is_default: Selecting none will result in using the default prover.
     create:
       starting_jobs: Proving jobs have been scheduled. Please come back in a few moments.
-      nothing_to_do: All theorems have been proven.
+      invalid_resource: Invalid proving request.
   proof_attempts:
     show:
       head: Proof Attempt of

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -251,7 +251,7 @@ Currently this will return the list of all symbols of the ontology.
           body: <<-BODY
 Will return a representation of the axiom. The axiom
 is determined according to the *locid.
-Currently this will return the list of all axiom of the ontology.
+Currently this will return the list of all axioms of the ontology.
       BODY
     end
 
@@ -267,7 +267,7 @@ Currently this will return the list of all axiom of the ontology.
           body: <<-BODY
 Will return a representation of the axiom. The axiom
 is determined according to the *locid.
-Currently this will return the list of all axiom of the ontology.
+Currently this will return the list of all axioms of the ontology.
       BODY
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -441,7 +441,7 @@ Will return a representation of the formality level.
       resources :theorems, only: %i(index show) do
         resources :proof_attempts, only: :show
       end
-      post '/prove', controller: :prove, action: :create
+      post '/proofs', controller: :proofs, action: :create
 
       resources :mappings do
         get 'update_version', :on => :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -251,7 +251,7 @@ Currently this will return the list of all symbols of the ontology.
           body: <<-BODY
 Will return a representation of the sentence. The sentence
 is determined according to the *locid.
-Currently this will return the list of all sentence of the ontology.
+Currently this will return the list of all sentences of the ontology.
       BODY
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -440,7 +440,10 @@ Will return a representation of the formality level.
       resources :axioms, only: %i(index show)
       resources :theorems, only: %i(index show) do
         resources :proof_attempts, only: :show
+        get '/proofs/new', controller: :proofs, action: :new
+        post '/proofs', controller: :proofs, action: :create
       end
+      get '/proofs/new', controller: :proofs, action: :new
       post '/proofs', controller: :proofs, action: :create
 
       resources :mappings do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,21 +88,6 @@ Currently the representation ist a list of all symbols in the ontology.
       BODY
     end
 
-  specified_get '/ref/mmt/:repository_id/*path' => 'api/v1/sentences#show',
-    as: :sentence_iri_mmt,
-    constraints: [
-      MMTRouterConstraint.new(Sentence, ontology: :ontology_id),
-    ] do
-      accept 'application/json'
-
-      doc title: 'MMT reference to a sentence',
-          body: <<-BODY
-Will return a representation of the sentence. The sentence
-is determined according to the *path and to the MMT-query-string.
-Currently the representation is a list of all sentences in the ontology.
-      BODY
-    end
-
   specified_get '/ref/mmt/:repository_id/*path' => 'axioms#index',
     as: :axiom_iri_mmt,
     constraints: [
@@ -131,6 +116,21 @@ Currently the representation is a list of all axioms in the ontology.
 Will return a representation of the theorem. The theorem
 is determined according to the *path and to the MMT-query-string.
 Currently the representation is a list of all theorems in the ontology.
+      BODY
+    end
+
+  specified_get '/ref/mmt/:repository_id/*path' => 'api/v1/sentences#show',
+    as: :sentence_iri_mmt,
+    constraints: [
+      MMTRouterConstraint.new(Sentence, ontology: :ontology_id),
+    ] do
+      accept 'application/json'
+
+      doc title: 'MMT reference to a sentence',
+          body: <<-BODY
+Will return a representation of the sentence. The sentence
+is determined according to the *path and to the MMT-query-string.
+Currently the representation is a list of all sentences in the ontology.
       BODY
     end
 
@@ -243,15 +243,15 @@ Currently this will return the list of all symbols of the ontology.
   specified_get '/:repository_id/*locid' => 'api/v1/sentences#show',
     as: :sentence_iri,
     constraints: [
-      LocIdRouterConstraint.new(Sentence, ontology: :ontology_id, element: :id),
+      LocIdRouterConstraint.new(Axiom, ontology: :ontology_id, element: :id),
     ] do
       accept 'application/json'
 
-      doc title: 'loc/id reference to a sentence',
+      doc title: 'loc/id reference to an axiom',
           body: <<-BODY
-Will return a representation of the sentence. The sentence
+Will return a representation of the axiom. The axiom
 is determined according to the *locid.
-Currently this will return the list of all sentences of the ontology.
+Currently this will return the list of all axiom of the ontology.
       BODY
     end
 
@@ -268,6 +268,37 @@ Currently this will return the list of all sentences of the ontology.
 Will return a representation of the axiom. The axiom
 is determined according to the *locid.
 Currently this will return the list of all axiom of the ontology.
+      BODY
+    end
+
+  specified_get '/:repository_id/*locid' => 'theorems#show',
+    as: :theorem_iri,
+    constraints: [
+      LocIdRouterConstraint.new(Theorem, ontology: :ontology_id, element: :id),
+    ] do
+      accept 'text/html'
+      reroute_on_mime 'application/json', to: 'api/v1/theorems#show'
+
+      doc title: 'loc/id reference to a theorem',
+          body: <<-BODY
+Will return a representation of the theorem. The theorem
+is determined according to the *locid.
+      BODY
+    end
+
+  specified_get '/:repository_id/*locid' => 'sentences#index',
+    as: :sentence_iri,
+    constraints: [
+      LocIdRouterConstraint.new(Sentence, ontology: :ontology_id, element: :id),
+    ] do
+      accept 'text/html'
+      reroute_on_mime 'application/json', to: 'api/v1/sentences#show'
+
+      doc title: 'loc/id reference to a sentence',
+          body: <<-BODY
+Will return a representation of the sentence. The sentence
+is determined according to the *locid.
+Currently this will return the list of all sentences of the ontology.
       BODY
     end
 
@@ -317,21 +348,6 @@ Will return a representation of the license model.
 Will return a representation of the formality level.
     BODY
   end
-
-  specified_get '/:repository_id/*locid' => 'theorems#show',
-    as: :mapping_iri,
-    constraints: [
-      LocIdRouterConstraint.new(Theorem, ontology: :ontology_id, element: :id),
-    ] do
-      accept 'text/html'
-      reroute_on_mime 'application/json', to: 'api/v1/theorems#show'
-
-      doc title: 'loc/id reference to a theorem',
-          body: <<-BODY
-Will return a representation of the theorem. The theorem
-is determined according to the *locid.
-      BODY
-    end
   #
   ###############
 

--- a/db/data/20150311194246_associate_provers_with_ontology_versions.rb
+++ b/db/data/20150311194246_associate_provers_with_ontology_versions.rb
@@ -1,0 +1,12 @@
+class AssociateProversWithOntologyVersions < ActiveRecord::Migration
+  def self.up
+    OntologyVersion.find_each(&:retrieve_available_provers)
+  end
+
+  def self.down
+    OntologyVersion.find_each do |ontology_version|
+      ontology_version.provers = []
+      ontology_version.save!
+    end
+  end
+end

--- a/db/data/20150313065037_use_prover_reference_in_proof_attempts.rb
+++ b/db/data/20150313065037_use_prover_reference_in_proof_attempts.rb
@@ -1,0 +1,9 @@
+class UseProverReferenceInProofAttempts < ActiveRecord::Migration
+  def self.up
+    prover = Prover.where(name: 'SPASS').first_or_create!
+    ProofAttempt.find_each do |proof_attempt|
+      proof_attempt.prover_id = prover.id
+      proof_attempt.save!
+    end
+  end
+end

--- a/db/migrate/20150311193056_create_provers.rb
+++ b/db/migrate/20150311193056_create_provers.rb
@@ -1,0 +1,11 @@
+class CreateProvers < ActiveRecord::Migration
+  def change
+    create_table :provers do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    add_index :provers, :name, unique: true
+  end
+end

--- a/db/migrate/20150311194246_associate_provers_with_ontology_versions.rb
+++ b/db/migrate/20150311194246_associate_provers_with_ontology_versions.rb
@@ -1,0 +1,8 @@
+class AssociateProversWithOntologyVersions < ActiveRecord::Migration
+  def change
+    create_table :ontology_versions_provers, id: false do |t|
+      t.references :ontology_version, null: false
+      t.references :prover, null: false
+    end
+  end
+end

--- a/db/migrate/20150313065037_use_prover_reference_in_proof_attempts.rb
+++ b/db/migrate/20150313065037_use_prover_reference_in_proof_attempts.rb
@@ -1,0 +1,11 @@
+class UseProverReferenceInProofAttempts < ActiveRecord::Migration
+  def up
+    remove_columns :proof_attempts, :prover
+    add_column :proof_attempts, :prover_id, :integer
+  end
+
+  def down
+    add_column :proof_attempts, :prover, :string
+    remove_column :proof_attempts, :prover_id
+  end
+end

--- a/lib/collective_proof_attempt.rb
+++ b/lib/collective_proof_attempt.rb
@@ -1,0 +1,48 @@
+class CollectiveProofAttempt
+  attr_accessor :resource, :provers, :prove_options_list
+
+  # Resource can be a Theorem or an OntologyVersion.
+  # We call prove for every possible options combination on the resource.
+  # The provers can be either Prover objects, IDs or names.
+  def initialize(resource, provers)
+    self.resource = resource
+    initialize_provers(provers)
+
+    self.prove_options_list = self.provers.map do |prover|
+      Hets::ProveOptions.new(prover: prover)
+    end
+  end
+
+  def run
+    ontology_version.update_state! :processing
+    ontology_version.do_or_set_failed do
+      prove_options_list.each { |opts| resource.prove(opts) }
+      ontology_version.update_state! :done
+    end
+  end
+
+  protected
+
+  def initialize_provers(provers)
+    self.provers = provers.map do |prover|
+      prover = prover.to_i if prover.is_a?(String) && prover.match(/\A\d+\z/)
+      if prover.is_a?(Fixnum)
+        Prover.find(prover)
+      else
+        prover
+      end
+    end
+    self.provers.compact!
+
+    self.provers = [nil] if self.provers.blank?
+  end
+
+  def ontology_version
+    @ontology_version ||=
+      if resource.is_a?(Theorem)
+        resource.ontology.current_version
+      else
+        resource
+      end
+  end
+end

--- a/lib/collective_proof_attempt_worker.rb
+++ b/lib/collective_proof_attempt_worker.rb
@@ -1,0 +1,15 @@
+class CollectiveProofAttemptWorker < BaseWorker
+  sidekiq_options queue: 'hets'
+
+  def self.perform_async(*args)
+    perform_async_on_queue('hets', *args)
+  end
+
+  # The resource is fetched from the database with klass and id, where
+  # klass can be 'Theorem' or 'OntologyVersion'.
+  # The provers can be either IDs or names.
+  def perform(klass, id, provers)
+    resource = klass.constantize.find(id)
+    CollectiveProofAttempt.new(resource, provers).run
+  end
+end

--- a/lib/hets.rb
+++ b/lib/hets.rb
@@ -123,7 +123,7 @@ we expected it to be matchable by this regular expression:
 
   def self.prove_via_api(resource, prove_options)
     prove_caller = Hets::ProveCaller.new(HetsInstance.choose!, prove_options)
-    prove_caller.call(resource.versioned_iri)
+    prove_caller.call(qualified_loc_id_for(resource))
   end
 
   def self.filetype(resource)

--- a/lib/hets.rb
+++ b/lib/hets.rb
@@ -126,6 +126,11 @@ we expected it to be matchable by this regular expression:
     prove_caller.call(qualified_loc_id_for(resource))
   end
 
+  def self.provers_via_api(resource, provers_options)
+    provers_caller = Hets::ProversCaller.new(HetsInstance.choose!, provers_options)
+    provers_caller.call(qualified_loc_id_for(resource))
+  end
+
   def self.filetype(resource)
     iri = qualified_loc_id_for(resource)
     filetype_caller = Hets::FiletypeCaller.new(HetsInstance.choose!)

--- a/lib/hets/prove/prove_evaluator.rb
+++ b/lib/hets/prove/prove_evaluator.rb
@@ -38,7 +38,7 @@ module Hets
           proof_attempt = ProofAttempt.new
           proof_attempt.theorem = find_theorem_with_hash(proof_info, ontology)
           proof_attempt.proof_status = find_proof_status_with_hash(proof_info)
-          proof_attempt.prover = proof_info[:used_prover]
+          proof_attempt.prover = find_or_create_prover_with_hash(proof_info)
           proof_attempt.prover_output = proof_info[:prover_output]
           proof_attempt.time_taken = proof_info[:time_taken]
           proof_attempt.tactic_script = tactic_script_from_hash(proof_info)
@@ -47,6 +47,8 @@ module Hets
           proof_attempt.used_axioms = used_axioms
           proof_attempt.used_theorems = used_theorems
           proof_attempt.generated_axioms = generated_axioms
+
+          proof_attempt.associate_prover_with_ontology_version
 
           proof_attempt.save!
         end
@@ -67,6 +69,10 @@ module Hets
             ProofStatus::DEFAULT_UNKNOWN_STATUS
           end
         ProofStatus.find(identifier)
+      end
+
+      def find_or_create_prover_with_hash(proof_info)
+        Prover.where(name: proof_info[:used_prover]).first_or_create!
       end
 
       def tactic_script_from_hash(proof_info)

--- a/lib/hets/prove_options.rb
+++ b/lib/hets/prove_options.rb
@@ -5,6 +5,7 @@ module Hets
     def prepare
       super
       prepare_node
+      prepare_prover
       prepare_axioms
       prepare_theorems
     end
@@ -14,6 +15,12 @@ module Hets
       if ontology.is_a?(Ontology)
         @options[:node] = ontology.name if ontology.in_distributed?
         @options.delete(:ontology)
+      end
+    end
+
+    def prepare_prover
+      if @options[:prover].is_a?(Prover)
+        @options[:prover] = @options[:prover].name
       end
     end
 

--- a/lib/hets/provers/evaluator.rb
+++ b/lib/hets/provers/evaluator.rb
@@ -1,0 +1,25 @@
+module Hets
+  module Provers
+    class Evaluator
+      attr_accessor :ontology_version, :io
+
+      # io needs to be an instance of IO or a Tempfile.
+      def initialize(ontology_version, io)
+        self.ontology_version = ontology_version
+        self.io = io
+      end
+
+      def import
+        hash = JSON.parse(io.read)
+        provers = hash['provers']
+        provers.each do |prover_name|
+          prover = Prover.where(name: prover_name).first_or_create!
+          unless ontology_version.provers.include?(prover)
+            ontology_version.provers << prover
+          end
+        end
+        ontology_version.save!
+      end
+    end
+  end
+end

--- a/lib/hets/provers_caller.rb
+++ b/lib/hets/provers_caller.rb
@@ -1,0 +1,18 @@
+module Hets
+  class ProversCaller < ActionCaller
+    CMD = 'provers'
+    METHOD = :get
+    COMMAND_LIST = %w(auto)
+
+    OPTIONS = {format: 'json'}
+
+    def call(iri)
+      escaped_iri = Rack::Utils.escape_path(iri)
+      arguments = [escaped_iri, *COMMAND_LIST]
+      api_uri = build_api_uri(CMD, arguments, OPTIONS.merge(build_query_string))
+      perform(api_uri, {}, METHOD)
+    rescue UnfollowableResponseError => error
+      handle_possible_hets_error(error)
+    end
+  end
+end

--- a/lib/hets/provers_options.rb
+++ b/lib/hets/provers_options.rb
@@ -1,0 +1,18 @@
+module Hets
+  class ProversOptions < HetsOptions
+    protected
+
+    def prepare
+      super
+      prepare_node
+    end
+
+    def prepare_node
+      ontology = @options[:ontology]
+      if ontology.is_a?(Ontology)
+        @options[:node] = ontology.name if ontology.in_distributed?
+        @options.delete(:ontology)
+      end
+    end
+  end
+end

--- a/lib/proof.rb
+++ b/lib/proof.rb
@@ -1,0 +1,55 @@
+class Proof < FakeRecord
+  class ProversValidator < ActiveModel::EachValidator
+    def validate_each(record, attribute, value)
+      not_provers = value.reject { |id| Prover.where(id: id).any? }
+      if not_provers.any?
+        record.errors.add attribute, "#{not_provers} are not provers"
+      end
+    end
+  end
+
+  attr_reader :proof_obligation, :provers, :ontology
+
+  validates :provers, provers: true
+
+  def initialize(opts)
+    opts[:proof] ||= {}
+    opts[:proof][:provers] ||= []
+
+    @ontology = Ontology.find(opts[:ontology_id])
+    # HACK: remove the empty string from params
+    # Rails 4.2 introduces the html form option :include_hidden
+    @provers = opts[:proof][:provers].select(&:present?).map(&:to_i)
+    @proof_obligation = proof_initialize_obligaion(opts)
+  end
+
+  def save!
+    ontology_version.update_state! :pending
+    CollectiveProofAttemptWorker.perform_async(proof_obligation.class.to_s,
+                                               proof_obligation.id,
+                                               provers)
+  end
+
+  def theorem?
+    proof_obligation.is_a?(Theorem)
+  end
+
+  def to_s
+    proof_obligation.to_s
+  end
+
+  protected
+
+  def proof_initialize_obligaion(opts)
+    @proof_obligation ||=
+      if opts[:theorem_id]
+        Theorem.find(opts[:theorem_id])
+      else
+        ontology_version
+      end
+  end
+
+  def ontology_version
+    @ontology_version ||= ontology.current_version
+  end
+end

--- a/lib/proof.rb
+++ b/lib/proof.rb
@@ -1,3 +1,7 @@
+# The Proof class is not supposed to be stored in the database. Its purpose is
+# to allow for an easy way to create proving commands in the RESTful manner.
+# It is called Proof to comply with the ProofsController which in turn gets
+# called on */proofs routes.
 class Proof < FakeRecord
   class ProversValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)

--- a/spec/controllers/proofs_controller_spec.rb
+++ b/spec/controllers/proofs_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ProveController do
+describe ProofsController do
   before { allow_any_instance_of(OntologyVersion).to receive(:async_prove) }
   let(:theorem) { create :theorem }
   let(:ontology) { theorem.ontology }

--- a/spec/factories/proof_attempt_factory.rb
+++ b/spec/factories/proof_attempt_factory.rb
@@ -1,11 +1,11 @@
 FactoryGirl.define do
   factory :proof_attempt do
-    prover { 'SPASS' }
     prover_output { 'SPASS Output' }
     tactic_script { 'SPASS Tactic Script' }
     time_taken { rand(5) }
 
     association :proof_status, factory: :proof_status_proven
     association :theorem
+    association :prover
   end
 end

--- a/spec/factories/prover_factory.rb
+++ b/spec/factories/prover_factory.rb
@@ -1,5 +1,15 @@
 FactoryGirl.define do
+  sequence :prover_name do |n|
+    "prover-#{n}"
+  end
+
   factory :prover do
     name { 'SPASS' }
+
+    trait :with_sequenced_name do
+      after(:build) do |prover|
+        prover.name = generate :prover_name
+      end
+    end
   end
 end

--- a/spec/factories/prover_factory.rb
+++ b/spec/factories/prover_factory.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :prover do
+    name { 'SPASS' }
+  end
+end

--- a/spec/hets_helper.rb
+++ b/spec/hets_helper.rb
@@ -68,6 +68,10 @@ def stub_hets_for(ontology_fixture,
     to_return(body: Hets.minimal_version_string)
   stub_request(method, hets_uri(command, with, with_version)).
     to_return(body: hets_out_body(command, ontology_fixture))
+  if command == 'dg'
+    stub_request(method, hets_uri('provers', with, with_version)).
+      to_return(body: hets_out_body('provers', ontology_fixture))
+  end
 end
 
 def hets_uri(command = 'dg', portion = nil, version = nil)

--- a/spec/lib/collective_proof_attempt_spec.rb
+++ b/spec/lib/collective_proof_attempt_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe CollectiveProofAttempt do
+  let(:theorem) { create :theorem }
+  let(:ontology) { theorem.ontology }
+  let(:prover1) { create :prover, :with_sequenced_name }
+  let(:prover2) { create :prover, :with_sequenced_name }
+
+  context 'no provers' do
+    let(:cpa) { CollectiveProofAttempt.new(theorem, []) }
+
+    it 'have a prove_options_list with one entry' do
+      expect(cpa.prove_options_list.size).to eq(1)
+    end
+
+    it 'have a prove_options_list element with no specified prover' do
+      expect(cpa.prove_options_list.first.options.has_key?(:prover)).
+        to be(false)
+    end
+  end
+
+  context 'two provers passed as IDs' do
+    let(:cpa) do
+      CollectiveProofAttempt.new(theorem, [prover1.to_param, prover2.to_param])
+    end
+
+    it 'have the two provers' do
+      provers = cpa.prove_options_list.map do |prove_options|
+        prove_options.options[:prover]
+      end
+      # We use .name because ProveOptions already converts it
+      expect(provers).to eq([prover1.name, prover2.name])
+    end
+  end
+
+  context 'two provers passed as objects' do
+    let(:cpa) { CollectiveProofAttempt.new(theorem, [prover1, prover2]) }
+
+    it 'have the two provers' do
+      provers = cpa.prove_options_list.map do |prove_options|
+        prove_options.options[:prover]
+      end
+      # We use .name because ProveOptions already converts it
+      expect(provers).to eq([prover1.name, prover2.name])
+    end
+
+    context 'run' do
+      let(:ontology_version) { cpa.send(:ontology_version) }
+      before do
+        allow(ontology_version).to receive(:update_state!).and_call_original
+        allow(cpa.resource).to receive(:prove)
+        cpa.run
+      end
+
+      it 'call prove with all options' do
+        cpa.prove_options_list.each do |prove_options|
+          expect(cpa.resource).to have_received(:prove).with(prove_options)
+        end
+      end
+
+      it 'update ontology_version state to processing' do
+        expect(ontology_version).
+          to have_received(:update_state!).with(:processing)
+      end
+
+      it 'update ontology_version state to done' do
+        expect(ontology_version).
+          to have_received(:update_state!).with(:done)
+      end
+    end
+  end
+end

--- a/spec/lib/collective_proof_attempt_worker_spec.rb
+++ b/spec/lib/collective_proof_attempt_worker_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe CollectiveProofAttemptWorker do
+  context 'perform_async' do
+    let(:args) { %i(some arguments) }
+    before do
+      allow(CollectiveProofAttemptWorker).
+        to receive(:perform_async_on_queue)
+    end
+
+    it 'call perform_async_on_queue with hets' do
+      CollectiveProofAttemptWorker.perform_async(*args)
+      expect(CollectiveProofAttemptWorker).
+        to have_received(:perform_async_on_queue).
+        with('hets', *args)
+    end
+  end
+
+  context 'perform' do
+    let(:cpa_worker) { CollectiveProofAttemptWorker.new }
+    let(:cpa) { Object.new } # A spy. For Rspec 3, use spy(:something)
+    before do
+      allow(CollectiveProofAttempt).to receive(:new).and_return(cpa)
+      allow(cpa).to receive(:run)
+    end
+
+    let(:provers) { [] }
+    let(:theorem) { create :theorem }
+    let(:ontology_version) { theorem.ontology.current_version }
+
+    context 'on the theorem' do
+      before do
+        cpa_worker.perform(theorem.class.to_s, theorem.id, provers)
+      end
+
+      it 'create a CollectiveProofAttempt' do
+        expect(CollectiveProofAttempt).
+          to have_received(:new).
+          with(theorem, provers)
+      end
+
+      it 'call run' do
+        expect(cpa).to have_received(:run)
+      end
+    end
+
+    context 'on the ontology_version' do
+      before do
+        cpa_worker.perform(ontology_version.class.to_s,
+                           ontology_version.id,
+                           provers)
+      end
+
+      it 'create a CollectiveProofAttempt' do
+        expect(CollectiveProofAttempt).
+          to have_received(:new).
+          with(ontology_version, provers)
+      end
+
+      it 'call run' do
+        expect(cpa).to have_received(:run)
+      end
+    end
+  end
+end

--- a/spec/lib/hets/prove_options_spec.rb
+++ b/spec/lib/hets/prove_options_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe Hets::ProveOptions do
+  let(:prover) { create :prover }
   let(:theorem) { create :theorem }
   let(:ontology) { theorem.ontology }
   let(:axiom) { create :axiom, ontology: ontology }
@@ -8,6 +9,7 @@ describe Hets::ProveOptions do
 
   context 'with strings' do
     let(:options) { {node: ontology.name,
+                     prover: prover.name,
                      axioms: [axiom.name],
                      theorems: [theorem.name]} }
     let(:prove_options) { Hets::ProveOptions.new(options) }
@@ -19,6 +21,7 @@ describe Hets::ProveOptions do
 
   context 'with general objects' do
     let(:options) { {ontology: ontology,
+                     prover: prover,
                      axioms: [axiom],
                      theorems: [theorem]} }
     let!(:axiom_names) { options[:axioms].map(&:name) }
@@ -31,6 +34,10 @@ describe Hets::ProveOptions do
 
     it 'sets :node to the ontology name' do
       expect(prove_options.options[:node]).to eq(ontology.name)
+    end
+
+    it 'sets :prover to the prover name' do
+      expect(prove_options.options[:prover]).to eq(prover.name)
     end
 
     it 'sets :axioms to the axioms names' do

--- a/spec/lib/hets/provers_options_spec.rb
+++ b/spec/lib/hets/provers_options_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Hets::ProversOptions do
+  let(:parent_ontology) { create :linked_distributed_ontology }
+  let(:child_ontology) { parent_ontology.children.first }
+
+  context 'with strings' do
+    let(:options) { {node: child_ontology.name} }
+    let(:provers_options) { Hets::ProversOptions.new(options) }
+
+    it 'does not change the options' do
+      expect(provers_options.options).to eq(options)
+    end
+  end
+
+  context 'with general objects' do
+    let(:options) { {ontology: child_ontology} }
+    let(:provers_options) { Hets::ProversOptions.new(options) }
+
+    it "removes the key 'ontology'" do
+      expect(provers_options.options.has_key?(:ontology)).to be(false)
+    end
+
+    it 'sets :node to the ontology name' do
+      expect(provers_options.options[:node]).to eq(child_ontology.name)
+    end
+  end
+
+  context 'using the parent ontology' do
+    let(:options) { {ontology: parent_ontology} }
+    let(:provers_options) { Hets::ProversOptions.new(options) }
+
+    it 'it does not set :node' do
+      expect(provers_options.options.has_key?(:node)).to be(false)
+    end
+
+    it "removes the key 'ontology'" do
+      expect(provers_options.options.has_key?(:ontology)).to be(false)
+    end
+  end
+end

--- a/spec/lib/proof_spec.rb
+++ b/spec/lib/proof_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe Proof do
+  let(:prover) { create :prover }
+  let(:theorem) { create :theorem }
+  let(:ontology) { theorem.ontology }
+  let(:ontology_version) { ontology.current_version }
+  let(:repository) { ontology.repository }
+  let(:params) do
+    {
+      repository_id: repository.to_param,
+      ontology_id: ontology.to_param,
+      proof: {provers: [prover.to_param.to_s, '']},
+    }
+  end
+
+  context 'validations' do
+    it 'is valid' do
+      expect(Proof.new(params).valid?).to be(true)
+    end
+
+    it 'is not valid with bad provers' do
+      bad_params = params.merge({proof: {provers: ['-1', '']}})
+      expect(Proof.new(bad_params).valid?).to be(false)
+    end
+  end
+
+  context 'usage for ontology_version' do
+    let(:proof) { Proof.new(params) }
+
+    it 'has IDs as provers' do
+      proof.provers.each do |prover|
+        expect(prover).to be > 0
+      end
+    end
+
+    it 'has the ontology_version as proof obligation' do
+      expect(proof.proof_obligation).to eq(ontology_version)
+    end
+
+    it 'starts proving on save!' do
+      allow(CollectiveProofAttemptWorker).to receive(:perform_async)
+      proof.save!
+      expect(CollectiveProofAttemptWorker).
+        to have_received(:perform_async).
+        with(OntologyVersion.to_s, ontology_version.id, proof.provers)
+    end
+  end
+
+  context 'usage for theorem' do
+    let(:theorem_params) { params.merge(theorem_id: theorem.to_param) }
+    let(:proof) { Proof.new(theorem_params) }
+
+    it 'has the theorem as proof obligation' do
+      expect(proof.proof_obligation).to eq(theorem)
+    end
+
+    it 'starts proving on save!' do
+      allow(CollectiveProofAttemptWorker).to receive(:perform_async)
+      proof.save!
+      expect(CollectiveProofAttemptWorker).
+        to have_received(:perform_async).
+        with(Theorem.to_s, theorem.id, proof.provers)
+    end
+  end
+end

--- a/spec/models/ontology_version/provers_spec.rb
+++ b/spec/models/ontology_version/provers_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'OntologyVersion - Provers' do
+  setup_hets
+  let(:user) { create :user }
+  let(:repository) { create :repository }
+
+  before do
+    stub_hets_for('prove/Simple_Implications.casl')
+    @version =
+      version_for_file(repository,
+                       ontology_file('prove/Simple_Implications', 'casl'))
+    @version.parse
+  end
+
+  let(:ontology) { @version.ontology }
+
+  it 'have fetched available provers' do
+    expect(@version.provers.count).to be > 0
+  end
+
+  it "all child ontologies' versions have fetched available provers" do
+    ontology.children.each do |child|
+      expect(child.current_version.provers.count).to be > 0
+    end
+  end
+end

--- a/spec/models/ontology_version/proving_spec.rb
+++ b/spec/models/ontology_version/proving_spec.rb
@@ -107,7 +107,7 @@ describe 'OntologyVersion - Proving' do
         end
 
         it 'have "SPASS" prover' do
-          expect(proof_attempt.prover).to eq('SPASS')
+          expect(proof_attempt.prover.name).to eq('SPASS')
         end
 
         it 'have prover output' do

--- a/spec/models/prover_spec.rb
+++ b/spec/models/prover_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe Prover do
+  let(:prover) { create :prover }
+  it 'to_s is the name' do
+    expect(prover.to_s).to eq(prover.name)
+  end
+end

--- a/spec/models/theorem_spec.rb
+++ b/spec/models/theorem_spec.rb
@@ -6,6 +6,28 @@ describe Theorem do
     it { should belong_to(:proof_status) }
   end
 
+  context 'Proving' do
+    let(:user) { create :user }
+    let(:parent_ontology) { create :distributed_ontology }
+
+    before do
+      parse_ontology(user, parent_ontology, 'prove/Simple_Implications.casl')
+      stub_hets_for('prove/Simple_Implications.casl',
+                    command: 'prove', method: :post)
+    end
+
+    let(:ontology) { parent_ontology.children.find_by_name('Group') }
+    let(:version) { ontology.current_version }
+    let(:theorem) { ontology.theorems.find_by_name('rightunit') }
+    let(:other_theorem) { ontology.theorems.find_by_name('zero_plus') }
+
+    before { theorem.prove }
+
+    it 'the theorem is solved' do
+      expect(theorem.proof_attempts.count).to eq(1)
+    end
+  end
+
   context 'update_proof_status' do
     let(:success) { create :proof_status_success }
     let(:proven) { create :proof_status_proven }


### PR DESCRIPTION
This shall fix #1237. This branch allows the user to select _multiple_ available provers for proving. For each prover, a proof attempt is made. Those proof attempts are processed sequentially.
#### Possibly important notes
- The `prove/` route has been replaced by `proofs/` to use the REST convention
- The new ProofsController is completely rewritten and has nothing in common with the previous ProveController
- I tried to make many small commits and to not revert previous changes in the same branch. It should be easier to review this pull request commit by commit.

This branch is based on the branch of #1262 (**introduce_hets_options**) instead of **staging**.  It might be easier to review that one first.
