### PR TITLE
Add gitter support for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,12 @@ services:
 
 notifications:
   email: false
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/1e9d1f1a0e20c6c7c6ba
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: false     # default: false
 
 before_install:
   - 'export DISPLAY=:99.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ notifications:
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/1e9d1f1a0e20c6c7c6ba
-    on_success: change  # options: [always|never|change] default: always
+    on_success: always  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
-    on_start: false     # default: false
+    on_start: true     # default: false
 
 before_install:
   - 'export DISPLAY=:99.0'


### PR DESCRIPTION
Allows gitter to add notifications for travis actions (test-start, -success, -fail) into the gitter chat.