### PR TITLE
1292 add api key

### DIFF
--- a/app/controllers/api/v1/base.rb
+++ b/app/controllers/api/v1/base.rb
@@ -1,9 +1,25 @@
 # Base controller for all API controllers
 class Api::V1::Base < ApplicationController
+  API_KEY_HEADER = 'Ontohub-API-Key'
+  API_KEY_SYMBOL = :api_key
+
   respond_to :json
 
   protected
   def check_write_permission
     authorize! :write, resource
+  end
+
+  def current_user
+    ApiKey.valid.where(key: api_key).first if api_key
+  end
+
+  def api_key
+    @api_key_in_request ||=
+      if params[API_KEY_SYMBOL].present?
+        params[API_KEY_SYMBOL]
+      elsif request.headers[API_KEY_HEADER].present?
+        request.headers[API_KEY_HEADER]
+      end
   end
 end

--- a/app/controllers/api/v1/base.rb
+++ b/app/controllers/api/v1/base.rb
@@ -11,7 +11,7 @@ class Api::V1::Base < ApplicationController
   end
 
   def current_user
-    ApiKey.valid.where(key: api_key).first if api_key
+    ApiKey.valid.where(key: api_key).first.try(:user) if api_key
   end
 
   def api_key

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -1,0 +1,16 @@
+class ApiKeysController < InheritedResources::Base
+  before_filter :authenticate_user!
+
+  actions :create
+  respond_to :html
+
+  def create
+    respond_with do |format|
+      format.html do
+        ApiKey.create_new_key!(current_user)
+        redirect_to edit_user_registration_path(anchor: 'api_key'),
+          notice: t(:successful_api_key_generation)
+      end
+    end
+  end
+end

--- a/app/controllers/users/api_keys_controller.rb
+++ b/app/controllers/users/api_keys_controller.rb
@@ -1,4 +1,4 @@
-class ApiKeysController < InheritedResources::Base
+class Users::ApiKeysController < InheritedResources::Base
   before_filter :authenticate_user!
 
   actions :create

--- a/app/helpers/users/registrations_helper.rb
+++ b/app/helpers/users/registrations_helper.rb
@@ -1,0 +1,9 @@
+module Users::RegistrationsHelper
+  def api_key
+    resource.api_keys.valid.first
+  end
+
+  def blank_api_key
+    ApiKey.new(user: resource)
+  end
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,28 @@
+class ApiKey < ActiveRecord::Base
+  KEY_LENGTH = 48
+  STATES = %w(valid invalid)
+
+  belongs_to :user
+  attr_accessible :key, :status
+
+  before_validation :initialize_key
+
+  validates :user, presence: true
+  validates :key, presence: true, uniqueness: true
+  validates :status, inclusion: {in: STATES}
+
+  private
+  def initialize_key
+    generate_key! unless key
+    set_status! unless status
+    true
+  end
+
+  def generate_key!
+    self.key = SecureRandom.hex(KEY_LENGTH)
+  end
+
+  def set_status!
+    self.status = 'valid'
+  end
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -4,12 +4,26 @@ class ApiKey < ActiveRecord::Base
 
   belongs_to :user
   attr_accessible :key, :status
+  attr_accessible :user
 
   before_validation :initialize_key
 
   validates :user, presence: true
   validates :key, presence: true, uniqueness: true
   validates :status, inclusion: {in: STATES}
+
+  def self.create_new_key!(user)
+    transaction do
+      where(user_id: user, status: 'valid').
+        find_each { |key| key.invalidate! }
+      create!(user: user)
+    end
+  end
+
+  def invalidate!
+    self.status = 'invalid'
+    save!
+  end
 
   private
   def initialize_key

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -12,6 +12,8 @@ class ApiKey < ActiveRecord::Base
   validates :key, presence: true, uniqueness: true
   validates :status, inclusion: {in: STATES}
 
+  scope :valid, -> { where(status: 'valid') }
+
   def self.create_new_key!(user)
     transaction do
       where(user_id: user, status: 'valid').

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ActiveRecord::Base
   has_many :metadata
   has_many :permissions, :as => :subject
   has_many :keys
+  has_many :api_keys
 
   attr_accessible :email, :name, :first_name, :admin, :password, :as => :admin
 

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -19,6 +19,15 @@
   %p Your account is not yet confirmed.
   = link_to 'Resend confirmation E-Mail!', confirmation_path(resource_name, user: {email: resource.email}), method: :post, class: 'btn btn-default', disable_with: t(:wait)
 
