### PR TITLE
1170 git handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,13 @@ config/environments/*.local.rb
 /coverage
 
 spec/fixtures/vcr/hets-out
+# Ignore custom compiled binaries
+bin/cp_keys
+
+spec/fixtures/ontologies/xml
+
+spec/fixtures/ontologies/hets-out/*
+!spec/fixtures/ontologies/hets-out/.gitkeep
+
+spec/fixtures/ontologies/hets-out/prove
+!spec/fixtures/ontologies/hets-out/prove/.gitkeep

--- a/config/initializers/paths.rb
+++ b/config/initializers/paths.rb
@@ -19,17 +19,6 @@ module PathsInitializer
 
       config.commits_path =
         cleanup_release(Rails.root.join(Settings.paths.commits))
-
-      settings = Settings.git
-      if settings && settings.user
-        config.git_user  = settings.user
-        config.git_group = settings.group
-        config.git_home  = File.expand_path("~#{config.git_user}")
-      else
-        config.git_user  = nil
-        config.git_group = nil
-        config.git_home  = Rails.root.join('tmp','git')
-      end
     end
   end
 end

--- a/config/initializers/paths.rb
+++ b/config/initializers/paths.rb
@@ -11,6 +11,9 @@ module PathsInitializer
       config.git_root =
         cleanup_release(Rails.root.join(Settings.paths.git_repositories))
 
+      config.git_home =
+        cleanup_release(Rails.root.join(Settings.paths.git_home))
+
       config.symlink_path =
         cleanup_release(Rails.root.join(Settings.paths.symlinks))
 

--- a/config/initializers/paths.rb
+++ b/config/initializers/paths.rb
@@ -1,24 +1,20 @@
 
 module PathsInitializer
   class << self
+    def expand(path)
+      Dir.chdir(Rails.root) { Pathname.new(path).expand_path }
+    end
+
     def cleanup_release(path)
       path.sub(%r(/releases/\d+/), "/current/")
     end
 
     def perform_initialization(config)
-      config.data_root = cleanup_release(Rails.root.join(Settings.paths.data))
-
-      config.git_root =
-        cleanup_release(Rails.root.join(Settings.paths.git_repositories))
-
-      config.git_home =
-        cleanup_release(Rails.root.join(Settings.paths.git_home))
-
-      config.symlink_path =
-        cleanup_release(Rails.root.join(Settings.paths.symlinks))
-
-      config.commits_path =
-        cleanup_release(Rails.root.join(Settings.paths.commits))
+      config.data_root = cleanup_release(expand(Settings.paths.data))
+      config.git_root = cleanup_release(expand(Settings.paths.git_repositories))
+      config.git_home = cleanup_release(expand(Settings.paths.git_home))
+      config.symlink_path = cleanup_release(expand(Settings.paths.symlinks))
+      config.commits_path = cleanup_release(expand(Settings.paths.commits))
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -81,7 +81,7 @@ paths:
   commits: data/commits
   # home directory of the git user
   #   needed for handling of ssh keys in ~git/.ssh/authorized_keys
-  git_home: /home/git
+  git_home: ~git
 
 git:
   verify_url: http://localhost/

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -79,6 +79,9 @@ paths:
   symlinks: data/git_daemon
   # cache for files that needed to be checked out from the git repositories
   commits: data/commits
+  # home directory of the git user
+  #   needed for handling of ssh keys in ~git/.ssh/authorized_keys
+  git_home: /home/git
 
 git:
   user: # can be nil if git commands are to be executed with the current user

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -84,8 +84,6 @@ paths:
   git_home: /home/git
 
 git:
-  user: # can be nil if git commands are to be executed with the current user
-  group: # can be nil if git commands are to be executed with the current group
   verify_url: http://localhost/
   default_branch: 'master'
   push_priority:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -5,3 +5,6 @@ git:
   verify_url: http://localhost:3000/
 
 display_head_commit: true
+
+paths:
+  git_home: tmp/git

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -10,3 +10,4 @@ paths:
   git_repositories: tmp/data/git
   symlinks: tmp/data/git_daemon
   commits: tmp/data/commits
+  git_home: tmp/git

--- a/doc/productive_deployment.md
+++ b/doc/productive_deployment.md
@@ -167,6 +167,12 @@ exception_notifier.exception_recepients
 paths
 ```
 
+Whenever you change the `paths` in the settings, you need to run
+`RAILS_ENV=production bundle exec rake git:compile_cp_keys` in order to have
+the git-ssh interaction working correctly, because the `paths` from the
+settings are compiled into the binary which manipulates the authorized_keys
+file.
+
 ##### Settings for deployment with capistrano
 
 For deployment with capistrano, you need to change the hostname (in the

--- a/git/lib/git_shell.rb
+++ b/git/lib/git_shell.rb
@@ -8,7 +8,8 @@ class GitShell
   def initialize(key_id, command)
     @key_id     = key_id
     @command    = command
-    @repos_path = File.join(Settings.git_home, 'repositories')
+    # Here, Settings has added values from the PathsInitializer
+    @repos_path = Settings.symlink_path
   end
 
   def exec
@@ -51,7 +52,7 @@ for more information about permissions."
   end
 
   def process_cmd
-    repo_full_path = File.join(repos_path, repo_name)
+    repo_full_path = repos_path.join(repo_name)
     cmd = "#{@git_cmd} #{repo_full_path}"
     Rails.logger.info "git-shell: executing git command <#{cmd}> for #{log_username}."
     exec_cmd(cmd)

--- a/lib/authorized_keys_manager.rb
+++ b/lib/authorized_keys_manager.rb
@@ -3,8 +3,7 @@ require 'pathname'
 class AuthorizedKeysManager
 
   CONFIG               = Ontohub::Application.config
-  GIT_HOME             = Pathname.new(CONFIG.git_home)
-  SSH_DIR              = GIT_HOME.join('.ssh')
+  SSH_DIR              = CONFIG.data_root.join('.ssh')
   AUTHORIZED_KEYS_FILE = SSH_DIR.join('authorized_keys')
   GIT_SHELL_FILE       = Rails.root.join('git', 'bin', 'git-shell').
     # replace capistrano-style release with 'current'-symlink

--- a/lib/authorized_keys_manager.rb
+++ b/lib/authorized_keys_manager.rb
@@ -3,14 +3,12 @@ require 'pathname'
 class AuthorizedKeysManager
 
   CONFIG               = Ontohub::Application.config
+  GIT_HOME_SSH_DIR     = CONFIG.git_home.join('.ssh')
   SSH_DIR              = CONFIG.data_root.join('.ssh')
   AUTHORIZED_KEYS_FILE = SSH_DIR.join('authorized_keys')
   GIT_SHELL_FILE       = Rails.root.join('git', 'bin', 'git-shell').
     # replace capistrano-style release with 'current'-symlink
     sub(%r{/releases/\d+/}, '/current/')
-
-  # make sure ssh-dir exists.
-  SSH_DIR.mkpath
 
   class << self
     def add(key_id, key)
@@ -49,6 +47,7 @@ class AuthorizedKeysManager
     end
 
     def in_authorized_keys(mode)
+      SSH_DIR.mkpath
       File.open(AUTHORIZED_KEYS_FILE, mode) do |file|
         file.flock(File::LOCK_EX)
         yield file
@@ -57,6 +56,7 @@ class AuthorizedKeysManager
     end
 
     def copy_authorized_keys_to_git_home
+      GIT_HOME_SSH_DIR.mkpath
       system(Rails.root.join('bin', 'cp_keys').to_s)
     end
   end

--- a/lib/authorized_keys_manager.rb
+++ b/lib/authorized_keys_manager.rb
@@ -54,8 +54,11 @@ class AuthorizedKeysManager
         file.flock(File::LOCK_EX)
         yield file
       end
+      copy_authorized_keys_to_git_home
     end
 
+    def copy_authorized_keys_to_git_home
+      system(Rails.root.join('bin', 'cp_keys').to_s)
+    end
   end
-
 end

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -48,7 +48,9 @@ namespace :git do
     compile_gcc(reconfigured_source_tempfile.path, target_path)
     remove_symbols(target_path)
     set_permissions('4500', target_path,
-                    'the git user and the webserver-running group.')
+                    'the git user and the webserver-running group. Also, add '\
+                    'execute-permissions for the webserver-running user with '\
+                    "ACLs, e.g.: setfacl -m u:ontohub:--x,m::rwx #{target_path}")
     reconfigured_source_tempfile.unlink
   end
 

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -1,0 +1,16 @@
+namespace :git do
+  def compile_gcc(source_path, target_path)
+    command = ['gcc', source_path, '-o', target_path]
+    puts "Compiling #{target_path.split('/').last} with"
+    puts command.map { |c| c.match(/\s/) ? "'#{c}'" : c }.join(' ')
+    system(*command)
+  end
+
+  desc 'Compile cp_keys binary'
+  task :compile_cp_keys => :environment do
+    source_file = Rails.root.join('script', 'cp_keys.c')
+    target_path = Rails.root.join('bin', 'cp_keys').to_s
+
+    compile_gcc(source_file.to_s, target_path)
+  end
+end

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -51,4 +51,17 @@ namespace :git do
                     'the git user and the webserver-running group.')
     reconfigured_source_tempfile.unlink
   end
+
+  desc 'Create authorized_keys file and set its permissions'
+  task :prepare_authorized_keys => :environment do
+    SSH_DIR = Ontohub::Application.config.data_root.join('.ssh')
+    AUTHORIZED_KEYS = SSH_DIR.join('authorized_keys')
+    SSH_DIR.mkpath
+    if !File.exists?(AUTHORIZED_KEYS)
+      puts "Creating the file #{AUTHORIZED_KEYS}."
+      FileUtils.touch(AUTHORIZED_KEYS)
+      set_permissions('0640', AUTHORIZED_KEYS.to_s,
+                      'the webserver-running user.')
+    end
+  end
 end

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -1,4 +1,22 @@
 namespace :git do
+  def reconfigure_cp_keys(source_file)
+    data_root = Ontohub::Application.config.data_root
+    git_home = Ontohub::Application.config.git_home
+
+    reconfigured_source = File.read(source_file).
+      sub(/^#define DATA_ROOT .*$/, "#define DATA_ROOT \"#{data_root}\"").
+      sub(/^#define GIT_HOME .*$/, "#define GIT_HOME \"#{git_home}\"")
+
+    reconfigured_source_file = Tempfile.new(%w(cp_keys .c))
+    reconfigured_source_file.write(reconfigured_source)
+    reconfigured_source_file.close
+    puts "Copying #{source_file} to tempfile #{reconfigured_source_file.path}"
+    puts "Reconfiguring DATA_ROOT in this tempfile to #{data_root}"
+    puts "Reconfiguring GIT_HOME in this tempfile to #{git_home}"
+
+    reconfigured_source_file
+  end
+
   def compile_gcc(source_path, target_path)
     command = ['gcc', source_path, '-o', target_path]
     puts "Compiling #{target_path.split('/').last} with"
@@ -11,6 +29,8 @@ namespace :git do
     source_file = Rails.root.join('script', 'cp_keys.c')
     target_path = Rails.root.join('bin', 'cp_keys').to_s
 
-    compile_gcc(source_file.to_s, target_path)
+    reconfigured_source_tempfile = reconfigure_cp_keys(source_file)
+    compile_gcc(reconfigured_source_tempfile.path, target_path)
+    reconfigured_source_tempfile.unlink
   end
 end

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -24,6 +24,21 @@ namespace :git do
     system(*command)
   end
 
+  def remove_symbols(target_path)
+    command = ['strip', target_path]
+    puts 'Removing symbols with'
+    puts command.map { |c| c.match(/\s/) ? "'#{c}'" : c }.join(' ')
+    system(*command)
+  end
+
+  def set_permissions(mode, path, owner_group)
+    command_chmod = ['chmod', mode, path]
+    puts 'Changing owner with'
+    puts command_chmod.map { |c| c.match(/\s/) ? "'#{c}'" : c }.join(' ')
+    system(*command_chmod)
+    puts "You need to manually set the owner/group of '#{path}' to #{owner_group}"
+  end
+
   desc 'Compile cp_keys binary'
   task :compile_cp_keys => :environment do
     source_file = Rails.root.join('script', 'cp_keys.c')
@@ -31,6 +46,9 @@ namespace :git do
 
     reconfigured_source_tempfile = reconfigure_cp_keys(source_file)
     compile_gcc(reconfigured_source_tempfile.path, target_path)
+    remove_symbols(target_path)
+    set_permissions('4500', target_path,
+                    'the git user and the webserver-running group.')
     reconfigured_source_tempfile.unlink
   end
 end

--- a/script/cp_keys.c
+++ b/script/cp_keys.c
@@ -1,0 +1,75 @@
+#include <unistd.h>
+#include <stdlib.h>
+
+#define DATA_ROOT "/data/git"
+#define GIT_HOME "/home/git"
+
+#define KEYS "/.ssh/authorized_keys"
+#ifdef linux
+#define CP "/bin/cp"
+#else
+#define CP "/usr/bin/cp"
+#endif
+
+/*
+ * The only purpose of this program is to copy the ssh authorized_keys file
+ * written by the web application to ${DATA_ROOT}/.ssh/authorized_keys to the
+ * ${GIT_HOME}/.ssh/authorized_keys file, whereby ${GIT_HOME} is the home
+ * directory of the user running the git service (default ~git).
+ *
+ * Thus to get it actually work, the resulting binary needs to be owned by the
+ * corresponding user running the git service and needs to be set suid (ssh
+ * accepts authorized_keys files writable the owning user, only - i.e. just
+ * setting the group write bit of the authorized_keys file simply doesn't work).
+ *
+ * Because suid stuff is always a "makes-me-nervous" thing, we hardcode the
+ * source and destination as well as the binary to call, so that it cannot be
+ * abused by malicious users - they would just cause a possibly redundant sync.
+ *
+ * As an alternative on a modern OS having a fine grained security model like
+ * Solaris one could create a web2git RBAC role, add this role to the user
+ * running the web service and add an appropriate entry to the exec_attr(4)
+ * file, which allows web2git role to run the given command with euid of the
+ * user running the git service and thus no suid bit is needed, e.g.:
+ * web2git:suser:cmd:::/data/git/.ssh/cp_keys:uid=123:gid=456
+ * On Linux with its coarse grained/ancient security models like apparmor
+ * running scripts in a similar way is impossible, because when the related
+ * interpreter gets executed, it doesn't inherit the capabilities/euid/... of
+ * the script. Anyway, if one has a lot of time and likes really complex setups,
+ * he might be able to define appropriate SELinux contexts/policies/labels and
+ * get script work in a similar way. However, we don't support that, i.e. we
+ * leave such complex tasks to real security experts. The 3rd alternative is
+ * for people which do not care a lot about security: the 'StrictModes no'
+ * setting of the sshd_config instructs the ssh daemon to relax checks and thus
+ * accept group writable authorized_keys files. But this is not recommended,
+ * since this setting applies to ALL users and NOT ONLY to the authorized_keys
+ * files!
+ *
+ * Last but not least: The application expects the resulting binary in the
+ * .ssh directory of the ${DATA_ROOT}, which should be equal to the
+ * Settings.git.data_dir value - see app/models/key.rb as well as
+ * lib/authorized_keys_manager.rb for more info.
+ *
+ * Steps to do (we assume the web service is run by webservd:webservd and the
+ * git service is run by the user git:webservd):
+ *  0) edit cp_keys.c  - adjust DATA_ROOT and GIT_HOME wrt. your environment
+ *  1) gcc -o ${DATA_DIR}/.ssh/cp_keys cp_keys.c
+ *  2) strip ${DATA_DIR}/.ssh/cp_keys
+ *  3) chown git:webservd ${DATA_DIR}/.ssh/cp_keys
+ *  4) chmod 4500 ${DATA_DIR}/.ssh/cp_keys
+ *  5) optional for paranoid people add exec restricting withdrawn POSIX ACLs:
+ *      chacl u::r-x,g::---,o::---,u:ontohub:r-x,u:webservd:--x,m::rwx \
+ *      ${DATA_DIR}/.ssh/cp_keys
+ *  6) touch ${DATA_DIR}/.ssh/authorized_keys
+ *  7) chown webservd:webservd ${DATA_DIR}/.ssh/authorized_keys
+ *  8) chmod 0640 ${DATA_DIR}/.ssh/authorized_keys
+ */
+int
+main(int argc, char *argv[])
+{
+    char *nenv[] = { NULL };
+    char *nargv[] = { "cp", DATA_ROOT KEYS, GIT_HOME KEYS, NULL };
+    int res = execve(CP, nargv, nenv);
+    perror("execve");
+    exit(res);
+}

