### PR TITLE
Add tactic script model

### DIFF
--- a/app/models/proof_attempt.rb
+++ b/app/models/proof_attempt.rb
@@ -9,6 +9,7 @@ class ProofAttempt < ActiveRecord::Base
   belongs_to :prover
   belongs_to :proof_attempt_configuration
   has_one :prover_output
+  has_one :tactic_script
   has_many :generated_axioms, dependent: :destroy
   has_and_belongs_to_many :used_axioms,
                           class_name: 'Axiom',
@@ -20,8 +21,7 @@ class ProofAttempt < ActiveRecord::Base
                           join_table: 'used_axioms_proof_attempts'
 
   attr_accessible :locid
-  attr_accessible :tactic_script,
-                  :time_taken,
+  attr_accessible :time_taken,
                   :number,
                   :state,
                   :state_updated_at,

--- a/app/models/tactic_script.rb
+++ b/app/models/tactic_script.rb
@@ -1,0 +1,10 @@
+class TacticScript < ActiveRecord::Base
+  belongs_to :proof_attempt
+  has_many :extra_options, class_name: TacticScriptExtraOption.to_s
+  attr_accessible :time_limit 
+
+  def to_s
+    {time_limit: time_limit,
+     extra_options: extra_options.map(&:option)}.to_json
+  end
+end

--- a/app/models/tactic_script_extra_option.rb
+++ b/app/models/tactic_script_extra_option.rb
@@ -1,0 +1,5 @@
+class TacticScriptExtraOption < ActiveRecord::Base
+  belongs_to :tactic_script
+  attr_accessible :option
+  validates :option, presence: true
+end

--- a/app/serializers/proof_attempt_serializer.rb
+++ b/app/serializers/proof_attempt_serializer.rb
@@ -10,8 +10,8 @@ class ProofAttemptSerializer < ApplicationSerializer
 
   attributes :iri,
              :number,
-             :used_prover,
-             :tactic_script
+             :used_prover
+  has_one :tactic_script
   has_one :prover_output, serializer: ProverOutputSerializer::Reference
   attributes :time_taken,
              :evaluation_state

--- a/app/serializers/tactic_script_serializer.rb
+++ b/app/serializers/tactic_script_serializer.rb
@@ -1,0 +1,7 @@
+class TacticScriptSerializer < ApplicationSerializer
+  attributes :time_limit, :extra_options
+
+  def extra_options
+    object.extra_options.map(&:option)
+  end
+end

--- a/db/migrate/20150409051342_create_tactic_scripts.rb
+++ b/db/migrate/20150409051342_create_tactic_scripts.rb
@@ -1,0 +1,9 @@
+class CreateTacticScripts < ActiveRecord::Migration
+  def change
+    create_table :tactic_scripts do |t|
+      t.references :proof_attempt, null: false
+      t.integer :time_limit
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20150409051349_create_tactic_script_extra_options.rb
+++ b/db/migrate/20150409051349_create_tactic_script_extra_options.rb
@@ -1,0 +1,9 @@
+class CreateTacticScriptExtraOptions < ActiveRecord::Migration
+  def change
+    create_table :tactic_script_extra_options do |t|
+      t.references :tactic_script, index: true, null: false
+      t.text :option, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20150409051440_move_tactic_script_from_proof_attempt_to_separate_model.rb
+++ b/db/migrate/20150409051440_move_tactic_script_from_proof_attempt_to_separate_model.rb
@@ -1,0 +1,41 @@
+class MoveTacticScriptFromProofAttemptToSeparateModel < ActiveRecord::Migration
+  def up
+    ProofAttempt.find_each do |proof_attempt|
+      tactic_script_json = ProofAttempt.where(id: proof_attempt).
+        pluck(:tactic_script).first
+      if tactic_script_json
+        tactic_script_hash = JSON.parse(tactic_script_json)
+        tactic_script = TacticScript.new
+        tactic_script.
+          update_attributes!({time_limit: tactic_script_hash['time_limit'].to_i,
+                              proof_attempt_id: proof_attempt.id},
+                             without_protection: true)
+        tactic_script_hash['extra_options'].try(:each) do |option|
+          extra_option = TacticScriptExtraOption.new
+          extra_option.
+            update_attributes!({option: option,
+                                tactic_script_id: tactic_script.id},
+                               without_protection: true)
+        end
+      end
+    end
+    remove_column :proof_attempts, :tactic_script
+  end
+
+  def down
+    add_column :proof_attempts, :tactic_script, :text
+    TacticScript.find_each do |tactic_script|
+      extra_options = TacticScriptExtraOption.
+        where(tactic_script_id: tactic_script).pluck(:option)
+      time_limit =
+        TacticScript.where(id: tactic_script).pluck(:time_limit).first
+      proof_attempt_id =
+        TacticScript.where(id: tactic_script).pluck(:proof_attempt_id).first
+      proof_attempt = ProofAttempt.find(proof_attempt_id)
+      tactic_script_json =
+        {time_limit: time_limit, extra_options: extra_options}.to_json
+      proof_attempt.update_attributes!({tactic_script: tactic_script_json},
+                                       without_protection: true)
+    end
+  end
+end

