### PR TITLE
Fix ontology state update

### DIFF
--- a/app/assets/javascripts/ontology_version-state.js.coffee
+++ b/app/assets/javascripts/ontology_version-state.js.coffee
@@ -8,7 +8,7 @@ update = (container) ->
   updateContainer = (container) ->
     current_state = container.data('state')
 
-    $.getJSON container.data('uri') + ".json", (data) ->
+    $.getJSON container.data('uri'), (data) ->
       state = data.state
 
       if state == current_state && !_.contains(final_states, state)

--- a/app/assets/javascripts/ontology_version-state.js.coffee
+++ b/app/assets/javascripts/ontology_version-state.js.coffee
@@ -9,7 +9,7 @@ update = (container) ->
     current_state = container.data('state')
 
     $.getJSON container.data('uri'), (data) ->
-      state = data.state
+      state = data.evaluation_state
 
       if state == current_state && !_.contains(final_states, state)
         enqueue(container)

--- a/app/helpers/ontology_helper.rb
+++ b/app/helpers/ontology_helper.rb
@@ -16,13 +16,12 @@ module OntologyHelper
 
   def status_tag(resource)
     version = resource.is_a?(Ontology) ? resource.current_version : resource
-    uri = repository_ontology_ontology_version_url(
-      version.ontology.repository, version.ontology, version)
+
     html_opts = {
       class: 'ontology-version-state',
       data: {
         ontology_version_id: version.id,
-        uri: uri,
+        uri: locid_for(version),
         state: version.state,
       }
     }

--- a/features/step_definitions/ontology_state_steps.rb
+++ b/features/step_definitions/ontology_state_steps.rb
@@ -19,6 +19,7 @@ end
 Then(/^the page should change the state on its own$/) do
   el_css = 'small.ontology-version-state'
   field = 'data-ontology-version-id'
+  wait_for_ajax
   within %{#{el_css}[#{field}="#{@ontology_version.id}"]} do
     expect(find('span')).to have_content(@state)
   end

--- a/features/step_definitions/ontology_state_steps.rb
+++ b/features/step_definitions/ontology_state_steps.rb
@@ -20,6 +20,6 @@ Then(/^the page should change the state on its own$/) do
   el_css = 'small.ontology-version-state'
   field = 'data-ontology-version-id'
   within %{#{el_css}[#{field}="#{@ontology_version.id}"]} do
-    find('span').has_content?(@state)
+    expect(find('span')).to have_content(@state)
   end
 end

--- a/lib/ontology_version_finder.rb
+++ b/lib/ontology_version_finder.rb
@@ -1,6 +1,6 @@
 class OntologyVersionFinder
   SUPPORTED_BRANCHES = %w(master)
-  REF_RE = %r{\A/?ref/([^/]+)(/.+)\Z}
+  REF_RE = %r{\A/?ref/([^/]+)(/[^?]+).*\Z}
 
   attr_accessor :ontology, :reference
 


### PR DESCRIPTION
Shall fix the ontology state feature yet again. This time for usage of locids, and in turn fixes version-locid resolving by excluding the query-string.