### PR TITLE
1280 hets error handling for proving

### DIFF
--- a/app/models/repository/destroying.rb
+++ b/app/models/repository/destroying.rb
@@ -24,10 +24,8 @@ module Repository::Destroying
     self.destroy_job_id = nil
     self.destroy_job_at = nil
     save!
-    raise e.class,
-          I18n.t('repository.delete_error',
-            oms: Settings.OMS.with_indefinite_article),
-          cause: e
+    raise e.class, I18n.t('repository.delete_error',
+                          oms: Settings.OMS.with_indefinite_article)
   end
 
   def undestroy

--- a/lib/collective_proof_attempt.rb
+++ b/lib/collective_proof_attempt.rb
@@ -60,6 +60,9 @@ class CollectiveProofAttempt
                           ontology_version.user,
                           proof_attempts,
                           input_io)
+  rescue => e
+    set_failed_on_many(proof_attempts, e)
+    raise
   end
 
   def execute_proof(prove_options)
@@ -68,5 +71,14 @@ class CollectiveProofAttempt
   rescue Hets::ExecutionError => e
     handle_hets_execution_error(e, self)
     [:abort, nil]
+  end
+
+  def set_failed_on_many(objects, error)
+    objects.each do |object|
+      begin
+        object.do_or_set_failed { raise error }
+      rescue error.class
+      end
+    end
   end
 end

--- a/lib/collective_proof_attempt.rb
+++ b/lib/collective_proof_attempt.rb
@@ -18,8 +18,13 @@ class CollectiveProofAttempt
         end
       else
         resource.theorems.each { |theorem| theorem.update_state!(:processing) }
-        run_body
-        resource.theorems.each { |theorem| theorem.update_state!(:done) }
+        begin
+          run_body
+          resource.theorems.each { |theorem| theorem.update_state!(:done) }
+        rescue => e
+          set_failed_on_many(resource.theorems, e)
+          raise
+        end
       end
       ontology_version.update_state!(:done)
     end

--- a/lib/hets/hets_error_process.rb
+++ b/lib/hets/hets_error_process.rb
@@ -1,6 +1,7 @@
 module Hets
   class HetsErrorProcess
     HETS_ERROR_CODES = %w(400, 422)
+    HETS_ERROR_MESSAGE_REGEXP = /\A[*]{3}\s*Error:\s*/
 
     attr_reader :error, :response
     delegate :body, to: :response
@@ -27,7 +28,12 @@ module Hets
     end
 
     def message
-      body_lines.slice(1..-1).join
+      match = error_header.match(HETS_ERROR_MESSAGE_REGEXP)
+      if match
+        body[match[0].length..-1]
+      else
+        body_lines[1..-1].join("\n")
+      end
     end
 
     def body_lines
@@ -39,7 +45,7 @@ module Hets
     end
 
     def error_header?
-      !!(error_header =~ /\A[*]{3}\s*Error:\s*\Z/)
+      !!(error_header =~ HETS_ERROR_MESSAGE_REGEXP)
     end
   end
 end

--- a/lib/hets/json_parser.rb
+++ b/lib/hets/json_parser.rb
@@ -1,5 +1,7 @@
 module Hets
   class JSONParser
+    class ParserError < ::StandardError; end
+
     attr_accessor :resource, :callback, :parser
     attr_accessor :hierarchy, :keys_hierarchy
 
@@ -14,6 +16,8 @@ module Hets
       input = resource.respond_to?(:close) ? resource : File.open(resource)
       parser << input.read
       input.close
+    rescue JSON::Stream::ParserError => e
+      raise ParserError, e.message
     end
 
     protected

--- a/lib/hets/prove/importer.rb
+++ b/lib/hets/prove/importer.rb
@@ -31,6 +31,16 @@ module Hets
           parser.parse(callback: callback)
           callback.process(:all, :end)
         end
+      rescue Hets::JSONParser::ParserError => e
+        io.rewind
+        if io.read(16) == 'nothing to prove'
+          pa_configuration = proof_attempts.first.proof_attempt_configuration
+          msg_lines = ['Hets found no theorems to prove']
+          msg_lines << "Configuration: #{pa_configuration.inspect}"
+          raise Hets::Errors::HetsFileError, msg_lines.join("\n")
+        else
+          raise
+        end
       end
 
       private

--- a/spec/lib/collective_proof_attempt_spec.rb
+++ b/spec/lib/collective_proof_attempt_spec.rb
@@ -54,53 +54,56 @@ describe CollectiveProofAttempt do
         [cpa.send(:ontology_version), *theorems, *proof_attempts].each do |obj|
           allow(obj).to receive(:update_state!).and_call_original
         end
-        cpa.run
       end
 
-      it 'set state of theorem to processing' do
-        expect(theorem).to have_received(:update_state!).with(:processing)
-      end
+      context 'without exception' do
+        before { cpa.run }
 
-      it 'set state of cpa.ontology_version to processing' do
-        expect(cpa.send(:ontology_version)).
-          to have_received(:update_state!).with(:processing)
-      end
+        it 'set state of theorem to processing' do
+          expect(theorem).to have_received(:update_state!).with(:processing)
+        end
 
-      it 'cpa.ontology_version equals ontology_version' do
-        expect(cpa.send(:ontology_version)).to eq(ontology_version)
-      end
+        it 'set state of cpa.ontology_version to processing' do
+          expect(cpa.send(:ontology_version)).
+            to have_received(:update_state!).with(:processing)
+        end
 