+%h3#api_key= t(:api_key_headline)
+
+= simple_form_for [:users, blank_api_key] do |f|
+  - if api_key
+    = f.input :key, as: :string, readonly: true, input_html: {value: api_key.key}
+    = f.button :wrapped, t(:generate_api_key)
+  - else
+    = f.button :wrapped, t(:generate_initial_api_key)
+
 %h3 Cancel my account
 
 %p Unhappy?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,10 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
+  successful_api_key_generation: API-Key was successfully generated
+  api_key_headline: API-Key
+  generate_initial_api_key: Generate initial API-Key
+  generate_api_key: Generate new API-Key
   admin_deletion_error_message: |
     You probably shouldn't remove this account, as deleting
     it would leave the system with too few admins.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -342,6 +342,9 @@ is determined according to the *locid.
     registrations: 'users/registrations'
   }
   resources :users, only: :show
+  namespace 'users' do
+    resource :api_keys, only: %w(create)
+  end
   resources :keys, except: [:show, :edit, :update]
 
   resources :logics, only: [:index, :show] do

--- a/db/migrate/20150329121431_create_api_keys.rb
+++ b/db/migrate/20150329121431_create_api_keys.rb
@@ -1,0 +1,14 @@
+class CreateApiKeys < ActiveRecord::Migration
+  def change
+    create_table :api_keys do |t|
+      t.text :key
+      t.references :user
+      t.string :status
+
+      t.timestamps
+    end
+    add_index :api_keys, :key, unique: true
+    add_index :api_keys, [:user_id, :status]
+    add_index :api_keys, :user_id
+  end
+end

--- a/db/migrate/20150329121431_create_api_keys.rb
+++ b/db/migrate/20150329121431_create_api_keys.rb
@@ -3,12 +3,12 @@ class CreateApiKeys < ActiveRecord::Migration
     create_table :api_keys do |t|
       t.text :key
       t.references :user
-      t.string :status
+      t.string :state
 
       t.timestamps
     end
     add_index :api_keys, :key, unique: true
-    add_index :api_keys, [:user_id, :status]
+    add_index :api_keys, [:user_id, :state]
     add_index :api_keys, :user_id
   end
 end

--- a/features/User.feature
+++ b/features/User.feature
@@ -25,14 +25,14 @@ Scenario: Generating API-Key
   Given that I am really logged in
   And I visit the Account page
   And there is no existing API-Key
-  When i click on the generate button
-  Then i should see an API-Key
+  When I click on the generate button
+  Then I should see an API-Key
 
 Scenario: Regenerating API-Key
   I want to generate a new personal API-Key
   Given that I am really logged in
   And I have an API-Key
   When I visit the Account page
-  Then i should see the existing API-Key
-  When i click on the generate button
-  Then i should see the new API-Key
+  Then I should see the existing API-Key
+  When I click on the generate button
+  Then I should see the new API-Key

--- a/features/User.feature
+++ b/features/User.feature
@@ -19,3 +19,20 @@ Scenario: User Login
   When I fill in the login form.
   And click on the sign in button.
   Then I should be logged in.
+
+Scenario: Generating API-Key
+  I want to generate a personal API-Key
+  Given that I am really logged in
+  And I visit the Account page
+  And there is no existing API-Key
+  When i click on the generate button
+  Then i should see an API-Key
+
+Scenario: Regenerating API-Key
+  I want to generate a new personal API-Key
+  Given that I am really logged in
+  And I have an API-Key
+  When I visit the Account page
+  Then i should see the existing API-Key
+  When i click on the generate button
+  Then i should see the new API-Key

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -78,11 +78,11 @@ Given(/^there is no existing API\-Key$/) do
     to raise_error(Capybara::ElementNotFound)
 end
 
-When(/^i click on the generate button$/) do
+When(/^I click on the generate button$/) do
   find('form#new_api_key input[name=commit]').click
 end
 
-Then(/^i should see an API\-Key$/) do
+Then(/^I should see an API\-Key$/) do
   expect(find('form#new_api_key input#api_key_key').value).
     to eq(@user.api_keys.valid.first.key)
 end
@@ -91,12 +91,12 @@ Given(/^I have an API-Key$/) do
   @api_key = ApiKey.create_new_key!(@user)
 end
 
-Then(/^i should see the existing API\-Key$/) do
+Then(/^I should see the existing API\-Key$/) do
   expect(find('form#new_api_key input#api_key_key').value).
     to eq(@api_key.key)
 end
 
-Then(/^i should see the new API\-Key$/) do
+Then(/^I should see the new API\-Key$/) do
   key = find('form#new_api_key input#api_key_key').value
   expect(key).to eq(@user.api_keys.valid.first.key)
   expect(key).to_not eq(@api_key.key)

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -57,3 +57,47 @@ Then(/^I should be logged in\.$/) do
   page.should have_content(@user.name)
   page.should have_content("Signed in successfully")
 end