--- a/script/cp_keys.c
+++ b/script/cp_keys.c
@@ -1,3 +1,6 @@
+#ifdef __APPLE__
+#include <libc.h>
+#endif
 #include <unistd.h>
 #include <stdlib.h>
 

--- a/script/rebuild-ontohub
+++ b/script/rebuild-ontohub
@@ -37,4 +37,5 @@ initialize_new_invoker_instance
 execute_or_die "bundle exec rake elasticsearch:wipe"
 execute_or_die "bundle exec rake db:migrate:clean"
 execute_or_die "redis-cli flushdb"
+execute_or_die "bundle exec rake git:compile_cp_keys"
 execute_or_die "bundle exec rake db:seed"

--- a/spec/controllers/keys_controller_spec.rb
+++ b/spec/controllers/keys_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe KeysController do
-
   let(:user){ create :user }
+  before { stub_cp_keys }
 
   context 'not signed in' do
     before { get :index }
@@ -44,5 +44,4 @@ describe KeysController do
       end
     end
   end
-
 end

--- a/spec/controllers/ssh_access_controller_spec.rb
+++ b/spec/controllers/ssh_access_controller_spec.rb
@@ -5,6 +5,8 @@ describe SSHAccessController do
   let(:repository) { create :repository }
   let(:user) { create :user }
 