-      it 'set state of proof_attempt to processing' do
-        expect(proof_attempt).
-          to have_received(:update_state!).with(:processing)
-      end
+        it 'cpa.ontology_version equals ontology_version' do
+          expect(cpa.send(:ontology_version)).to eq(ontology_version)
+        end
 
-      it "proof_attempt's proof_status is THM" do
-        expect(proof_attempt.reload.proof_status).to eq(status_proven)
-      end
+        it 'set state of proof_attempt to processing' do
+          expect(proof_attempt).
+            to have_received(:update_state!).with(:processing)
+        end
 
-      it "theorem's proof_status is THM" do
-        expect(theorem.reload.proof_status).to eq(status_proven)
-      end
+        it "proof_attempt's proof_status is THM" do
+          expect(proof_attempt.reload.proof_status).to eq(status_proven)
+        end
 
-      it "proof_attempt2's proof_status is OPN" do
-        expect(proof_attempt2.reload.proof_status).to eq(status_open)
-      end
+        it "theorem's proof_status is THM" do
+          expect(theorem.reload.proof_status).to eq(status_proven)
+        end
 
-      it "theorem2's proof_status is OPN" do
-        expect(theorem2.reload.proof_status).to eq(status_open)
-      end
+        it "proof_attempt2's proof_status is OPN" do
+          expect(proof_attempt2.reload.proof_status).to eq(status_open)
+        end
 
-      it 'state of proof_attempt is done in the end' do
-        expect(proof_attempt.reload.state).to eq('done')
-      end
+        it "theorem2's proof_status is OPN" do
+          expect(theorem2.reload.proof_status).to eq(status_open)
+        end
 
-      it 'state of theorem is done in the end' do
-        expect(theorem.reload.state).to eq('done')
-      end
+        it 'state of proof_attempt is done in the end' do
+          expect(proof_attempt.reload.state).to eq('done')
+        end
 
-      it "ontology_version's state is done in the end" do
-        expect(ontology_version.reload.state).to eq('done')
+        it 'state of theorem is done in the end' do
+          expect(theorem.reload.state).to eq('done')
+        end
+
+        it "ontology_version's state is done in the end" do
+          expect(ontology_version.reload.state).to eq('done')
+        end
       end
     end
   end
@@ -131,51 +134,54 @@ describe CollectiveProofAttempt do
         [cpa.send(:ontology_version), *proof_attempts].each do |obj|
           allow(obj).to receive(:update_state!).and_call_original
         end
-        cpa.run
       end
 
-      it 'set state of cpa.ontology_version to processing' do
-        expect(cpa.send(:ontology_version)).
-          to have_received(:update_state!).with(:processing)
-      end
+      context 'without exception' do
+        before { cpa.run }
 
-      it 'cpa.ontology_version equals ontology_version' do
-        expect(cpa.send(:ontology_version)).to eq(ontology_version)
-      end
-
-      it 'set state of each proof_attempt to processing' do
-        proof_attempts.each do |proof_attempt|
-          expect(proof_attempt).
+        it 'set state of cpa.ontology_version to processing' do
+          expect(cpa.send(:ontology_version)).
             to have_received(:update_state!).with(:processing)
         end
-      end
 
-      it "each proof_attempt's proof_status is THM" do
-        proof_attempts.each do |proof_attempt|
-          expect(proof_attempt.reload.proof_status).to eq(status_proven)
+        it 'cpa.ontology_version equals ontology_version' do
+          expect(cpa.send(:ontology_version)).to eq(ontology_version)
         end
-      end
 
-      it "each theorem's proof_status is THM" do
-        theorems.each do |theorem|
-          expect(theorem.reload.proof_status).to eq(status_proven)
+        it 'set state of each proof_attempt to processing' do
+          proof_attempts.each do |proof_attempt|
+            expect(proof_attempt).
+              to have_received(:update_state!).with(:processing)
+          end
         end
-      end
 
-      it "each proof_attempt's is done in the end" do
-        proof_attempts.each do |proof_attempt|
-          expect(proof_attempt.reload.state).to eq('done')
+        it "each proof_attempt's proof_status is THM" do
+          proof_attempts.each do |proof_attempt|
+            expect(proof_attempt.reload.proof_status).to eq(status_proven)
+          end
         end
-      end
 
-      it "each theorem's state is done in the end" do
-        theorems.each do |theorem|
-          expect(theorem.reload.state).to eq('done')
+        it "each theorem's proof_status is THM" do
+          theorems.each do |theorem|
+            expect(theorem.reload.proof_status).to eq(status_proven)
+          end
         end
-      end
 
-      it "ontology_version's state is done in the end" do
-        expect(ontology_version.reload.state).to eq('done')
+        it "each proof_attempt's is done in the end" do
+          proof_attempts.each do |proof_attempt|
+            expect(proof_attempt.reload.state).to eq('done')
+          end
+        end
+
+        it "each theorem's state is done in the end" do
+          theorems.each do |theorem|
+            expect(theorem.reload.state).to eq('done')
+          end
+        end
+
+        it "ontology_version's state is done in the end" do
+          expect(ontology_version.reload.state).to eq('done')
+        end
       end
     end
   end


### PR DESCRIPTION
This shall fix #1280. Hets errors are recognized and the states are updated properly.

This only handles errors in the backend. Views for errors and states are part of #1283.