--- a/spec/factories/proof_attempt_factory.rb
+++ b/spec/factories/proof_attempt_factory.rb
@@ -1,11 +1,10 @@
 FactoryGirl.define do
   factory :proof_attempt do
-    tactic_script { 'SPASS Tactic Script' }
     time_taken { rand(5) }
 
     association :proof_status, factory: :proof_status_open
     association :theorem
-    association :prover
+    association :prover, :with_sequenced_name
 
     association :proof_attempt_configuration
 
@@ -13,11 +12,14 @@ FactoryGirl.define do
       proof_attempt.proof_attempt_configuration.ontology =
         proof_attempt.ontology
       proof_attempt.proof_attempt_configuration.save!
+      proof_attempt.tactic_script =
+        build :tactic_script, proof_attempt: proof_attempt
       create :prover_output, proof_attempt: proof_attempt
     end
 
     after(:create) do |proof_attempt|
       proof_attempt.prover_output.save!
+      proof_attempt.tactic_script.save!
     end
   end
 end

--- a/spec/factories/tactic_script_extra_options_factory.rb
+++ b/spec/factories/tactic_script_extra_options_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :tactic_script_extra_option do
+    option { Faker::Lorem.word }
+    association :tactic_script
+  end
+end

--- a/spec/factories/tactic_script_factory.rb
+++ b/spec/factories/tactic_script_factory.rb
@@ -1,0 +1,18 @@
+FactoryGirl.define do
+  factory :tactic_script do
+    time_limit { 1 }
+    association :proof_attempt
+
+    trait :with_extra_options do
+      after(:build) do |tactic_script|
+        extra_options = [1,2].map { build :tactic_script_extra_options }
+        tactic_script.extra_options = extra_options
+      end
+
+      after(:create) do |tactic_script|
+        tactic_script.extra_options.each(&:save!)
+        tactic_script.save!
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr/api/json-schemata/ontology/proof_attempt.yml
+++ b/spec/fixtures/vcr/api/json-schemata/ontology/proof_attempt.yml
@@ -21,17 +21,17 @@ http_interactions:
       Server:
       - nginx/1.6.2
       Date:
-      - Sat, 04 Apr 2015 19:37:35 GMT
+      - Thu, 09 Apr 2015 13:36:30 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '2171'
+      - '2165'
       Last-Modified:
-      - Sat, 04 Apr 2015 10:02:53 GMT
+      - Thu, 09 Apr 2015 12:13:31 GMT
       Connection:
       - keep-alive
       Etag:
-      - '"551fb6cd-87b"'
+      - '"55266ceb-875"'
       Strict-Transport-Security:
       - max-age=31536000
       X-Frame-Options:
