### PR TITLE
Fix error handling of BaseEvaluator

### DIFF
--- a/lib/hets/base_evaluator.rb
+++ b/lib/hets/base_evaluator.rb
@@ -57,9 +57,6 @@ module Hets
         default_method_name = :"#{node_type}_#{order}"
         self.send(default_method_name, *args) if respond_to?(default_method_name)
       end
-    rescue Exception => e
-      cancel_concurrency_handling_on_error
-      raise e
     end
 
     protected

--- a/lib/hets/concurrent_evaluator.rb
+++ b/lib/hets/concurrent_evaluator.rb
@@ -12,6 +12,13 @@ module Hets
     delegate *concurrency_delegates, to: :importer
     delegate :ontologies_count, to: :importer
 
+    def process(node_type, order, *args)
+      super(node_type, order, *args)
+    rescue Exception => e
+      cancel_concurrency_handling_on_error
+      raise e
+    end
+
     protected
     # As concurrency handling is usually performed across
     # multiple method calls during the parsing-chain,


### PR DESCRIPTION
When restructuring the evaluation, I forgot to put the rescue block
cancelling the concurrency handling into the ConcurrentEvaluator.