+
+Given(/^that I am really logged in$/) do
+  steps %Q{
+  Given I am a registered and confirmed user.
+  And I visit the landing page.
+  When I fill in the login form.
+  And click on the sign in button.
+  Then I should be logged in.
+  }
+end
+
+Given(/^I visit the Account page$/) do
+  visit root_path
+  click_on 'Account'
+end
+
+Given(/^there is no existing API\-Key$/) do
+  expect { find('form#new_api_key input#api_key_key') }.
+    to raise_error(Capybara::ElementNotFound)
+end
+
+When(/^i click on the generate button$/) do
+  find('form#new_api_key input[name=commit]').click
+end
+
+Then(/^i should see an API\-Key$/) do
+  expect(find('form#new_api_key input#api_key_key').value).
+    to eq(@user.api_keys.valid.first.key)
+end
+
+Given(/^I have an API-Key$/) do
+  @api_key = ApiKey.create_new_key!(@user)
+end
+
+Then(/^i should see the existing API\-Key$/) do
+  expect(find('form#new_api_key input#api_key_key').value).
+    to eq(@api_key.key)
+end
+
+Then(/^i should see the new API\-Key$/) do
+  key = find('form#new_api_key input#api_key_key').value
+  expect(key).to eq(@user.api_keys.valid.first.key)
+  expect(key).to_not eq(@api_key.key)
+end

--- a/spec/factories/api_key_factory.rb
+++ b/spec/factories/api_key_factory.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     association :user
 
     factory :invalid_api_key do
-      status { 'invalid' }
+      state { 'invalid' }
     end
   end
 end

--- a/spec/factories/api_key_factory.rb
+++ b/spec/factories/api_key_factory.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :api_key do
+    association :user
+
+    factory :invalid_api_key do
+      status { 'invalid' }
+    end
+  end
+end

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe ApiKey do
+  let(:api_key) { create :api_key }
+
+  it 'should have a valid factory' do
+    expect(api_key).to be_valid
+  end
+
+  context 'invalid on' do
+    it 'non-unique keys' do
+      invalid_key = build(:api_key, key: api_key.key)
+      expect(invalid_key).to_not be_valid
+    end
+
+    it 'non-present user' do
+      invalid_key = build(:api_key, user: nil)
+      expect(invalid_key).to_not be_valid
+    end
+
+    it 'unacceptable status' do
+      invalid_key = build(:api_key, status: 'nice status')
+      expect(invalid_key).to_not be_valid
+    end
+  end
+end

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -12,13 +12,13 @@ describe ApiKey do
     let!(:key) { described_class.create_new_key!(old_key.user) }
 
     it 'should only have the new key as valid' do
-      expect(described_class.where(status: 'valid').to_a).
+      expect(described_class.where(state: 'valid').to_a).
         to eq([key])
     end
 
     it 'should have invalidated the old key' do
       old_key.reload
-      expect(old_key.status).to eq('invalid')
+      expect(old_key.state).to eq('invalid')
     end
   end
 
@@ -33,8 +33,8 @@ describe ApiKey do
       expect(invalid_key).to_not be_valid
     end
 
-    it 'unacceptable status' do
-      invalid_key = build(:api_key, status: 'nice status')
+    it 'unacceptable state' do
+      invalid_key = build(:api_key, state: 'nice state')
       expect(invalid_key).to_not be_valid
     end
   end

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -7,6 +7,21 @@ describe ApiKey do
     expect(api_key).to be_valid
   end
 
+  context '.create_new_key!' do
+    let(:old_key) { create :api_key }
+    let!(:key) { described_class.create_new_key!(old_key.user) }
+
+    it 'should only have the new key as valid' do
+      expect(described_class.where(status: 'valid').to_a).
+        to eq([key])
+    end
+
+    it 'should have invalidated the old key' do
+      old_key.reload
+      expect(old_key.status).to eq('invalid')
+    end
+  end
+
   context 'invalid on' do
     it 'non-unique keys' do
       invalid_key = build(:api_key, key: api_key.key)


### PR DESCRIPTION
Shall close #1292.

Adds API-Keys to the application. Every user can create API-Keys. Only one per user will be valid at any given time. Currently the invalid ones will also be stored indefinitely - we might want to change this later on.

Also adds 'current_user'  handling based on the api-key for the API-Controller. Tests for this part will however have to wait until the first feature is implemented, that actually needs authentication (which will probably be #1156).