### PR TITLE
1284 show theorem and proof attempt state

### DIFF
--- a/app/assets/javascripts/evaluation-state.js.coffee
+++ b/app/assets/javascripts/evaluation-state.js.coffee
@@ -1,4 +1,4 @@
-containers    = $(".ontology-version-state")
+containers    = $(".evaluation-state")
 final_states  = ["done", "failed"]
 poll_time = 3000 # milliseconds
 

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -56,6 +56,7 @@ $grid-float-breakpoint: 992px
 @import relationList
 @import repository
 @import sentences
+@import state
 @import status
 @import pagination
 

--- a/app/assets/stylesheets/ontology.css.sass
+++ b/app/assets/stylesheets/ontology.css.sass
@@ -14,11 +14,6 @@ th.right
 td.left
   text-align: left
 
-div#ontology_infos
-  padding: 0.2em
-  max-width: 620px
-  +background-image(linear-gradient(#FFFFBB, #FFFFEE))
-
 #ontology-state
   span
     font-weight: bold

--- a/app/assets/stylesheets/state.css.sass
+++ b/app/assets/stylesheets/state.css.sass
@@ -1,0 +1,6 @@
+
+div#state_infos
+  padding: 0.2em
+  max-width: 620px
+  +background-image(linear-gradient(#FFFFBB, #FFFFEE))
+

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -87,7 +87,6 @@ class OntologiesController < InheritedResources::Base
 
   def retry_failed
     scope = end_of_association_chain
-
     if id = params[:id]
       # retry a specific ontology
       scope = scope.where(id: id)

--- a/app/controllers/proof_attempts_controller.rb
+++ b/app/controllers/proof_attempts_controller.rb
@@ -4,6 +4,12 @@ class ProofAttemptsController < InheritedResources::Base
   helper_method :ontology, :theorem
   before_filter :check_read_permissions
 
+  def retry_failed
+    check_write_permissions
+    resource.retry_failed
+    redirect_to locid_for(resource)
+  end
+
   protected
 
   def theorem
@@ -16,5 +22,9 @@ class ProofAttemptsController < InheritedResources::Base
 
   def check_read_permissions
     authorize! :show, ontology.repository
+  end
+
+  def check_write_permissions
+    authorize! :write, ontology.repository
   end
 end

--- a/app/fake_records/proof.rb
+++ b/app/fake_records/proof.rb
@@ -128,11 +128,8 @@ class Proof < FakeRecord
   end
 
   def normalize_for_async_call(options_to_attempts_hash)
-    result = {}
-    options_to_attempts_hash.each do |prove_options, proof_attempts|
-      result[prove_options.to_json] = proof_attempts.map(&:id)
-    end
-    result
+    CollectiveProofAttemptWorker.
+      normalize_for_async_call(options_to_attempts_hash)
   end
 
   def prove(options_and_pa_ids)

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -88,7 +88,7 @@ module LinkHelper
   def ontology_link_to(resource)
     data_type, value = determine_image_type(resource)
     content_tag(:span, class: 'ontology_title') do
-      link_to resource, {}, data_type => value
+      link_to resource, locid_for(resource), data_type => value
     end
   end
 

--- a/app/helpers/ontology_helper.rb
+++ b/app/helpers/ontology_helper.rb
@@ -13,45 +13,4 @@ module OntologyHelper
   def show_evaluate?
     show_oops? #|| show_foo?
   end
-
-  def status_tag(resource)
-    version = resource.is_a?(Ontology) ? resource.current_version : resource
-
-    html_opts = {
-      class: 'ontology-version-state',
-      data: {
-        ontology_version_id: version.id,
-        uri: locid_for(version),
-        state: version.state,
-      }
-    }
-    content_tag(:small, html_opts) do
-      status(version)
-    end
-  end
-
-  def status(resource)
-    html = content_tag :span, resource.state
-
-    if %w(pending fetching processing).include? resource.state
-      html << " " << image_tag('spinner-16x16.gif', class: 'spinner')
-    end
-
-    if resource.state == 'failed' and resource.is_a? Ontology
-      version = resource.versions.last
-
-      link = ' ('
-      link << link_to('error',
-        [resource.repository, resource, :ontology_versions],
-        :'data-original-title' => version.last_error,
-        class: 'help'
-      )
-      link << ')'
-
-      html << content_tag(:span, link.html_safe, class: 'error')
-    end
-
-    html
-  end
-
 end

--- a/app/helpers/state_helper.rb
+++ b/app/helpers/state_helper.rb
@@ -1,0 +1,42 @@
+module StateHelper
+  def state_tag(resource)
+    resource = resource.is_a?(Ontology) ? resource.current_version : resource
+
+    html_opts = {
+      class: "evaluation-state",
+      data: {
+        klass: resource.class.to_s,
+        id: resource.id,
+        uri: locid_for(resource),
+        state: resource.state,
+      }
+    }
+    content_tag(:small, html_opts) do
+      state(resource)
+    end
+  end
+
+  def state(resource)
+    html = content_tag(:span, resource.state)
+
+    unless State::TERMINAL_STATES.include?(resource.state)
+      html << " " << image_tag('spinner-16x16.gif', class: 'spinner')
+    end
+
+    if resource.state == 'failed' && resource.is_a?(Ontology)
+      version = resource.versions.last
+
+      link = ' ('
+      link << link_to('error',
+        locid_for(resource, :ontology_versions),
+        :'data-original-title' => version.last_error,
+        class: 'help'
+      )
+      link << ')'
+
+      html << content_tag(:span, link.html_safe, class: 'error')
+    end
+
+    html
+  end
+end

--- a/app/helpers/state_helper.rb
+++ b/app/helpers/state_helper.rb
@@ -11,6 +11,11 @@ module StateHelper
     end
   end
 
+  def retriable?(resource)
+    resource.respond_to?(:retry_failed) ||
+      resource.class.respond_to?(:retry_failed)
+  end
+
   def state_tag(resource)
     resource = resource.is_a?(Ontology) ? resource.current_version : resource
 

--- a/app/helpers/state_helper.rb
+++ b/app/helpers/state_helper.rb
@@ -1,4 +1,16 @@
 module StateHelper
+  def retry_resource_chain
+    if resource.is_a?(Ontology)
+      [:retry_failed, *resource_chain]
+    elsif resource.is_a?(Theorem)
+      [:retry_failed, *resource_chain, resource]
+    elsif resource.is_a?(ProofAttempt)
+      [:retry_failed, *resource_chain, resource.theorem, resource]
+    else
+      [:retry_failed, *resource_chain]
+    end
+  end
+
   def state_tag(resource)
     resource = resource.is_a?(Ontology) ? resource.current_version : resource
 

--- a/app/models/proof_attempt.rb
+++ b/app/models/proof_attempt.rb
@@ -66,4 +66,19 @@ class ProofAttempt < ActiveRecord::Base
       ontology_version.save!
     end
   end
+
+  def retry_failed
+    options_to_attempts = CollectiveProofAttemptWorker.
+      normalize_for_async_call({prove_options_from_configuration => [self]})
+    CollectiveProofAttemptWorker.
+      perform_async(Theorem.to_s, theorem.id, options_to_attempts)
+  end
+
+  protected
+
+  def prove_options_from_configuration
+    pac = proof_attempt_configuration
+    Hets::ProveOptions.new({prover: pac.prover,
+                            timeout: pac.timeout})
+  end
 end

--- a/app/views/ontologies/_info.html.haml
+++ b/app/views/ontologies/_info.html.haml
@@ -33,7 +33,7 @@
   = render partial: '/ontologies/oops_state', locals: {resource: resource}
 
 - if resource.non_current_active_version?(current_user)
-  = render partial: '/ontologies/status'
+  = render partial: '/shared/state', locals: {resource: resource}
 
 %nav.nav_tab_level1
   %ul.nav.nav-tabs

--- a/app/views/ontologies/_status.html.haml
+++ b/app/views/ontologies/_status.html.haml
@@ -1,9 +1,0 @@
-#ontology_infos.well
-  .ontology-state
-    = state_tag(@ontology)
-
-    - if @ontology.state == 'failed'
-      = link_to 'Retry', [:retry_failed, @ontology.repository, @ontology], method: :post, class: 'btn btn-xs btn-primary', data: {disable_with: t(:wait)}
-    - elsif @ontology.state == 'pending'
-      .pending_message
-        Our servers are currently busy, please come back later.

--- a/app/views/ontologies/_status.html.haml
+++ b/app/views/ontologies/_status.html.haml
@@ -1,6 +1,6 @@
 #ontology_infos.well
   .ontology-state
-    = status_tag(@ontology)
+    = state_tag(@ontology)
 
     - if @ontology.state == 'failed'
       = link_to 'Retry', [:retry_failed, @ontology.repository, @ontology], method: :post, class: 'btn btn-xs btn-primary', data: {disable_with: t(:wait)}

--- a/app/views/ontology_versions/_ontology_version.html.haml
+++ b/app/views/ontology_versions/_ontology_version.html.haml
@@ -4,7 +4,7 @@
   %td= timestamp ontology_version
   %td= ontology_version.user ? fancy_link(ontology_version.user) : '-'
   %td
-    = status_tag(ontology_version)
+    = state_tag(ontology_version)
     - if updated_at = ontology_version.state_updated_at
       (#{timestamp updated_at})
     = format_error_message ontology_version.last_error

--- a/app/views/ontology_versions/_ontology_version.html.haml
+++ b/app/views/ontology_versions/_ontology_version.html.haml
@@ -3,9 +3,5 @@
   %td= link_to ontology_version.commit_oid[0..8], repository_ref_path(ontology_version.repository, ontology_version.commit_oid, :diff)
   %td= timestamp ontology_version
   %td= ontology_version.user ? fancy_link(ontology_version.user) : '-'
-  %td
-    = state_tag(ontology_version)
-    - if updated_at = ontology_version.state_updated_at
-      (#{timestamp updated_at})
-    = format_error_message ontology_version.last_error
+  %td= render partial: 'shared/state_tag', locals: {resource: ontology_version}
   %td= link_to 'Download', fancy_repository_path(resource_chain[0], path: ontology_version.path, ref: ontology_version.commit_oid, action: :download), class: 'btn btn-xs btn-default'

--- a/app/views/proof_attempts/index.html.haml
+++ b/app/views/proof_attempts/index.html.haml
@@ -17,12 +17,12 @@
   %table
     %thead
       %tr
-        %th Number
-        %th Date
-        %th Time taken
-        %th Prover
-        %th Status
-        %th State
+        %th= t('proof_attempts.index.number')
+        %th= t('proof_attempts.index.date')
+        %th= t('proof_attempts.index.time_taken')
+        %th= t('proof_attempts.index.prover')
+        %th= t('proof_attempts.index.status')
+        %th= t('state')
     - collection.latest.each do |proof_attempt|
       %tr
         %td= link_to proof_attempt.number, proof_attempt.locid

--- a/app/views/proof_attempts/index.html.haml
+++ b/app/views/proof_attempts/index.html.haml
@@ -15,15 +15,14 @@
     %thead
       %tr
         %th Number
-        %th Status
         %th Date
         %th Time taken
         %th Prover
+        %th Status
         %th State
     - collection.latest.each do |proof_attempt|
       %tr
         %td= link_to proof_attempt.number, proof_attempt.locid
-        %td= render partial: 'theorems/proof_status', locals: {proof_status: proof_attempt.proof_status}
         %td
           = link_to proof_attempt.locid do
             %span.timestamp= proof_attempt.created_at
@@ -31,4 +30,5 @@
           = proof_attempt.time_taken
           = t('proof_attempts.show.seconds')
         %td= proof_attempt.prover
+        %td= render partial: 'theorems/proof_status', locals: {proof_status: proof_attempt.proof_status}
         %td= state_tag(proof_attempt)

--- a/app/views/proof_attempts/index.html.haml
+++ b/app/views/proof_attempts/index.html.haml
@@ -19,6 +19,7 @@
         %th Date
         %th Time taken
         %th Prover
+        %th State
     - collection.latest.each do |proof_attempt|
       %tr
         %td= link_to proof_attempt.number, proof_attempt.locid
@@ -30,3 +31,4 @@
           = proof_attempt.time_taken
           = t('proof_attempts.show.seconds')
         %td= proof_attempt.prover
+        %td= state_tag(proof_attempt)

--- a/app/views/proof_attempts/index.html.haml
+++ b/app/views/proof_attempts/index.html.haml
@@ -6,6 +6,9 @@
   = link_to theorem, locid_for(theorem)
   = render partial: 'theorems/proof_status', locals: {proof_status: theorem.proof_status}
 
+- unless State::TERMINAL_STATES.include?(theorem.state)
+  = render partial: '/shared/state', locals: {resource: theorem}
+
 %h4 Proof Attempts
 = link_to t('theorems.show.prove'), [*resource_chain, theorem, :proofs, :new], class: 'btn btn-primary'
 - if collection.empty?

--- a/app/views/proof_attempts/index.html.haml
+++ b/app/views/proof_attempts/index.html.haml
@@ -34,4 +34,4 @@
           = t('proof_attempts.show.seconds')
         %td= proof_attempt.prover
         %td= render partial: 'theorems/proof_status', locals: {proof_status: proof_attempt.proof_status}
-        %td= state_tag(proof_attempt)
+        %td= render partial: 'shared/state_tag', locals: {resource: proof_attempt}

--- a/app/views/proof_attempts/show.html.haml
+++ b/app/views/proof_attempts/show.html.haml
@@ -48,4 +48,7 @@
 %pre= resource.tactic_script
 
 %h4= t('proof_attempts.show.prover_output')
-= link_to t('proof_attempts.show.prover_output'), locid_for(resource.prover_output)
+- if resource.prover_output
+  = link_to t('proof_attempts.show.prover_output'), locid_for(resource.prover_output)
+- else
+  = t('proof_attempts.show.no_prover_output')

--- a/app/views/proof_attempts/show.html.haml
+++ b/app/views/proof_attempts/show.html.haml
@@ -7,6 +7,9 @@
   = link_to resource.theorem, locid_for(resource.theorem, :proof_attempts)
   = render partial: 'theorems/proof_status', locals: {proof_status: resource.proof_status}
 
+%h4= t('state')
+= render partial: '/shared/state', locals: {resource: resource}
+
 %h4= t('proof_attempts.show.created_at')
 = resource.created_at
 

--- a/app/views/shared/_state.html.haml
+++ b/app/views/shared/_state.html.haml
@@ -2,7 +2,7 @@
   .ontology-state
     = state_tag(resource)
 
-    - if resource.state == 'failed' && resource.class.respond_to?(:retry_failed)
+    - if resource.state == 'failed' && retriable?(resource)
       = link_to 'Retry', retry_resource_chain, method: :post, class: 'btn btn-xs btn-primary', data: {disable_with: t(:wait)}
     - elsif resource.state == 'pending'
       .pending_message

--- a/app/views/shared/_state.html.haml
+++ b/app/views/shared/_state.html.haml
@@ -1,0 +1,9 @@
+#state_infos.well
+  .ontology-state
+    = state_tag(resource)
+
+    - if resource.state == 'failed' && resource.class.respond_to?(:retry_failed)
+      = link_to 'Retry', retry_resource_chain, method: :post, class: 'btn btn-xs btn-primary', data: {disable_with: t(:wait)}
+    - elsif resource.state == 'pending'
+      .pending_message
+        Our servers are currently busy, please come back later.

--- a/app/views/shared/_state.html.haml
+++ b/app/views/shared/_state.html.haml
@@ -7,3 +7,6 @@
     - elsif resource.state == 'pending'
       .pending_message
         Our servers are currently busy, please come back later.
+
+- if resource.state == 'failed' && resource.last_error
+  = format_error_message resource.last_error

--- a/app/views/shared/_state.html.haml
+++ b/app/views/shared/_state.html.haml
@@ -2,7 +2,7 @@
   .ontology-state
     = state_tag(resource)
 
-    - if resource.state == 'failed' && retriable?(resource)
+    - if resource.state == 'failed' && retriable?(resource) && can?(:write, repository)
       = link_to 'Retry', retry_resource_chain, method: :post, class: 'btn btn-xs btn-primary', data: {disable_with: t(:wait)}
     - elsif resource.state == 'pending'
       .pending_message

--- a/app/views/shared/_state_tag.html.haml
+++ b/app/views/shared/_state_tag.html.haml
@@ -1,0 +1,4 @@
+= state_tag(resource)
+- if updated_at = resource.state_updated_at
+  (#{timestamp updated_at})
+= format_error_message resource.last_error

--- a/app/views/theorems/_theorem.html.haml
+++ b/app/views/theorems/_theorem.html.haml
@@ -2,3 +2,4 @@
   %td= link_to theorem, locid_for(theorem, :proof_attempts)
   %td= format_for_view(theorem)
   %td= render partial: 'proof_status', locals: {proof_status: theorem.proof_status}
+  %td= state_tag(theorem)

--- a/app/views/theorems/index.html.haml
+++ b/app/views/theorems/index.html.haml
@@ -9,9 +9,9 @@
   %table.sentences
     %thead
       %tr
-        %th Name
-        %th Text
-        %th Proof Status
-        %th State
+        %th= t('theorems.index.name')
+        %th= t('theorems.index.text')
+        %th= t('theorems.index.proof_status')
+        %th= t('state')
     %tbody
       = render partial: 'theorem', collection: collection

--- a/app/views/theorems/index.html.haml
+++ b/app/views/theorems/index.html.haml
@@ -12,5 +12,6 @@
         %th Name
         %th Text
         %th Proof Status
+        %th State
     %tbody
       = render partial: 'theorem', collection: collection

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,7 @@ en:
     it would leave the system with too few admins.
     The threshold level is: %{minimal_count}.
   wait: 'Please wait …'
+  state: 'Evaluation State'
   relation_list:
     team_user:
       placeholder: Add users to your team
@@ -115,6 +116,9 @@ en:
   theorems:
     index:
       prove: Prove all theorems
+      name: Name
+      text: Text
+      proof_status: Proof Status
     show:
       prove: Prove this theorem
       proof_attemps_empty: There are no proof attempts.
@@ -142,6 +146,12 @@ en:
       starting_jobs: Proving jobs have been scheduled. Please come back in a few moments.
       invalid_resource: Invalid proving request.
   proof_attempts:
+    index:
+      number: Number
+      date: Date
+      time_taken: Time taken
+      prover: Prover
+      status: Proof Status
     show:
       head: Proof Attempt of
       created_at: Date
@@ -155,6 +165,7 @@ en:
       prover: Prover
       tactic_script: Tactic script
       prover_output: Prover output
+      no_prover_output: There is no prover output.
       seconds: seconds
   prover_outputs:
     show:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -597,6 +597,9 @@ is determined according to the id.
       resources :axioms, only: :index
       resources :theorems, only: :index do
         resources :proof_attempts, only: %i(index show) do
+          member do
+            post 'retry_failed' => 'proof_attempts#retry_failed'
+          end
           resource :prover_output, only: :show
         end
         get '/proofs/new', controller: :proofs, action: :new

--- a/features/step_definitions/ontology_state_steps.rb
+++ b/features/step_definitions/ontology_state_steps.rb
@@ -17,10 +17,11 @@ When(/^we change the state of the ontology to: (\w+)$/) do |state|
 end
 
 Then(/^the page should change the state on its own$/) do
-  el_css = 'small.ontology-version-state'
-  field = 'data-ontology-version-id'
+  el_css = 'small.evaluation-state'
+  field = 'data-id'
+  field_klass = 'data-klass'
   wait_for_ajax
-  within %{#{el_css}[#{field}="#{@ontology_version.id}"]} do
+  within %{#{el_css}[#{field}="#{@ontology_version.id}"][#{field_klass}="OntologyVersion"]} do
     expect(find('span')).to have_content(@state)
   end
 end

--- a/features/step_definitions/ontology_versions_steps.rb
+++ b/features/step_definitions/ontology_versions_steps.rb
@@ -11,6 +11,6 @@ end
 
 Then(/^i should see the corresponding versions$/) do
   id = @ontology.versions.first.id
-  selector = %(small.ontology-version-state[data-ontology-version-id="#{id}"])
+  selector = %(small.evaluation-state[data-id="#{id}"][data-klass="OntologyVersion"])
   expect(page).to have_css(selector)
 end

--- a/lib/collective_proof_attempt_worker.rb
+++ b/lib/collective_proof_attempt_worker.rb
@@ -5,6 +5,14 @@ class CollectiveProofAttemptWorker < BaseWorker
     perform_async_on_queue('hets', *args)
   end
 
+  def self.normalize_for_async_call(options_to_attempts_hash)
+    result = {}
+    options_to_attempts_hash.each do |prove_options, proof_attempts|
+      result[prove_options.to_json] = proof_attempts.map(&:id)
+    end
+    result
+  end
+
   # The resource is fetched from the database with klass and id, where
   # klass can be 'Theorem' or 'OntologyVersion'.
   #

--- a/spec/controllers/proof_attempts_controller_spec.rb
+++ b/spec/controllers/proof_attempts_controller_spec.rb
@@ -6,7 +6,7 @@ describe ProofAttemptsController do
   let!(:ontology) { theorem.ontology }
   let!(:repository) { ontology.repository }
 
-  context 'signed in with read access' do
+  context 'signed in with permissions' do
     let(:user) { create(:permission, item: repository).subject }
     before { sign_in user }
 
@@ -21,9 +21,30 @@ describe ProofAttemptsController do
       it { should respond_with :success }
       it { should render_template :show }
     end
+
+    context 'retry_failed' do
+      before do
+        allow_any_instance_of(ProofAttempt).to receive(:retry_failed)
+        expect_any_instance_of(ProofAttempt).to receive(:retry_failed)
+        proof_attempt.update_state!(:failed)
+        post :retry_failed,
+             repository_id: repository.to_param,
+             ontology_id: ontology.to_param,
+             theorem_id: theorem.to_param,
+             id: proof_attempt.to_param
+      end
+
+      it 'redirect to the root path' do
+        expect(response).to redirect_to(controllers_locid_for(proof_attempt))
+      end
+
+      it 'not set the flash' do
+        expect(flash[:alert]).to be(nil)
+      end
+    end
   end
 
-  context 'signed in without read access on private repository' do
+  context 'signed in without access on private repository' do
     let(:user) { create(:user) }
     before do
       repository.access = 'private_rw'
@@ -49,6 +70,27 @@ describe ProofAttemptsController do
         expect(response).to redirect_to(root_path)
       end
     end
+
+    context 'retry_failed' do
+      before do
+        allow_any_instance_of(ProofAttempt).to receive(:retry_failed)
+        expect_any_instance_of(ProofAttempt).not_to receive(:retry_failed)
+        proof_attempt.update_state!(:failed)
+        post :retry_failed,
+             repository_id: repository.to_param,
+             ontology_id: ontology.to_param,
+             theorem_id: theorem.to_param,
+             id: proof_attempt.to_param
+      end
+
+      it 'set the flash/alert' do
+        expect(flash[:alert]).to match(/not authorized/)
+      end
+
+      it 'redirect to the root path' do
+        expect(response).to redirect_to(root_path)
+      end
+    end
   end
 
   context 'not signed in' do
@@ -62,6 +104,27 @@ describe ProofAttemptsController do
       end
       it { should respond_with :success }
       it { should render_template :show }
+    end
+
+    context 'retry_failed' do
+      before do
+        allow_any_instance_of(ProofAttempt).to receive(:retry_failed)
+        expect_any_instance_of(ProofAttempt).not_to receive(:retry_failed)
+        proof_attempt.update_state!(:failed)
+        post :retry_failed,
+             repository_id: repository.to_param,
+             ontology_id: ontology.to_param,
+             theorem_id: theorem.to_param,
+             id: proof_attempt.to_param
+      end
+
+      it 'set the flash/alert' do
+        expect(flash[:alert]).to match(/not authorized/)
+      end
+
+      it 'redirect to the root path' do
+        expect(response).to redirect_to(root_path)
+      end
     end
   end
 end


### PR DESCRIPTION
This shall fix #1284. It also adds retry functionality to failed proof attempts.

~~The branch of this pull request is based on:~~
* ~~add_tactic_script_model (#1311)~~
* ~~1256-add_proving_related_serializers (#1289)~~

~~The first commit of this branch is:~~
~~Move state helper to own module and generalize it.	33f017c~~