+  before { stub_cp_keys }
+
   context 'should return valid response when encountering error' do
     before do
       get :index, repository_id: repository.to_param, key_id: nil, permission: 'write'

--- a/spec/models/key_spec.rb
+++ b/spec/models/key_spec.rb
@@ -11,6 +11,7 @@ describe Key do
 
   context 'creating a key' do
     let(:user){ create :user }
+    before { stub_cp_keys }
 
     context 'that is valid' do
       subject do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,10 @@ end
 
 require Rails.root.join('spec', 'support', 'common_helper_methods.rb')
 
+def stub_cp_keys
+  allow(AuthorizedKeysManager).to receive(:copy_authorized_keys_to_git_home)
+end
+
 # Recording HTTP Requests
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/fixtures/vcr'


### PR DESCRIPTION
This pull request replaces #1197. What it does:
* Make the paths around git configurable.
* Add rake tasks to prepare git authorized_keys handling
  * Compile the key-copy binary (and set custom permissions)
    * Before compilation, the source file `cp_keys.c` is changed to use the settings which the Rails app uses. Make sure, this rake task is called with the correct RAILS_ENV.
  * Create the ontohub-editable authorized_keys with custom permissions file if it doesn't exist
  * Print messages on what is yet to do manually (`chown`). We can't do this automatically, because we donÄt know which owner/group we want to set. We could add settings for user/group, but we would to have need root privileges on some systems for `chown`. The root privileges are the reason why I want to let the admin do this manually.