@@ -61,10 +61,7 @@ http_interactions:
               "description": "The name of the prover used during this attempt",
               "type": "string"
             },
-            "tactic_script": {
-              "description": "The tactic script of this attempt",
-              "type": "string"
-            },
+            "tactic_script": { "$ref": "https://masterthesis.rightsrestricted.com/ontohub/tactic_script.json" },
             "prover_output": {
               "oneOf": [
                 { "$ref": "references.json#/definitions/prover_output" },
@@ -116,7 +113,72 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Sat, 04 Apr 2015 19:37:35 GMT
+  recorded_at: Thu, 09 Apr 2015 13:36:30 GMT
+- request:
+    method: get
+    uri: https://masterthesis.rightsrestricted.com/ontohub/tactic_script.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.2
+      Date:
+      - Thu, 09 Apr 2015 13:36:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '623'
+      Last-Modified:
+      - Thu, 09 Apr 2015 12:31:34 GMT
+      Connection:
+      - keep-alive
+      Etag:
+      - '"55267126-26f"'
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - DENY
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "https://masterthesis.rightsrestricted.com/ontohub/tactic_script.json#",
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "title": "Tactic Script",
+          "description": "The tactic script generated in a proof attempt",
+          "type": "object",
+          "properties": {
+            "time_limit": {
+              "description": "The time limit in seconds",
+              "type": "integer"
+            },
+            "extra_options": {
+              "description": "Additional prover-specific options",
+              "type": "array",
+              "items": {
+                "description": "A prover-specific option",
+                "type": "string"
+              }
+            }
+          },
+          "required": [ "time_limit" ]
+        }
+    http_version: 
+  recorded_at: Thu, 09 Apr 2015 13:36:30 GMT
 - request:
     method: get
     uri: https://masterthesis.rightsrestricted.com/ontohub/references.json
@@ -138,7 +200,7 @@ http_interactions:
       Server:
       - nginx/1.6.2
       Date:
-      - Sat, 04 Apr 2015 19:37:36 GMT
+      - Thu, 09 Apr 2015 13:36:30 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -397,5 +459,5 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Sat, 04 Apr 2015 19:37:36 GMT
+  recorded_at: Thu, 09 Apr 2015 13:36:30 GMT
 recorded_with: VCR 2.9.3

--- a/spec/models/proof_attempt_spec.rb
+++ b/spec/models/proof_attempt_spec.rb
@@ -6,6 +6,7 @@ describe ProofAttempt do
     it { should belong_to(:proof_status) }
     it { should belong_to(:proof_attempt_configuration) }
     it { should have_one(:prover_output) }
+    it { should have_one(:tactic_script) }
   end
 
   let(:proof_attempt) { create :proof_attempt }

--- a/spec/models/tactic_script_extra_option_spec.rb
+++ b/spec/models/tactic_script_extra_option_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe TacticScriptExtraOption do
+  context 'Associations' do
+    it { should belong_to(:tactic_script) }
+  end
+
+  context 'validations' do
+    let(:tseo) { create :tactic_script_extra_option }
+
+    it 'is valid' do
+      expect(tseo).to be_valid
+    end
+
+    context 'without option' do
+      before { tseo.option = nil }
+
+      it 'is invalid' do
+        expect(tseo).to be_invalid
+      end
+    end
+  end
+end

--- a/spec/models/tactic_script_spec.rb
+++ b/spec/models/tactic_script_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe TacticScript do
+  context 'Associations' do
+    it { should belong_to(:proof_attempt) }
+    it { should have_many(:extra_options) }
+  end
+end


### PR DESCRIPTION
This gets rid of storing the tactic script as json in the database by introducing a model for it.

~~The branch of this pull request is based on:~~
* ~~1256-add_proving_related_serializers (#1289)~~

~~The first commit of this branch is:~~
~~Add model: TacticScript.	0c2ba71~~