### PR TITLE
1283 improve proving related views

### DIFF
--- a/app/assets/javascripts/evaluation-state.js.coffee
+++ b/app/assets/javascripts/evaluation-state.js.coffee
@@ -29,9 +29,9 @@ update = (container) ->
           container.find(".spinner").
             replaceWith($('<a />').
               attr('href', document.location.href).
-              attr('class', 'btn btn-info btn-sm').
+              attr('class', 'btn btn-xs btn-primary').
               append($('<i />').
-                attr('class', 'icon-refresh')).
+                attr('class', 'fa fa-refresh')).
               text('refresh'))
         else
           enqueue(container)

--- a/app/assets/stylesheets/proof-attempt.css.sass
+++ b/app/assets/stylesheets/proof-attempt.css.sass
@@ -23,6 +23,13 @@ ul.sentences-list
 .proof-attempt-result > .tactic-script .panel-body > ul
   list-style: none
   padding: 0
+  margin-bottom: 0
   > li > ul
     list-style: none
     padding-left: 2em
+
+.panel-heading-small
+  padding: 5px 7px
+
+.panel-body-small
+  padding: 5px 7px

--- a/app/assets/stylesheets/proof-attempt.css.sass
+++ b/app/assets/stylesheets/proof-attempt.css.sass
@@ -12,7 +12,7 @@ ul.sentences-list
   li:last-child:after
     content: ""
 
-.proof-attempt-configuration
+.proof-attempt-configuration, .proof-attempt-result
   > div
     @extend .col-md-4
     display: inline

--- a/app/assets/stylesheets/proof-attempt.css.sass
+++ b/app/assets/stylesheets/proof-attempt.css.sass
@@ -1,4 +1,4 @@
-ul.used-axioms
+ul.sentences-list
   padding-left: 0
   display: inline
   list-style: none
@@ -11,3 +11,8 @@ ul.used-axioms
 
   li:last-child:after
     content: ""
+
+.proof-attempt-configuration
+  > div
+    @extend .col-md-4
+    display: inline

--- a/app/assets/stylesheets/proof-attempt.css.sass
+++ b/app/assets/stylesheets/proof-attempt.css.sass
@@ -16,3 +16,10 @@ ul.sentences-list
   > div
     @extend .col-md-4
     display: inline
+
+.proof-attempt-result > .tactic-script .panel-body > ul
+  list-style: none
+  padding: 0
+  > li > ul
+    list-style: none
+    padding-left: 2em

--- a/app/assets/stylesheets/proof-attempt.css.sass
+++ b/app/assets/stylesheets/proof-attempt.css.sass
@@ -14,7 +14,10 @@ ul.sentences-list
 
 .proof-attempt-configuration, .proof-attempt-result
   > div
-    @extend .col-md-4
+    @extend .col-lg-3
+    @extend .col-md-3
+    @extend .col-sm-4
+    @extend .col-xs-12
     display: inline
 
 .proof-attempt-result > .tactic-script .panel-body > ul

--- a/app/assets/stylesheets/state.css.sass
+++ b/app/assets/stylesheets/state.css.sass
@@ -8,4 +8,5 @@ div#state_infos
   border: 1px solid #c0c0c0
   +background-image(linear-gradient(#FFFFBB, #FFFFEE))
   margin-right: 1ex
-
+  .updated-at
+    font-weight: normal

--- a/app/assets/stylesheets/state.css.sass
+++ b/app/assets/stylesheets/state.css.sass
@@ -1,6 +1,11 @@
-
 div#state_infos
-  padding: 0.2em
-  max-width: 620px
+  @extend .label
+  color: black
+  padding: 3px 5px
+  font-size: 12px
+  line-height: 1.5
+  border-radius: 3px
+  border: 1px solid #c0c0c0
   +background-image(linear-gradient(#FFFFBB, #FFFFEE))
+  margin-right: 1ex
 

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -13,9 +13,6 @@ class OntologiesController < InheritedResources::Base
 
   respond_to :html, except: %i(show)
 
-  before_filter :check_write_permission, except: [:index, :show, :oops_state]
-  before_filter :check_read_permissions
-
   def index
     if in_repository?
       @search_response = paginate_for(parent.ontologies)

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -138,7 +138,7 @@ module NavigationHelper
   def in_subcontroller?(page, current_page)
     case page
     when :symbols
-      %w(classes sentences theorems).include?(controller_name)
+      %w(classes axioms theorems proof_attempts prover_outputs).include?(controller_name)
     when :metadata
       in_metadata?
     end

--- a/app/helpers/proof_attempts_helper.rb
+++ b/app/helpers/proof_attempts_helper.rb
@@ -1,0 +1,5 @@
+module ProofAttemptsHelper
+  def used_or_configured_prover(proof_attempt)
+    proof_attempt.prover || proof_attempt.proof_attempt_configuration.prover
+  end
+end

--- a/app/helpers/state_helper.rb
+++ b/app/helpers/state_helper.rb
@@ -28,7 +28,7 @@ module StateHelper
         state: resource.state,
       }
     }
-    content_tag(:small, html_opts) do
+    content_tag(:span, html_opts) do
       state(resource)
     end
   end

--- a/app/models/proof_attempt_configuration.rb
+++ b/app/models/proof_attempt_configuration.rb
@@ -21,6 +21,10 @@ class ProofAttemptConfiguration < ActiveRecord::Base
   validates :ontology, presence: true
   before_create :generate_locid
 
+  def empty?
+    [logic_mapping, prover, timeout, axioms, goals].all?(&:blank?)
+  end
+
   protected
 
   def self.find_with_locid(locid, _iri = nil)

--- a/app/models/tactic_script_extra_option.rb
+++ b/app/models/tactic_script_extra_option.rb
@@ -2,4 +2,8 @@ class TacticScriptExtraOption < ActiveRecord::Base
   belongs_to :tactic_script
   attr_accessible :option
   validates :option, presence: true
+
+  def to_s
+    option
+  end
 end

--- a/app/views/ontologies/_info.html.haml
+++ b/app/views/ontologies/_info.html.haml
@@ -48,7 +48,7 @@
     - @top_level_pages.each do |(page_title, page, controller)|
       %li{class: controller==current_page || in_subcontroller?(controller, current_page) ? 'active' : nil}
         = link_to page_title, page
-  - if %w(symbols axioms theorems children proof_attempts).include?(controller_name)
+  - if %w(symbols axioms theorems children proof_attempts prover_outputs).include?(controller_name)
     %nav.nav_tab_level2
       %ul.nav.nav-tabs
         - @symbols.each do |symbols|

--- a/app/views/proof_attempts/_configuration.html.haml
+++ b/app/views/proof_attempts/_configuration.html.haml
@@ -1,0 +1,23 @@
+- unless configuration.empty?
+  %h4= t('proof_attempts.configuration.headline')
+
+  .row.proof-attempt-configuration
+    - if configuration.timeout
+      .timeout
+        = render partial: 'item', locals: {title: t('proof_attempts.configuration.timeout.headline'), body: t('proof_attempts.configuration.timeout.text', timeout: configuration.timeout)}
+
+    - if configuration.prover
+      .prover
+        = render partial: 'item', locals: {title: t('proof_attempts.configuration.prover.headline'), body: configuration.prover}
+
+    - if configuration.logic_mapping
+      .logic_mapping
+        = render partial: 'item', locals: {title: t('proof_attempts.configuration.logic_mapping.headline'), body: configuration.logic_mapping}
+
+    - if configuration.axioms.present?
+      .axioms
+        = render partial: 'item', locals: {title: t('proof_attempts.configuration.axioms.headline'), body: render(partial: 'sentences_list', locals: {sentences: configuration.axioms})}
+
+    - if configuration.goals.present?
+      .goals
+        = render partial: 'item', locals: {title: t('proof_attempts.configuration.goals.headline'), body: render(partial: 'sentences_list', locals: {sentences: configuration.goals})}

--- a/app/views/proof_attempts/_item.html.haml
+++ b/app/views/proof_attempts/_item.html.haml
@@ -1,0 +1,6 @@
+.panel.panel-default
+  .panel-heading
+    %h5.panel-title
+      = title
+  .panel-body
+    = body

--- a/app/views/proof_attempts/_item.html.haml
+++ b/app/views/proof_attempts/_item.html.haml
@@ -1,6 +1,6 @@
 .panel.panel-default
-  .panel-heading
+  .panel-heading.panel-heading-small
     %h5.panel-title
       = title
-  .panel-body
+  .panel-body.panel-body-small
     = body

--- a/app/views/proof_attempts/_result.html.haml
+++ b/app/views/proof_attempts/_result.html.haml
@@ -1,36 +1,24 @@
 - if resource.state == 'done'
-  %h4= t('proof_attempts.show.time_taken')
-  = resource.time_taken
-  = t('proof_attempts.show.seconds')
+  %h4= t('proof_attempts.result.headline')
 
-  %h4= t('proof_attempts.show.used_axioms')
-  - if resource.used_axioms.empty?
-    = t('proof_attempts.show.no_used_axioms')
-  - else
-    = render partial: 'sentences_list', locals: {sentences: resource.used_axioms}
+  .row.proof-attempt-result
+    .time-taken
+      = render partial: 'item', locals: {title: t('proof_attempts.result.time_taken.headline'), body: t('proof_attempts.result.time_taken.text', time_taken: resource.time_taken)}
+    .used-prover
+      = render partial: 'item', locals: {title: t('proof_attempts.result.used_prover.headline'), body: resource.prover}
 
-  %h4= t('proof_attempts.show.used_theorems')
-  - if resource.used_theorems.empty?
-    = t('proof_attempts.show.no_used_theorems')
-  - else
-    = render partial: 'sentences_list', locals: {sentences: resource.used_theorems}
+    .prover-output
+      = render partial: 'item', locals: {title: t('proof_attempts.result.prover_output.headline'), body: link_to(t('proof_attempts.result.prover_output.link_text'), locid_for(resource.prover_output))}
 
-  %h4= t('proof_attempts.show.generated_axioms')
-  - if resource.generated_axioms.empty?
-    = t('proof_attempts.show.no_generated_axioms')
-  - else
-    %ul.sentences-list
-      - resource.generated_axioms.each do |axiom|
-        %li= axiom
+    - if resource.tactic_script
+      .tactic-script
+        = render partial: 'item', locals: {title: t('proof_attempts.result.tactic_script.headline'), body: resource.tactic_script}
 
-  %h4= t('proof_attempts.show.prover')
-  = resource.prover
+    .used-axioms
+      = render partial: 'item', locals: {title: t('proof_attempts.result.used_axioms.headline'), body: render(partial: 'sentences_list', locals: {sentences: resource.used_axioms})}
 
-  %h4= t('proof_attempts.show.tactic_script')
-  %pre= resource.tactic_script
+    .used-theorems
+      = render partial: 'item', locals: {title: t('proof_attempts.result.used_theorems.headline'), body: render(partial: 'sentences_list', locals: {sentences: resource.used_theorems})}
 
-  %h4= t('proof_attempts.show.prover_output')
-  - if resource.prover_output
-    = link_to t('proof_attempts.show.prover_output'), locid_for(resource.prover_output)
-  - else
-    = t('proof_attempts.show.no_prover_output')
+    .generated-axioms
+      = render partial: 'item', locals: {title: t('proof_attempts.result.generated_axioms.headline'), body: render(partial: 'sentences_list', locals: {sentences: resource.generated_axioms})}

--- a/app/views/proof_attempts/_result.html.haml
+++ b/app/views/proof_attempts/_result.html.haml
@@ -1,0 +1,36 @@
+- if resource.state == 'done'
+  %h4= t('proof_attempts.show.time_taken')
+  = resource.time_taken
+  = t('proof_attempts.show.seconds')
+
+  %h4= t('proof_attempts.show.used_axioms')
+  - if resource.used_axioms.empty?
+    = t('proof_attempts.show.no_used_axioms')
+  - else
+    = render partial: 'sentences_list', locals: {sentences: resource.used_axioms}
+
+  %h4= t('proof_attempts.show.used_theorems')
+  - if resource.used_theorems.empty?
+    = t('proof_attempts.show.no_used_theorems')
+  - else
+    = render partial: 'sentences_list', locals: {sentences: resource.used_theorems}
+
+  %h4= t('proof_attempts.show.generated_axioms')
+  - if resource.generated_axioms.empty?
+    = t('proof_attempts.show.no_generated_axioms')
+  - else
+    %ul.sentences-list
+      - resource.generated_axioms.each do |axiom|
+        %li= axiom
+
+  %h4= t('proof_attempts.show.prover')
+  = resource.prover
+
+  %h4= t('proof_attempts.show.tactic_script')
+  %pre= resource.tactic_script
+
+  %h4= t('proof_attempts.show.prover_output')
+  - if resource.prover_output
+    = link_to t('proof_attempts.show.prover_output'), locid_for(resource.prover_output)
+  - else
+    = t('proof_attempts.show.no_prover_output')

--- a/app/views/proof_attempts/_result.html.haml
+++ b/app/views/proof_attempts/_result.html.haml
@@ -12,7 +12,7 @@
 
     - if resource.tactic_script
       .tactic-script
-        = render partial: 'item', locals: {title: t('proof_attempts.result.tactic_script.headline'), body: resource.tactic_script}
+        = render partial: 'item', locals: {title: t('proof_attempts.result.tactic_script.headline'), body: render(partial: 'tactic_script', locals: {tactic_script: resource.tactic_script})}
 
     .used-axioms
       = render partial: 'item', locals: {title: t('proof_attempts.result.used_axioms.headline'), body: render(partial: 'sentences_list', locals: {sentences: resource.used_axioms})}

--- a/app/views/proof_attempts/_sentences_list.html.haml
+++ b/app/views/proof_attempts/_sentences_list.html.haml
@@ -1,0 +1,3 @@
+%ul.sentences-list
+  - sentences.each do |sentence|
+    %li= link_to sentence, locid_for(sentence)

--- a/app/views/proof_attempts/_sentences_list.html.haml
+++ b/app/views/proof_attempts/_sentences_list.html.haml
@@ -1,3 +1,9 @@
-%ul.sentences-list
-  - sentences.each do |sentence|
-    %li= link_to sentence, locid_for(sentence)
+- if sentences.any?
+  %ul.sentences-list
+    - sentences.each do |sentence|
+      - if sentence.is_a?(GeneratedAxiom)
+        %li= sentence
+      - else
+        %li= link_to sentence, locid_for(sentence)
+- else
+  = t('proof_attempts.show.no_sentences')

--- a/app/views/proof_attempts/_tactic_script.html.haml
+++ b/app/views/proof_attempts/_tactic_script.html.haml
@@ -1,0 +1,7 @@
+%ul
+  %li= t('proof_attempts.tactic_script.time_limit.text', time_limit: tactic_script.time_limit)
+  %li
+    = t('proof_attempts.tactic_script.extra_options.headline')
+    %ul
+      - tactic_script.extra_options.each do |extra_option|
+        %li= extra_option

--- a/app/views/proof_attempts/index.html.haml
+++ b/app/views/proof_attempts/index.html.haml
@@ -11,27 +11,26 @@
 
 %h4 Proof Attempts
 = link_to t('theorems.show.prove'), [*resource_chain, theorem, :proofs, :new], class: 'btn btn-primary'
-- if collection.empty?
-  = t('theorems.show.proof_attemps_empty')
-- else
-  %table
-    %thead
-      %tr
-        %th= t('proof_attempts.index.number')
-        %th= t('proof_attempts.index.date')
-        %th= t('proof_attempts.index.time_taken')
-        %th= t('proof_attempts.index.prover')
-        %th= t('proof_attempts.index.status')
-        %th= t('state')
-    - collection.latest.each do |proof_attempt|
-      %tr
-        %td= link_to proof_attempt.number, proof_attempt.locid
-        %td
-          = link_to proof_attempt.locid do
-            %span.timestamp= proof_attempt.created_at
-        %td
-          = proof_attempt.time_taken
-          = t('proof_attempts.show.seconds')
-        %td= proof_attempt.prover
-        %td= render partial: 'theorems/proof_status', locals: {proof_status: proof_attempt.proof_status}
-        %td= render partial: 'shared/state_tag', locals: {resource: proof_attempt}
+%div
+  - if collection.empty?
+    = t('theorems.show.proof_attemps_empty')
+  - else
+    %table
+      %thead
+        %tr
+          %th= t('proof_attempts.index.number')
+          %th= t('proof_attempts.index.date')
+          %th= t('proof_attempts.index.time_taken')
+          %th= t('proof_attempts.index.prover')
+          %th= t('proof_attempts.index.status')
+          %th= t('state')
+      - collection.latest.each do |proof_attempt|
+        %tr
+          %td= link_to proof_attempt.number, proof_attempt.locid
+          %td
+            = link_to proof_attempt.locid do
+              %span.timestamp= proof_attempt.created_at
+          %td= t('proof_attempts.result.time_taken.text', time_taken: proof_attempt.time_taken)
+          %td= proof_attempt.prover
+          %td= render partial: 'theorems/proof_status', locals: {proof_status: proof_attempt.proof_status}
+          %td= render partial: 'shared/state_tag', locals: {resource: proof_attempt}

--- a/app/views/proof_attempts/index.html.haml
+++ b/app/views/proof_attempts/index.html.haml
@@ -31,6 +31,6 @@
             = link_to proof_attempt.locid do
               %span.timestamp= proof_attempt.created_at
           %td= t('proof_attempts.result.time_taken.text', time_taken: proof_attempt.time_taken)
-          %td= proof_attempt.prover
+          %td= used_or_configured_prover(proof_attempt)
           %td= render partial: 'theorems/proof_status', locals: {proof_status: proof_attempt.proof_status}
           %td= render partial: 'shared/state_tag', locals: {resource: proof_attempt}

--- a/app/views/proof_attempts/show.html.haml
+++ b/app/views/proof_attempts/show.html.haml
@@ -10,42 +10,43 @@
 %div.timestamp= resource.updated_at
 = render partial: '/shared/state', locals: {resource: resource}
 
-%h4= t('proof_attempts.show.time_taken')
-= resource.time_taken
-= t('proof_attempts.show.seconds')
+- if resource.state == 'done'
+  %h4= t('proof_attempts.show.time_taken')
+  = resource.time_taken
+  = t('proof_attempts.show.seconds')
 
-%h4= t('proof_attempts.show.used_axioms')
-- if resource.used_axioms.empty?
-  = t('proof_attempts.show.no_used_axioms')
-- else
-  %ul.used-axioms
-    - resource.used_axioms.each do |axiom|
-      %li= link_to axiom, locid_for(axiom)
+  %h4= t('proof_attempts.show.used_axioms')
+  - if resource.used_axioms.empty?
+    = t('proof_attempts.show.no_used_axioms')
+  - else
+    %ul.used-axioms
+      - resource.used_axioms.each do |axiom|
+        %li= link_to axiom, locid_for(axiom)
 
-%h4= t('proof_attempts.show.used_theorems')
-- if resource.used_theorems.empty?
-  = t('proof_attempts.show.no_used_theorems')
-- else
-  %ul.used-axioms
-    - resource.used_theorems.each do |theorem|
-      %li= link_to theorem, locid_for(theorem)
+  %h4= t('proof_attempts.show.used_theorems')
+  - if resource.used_theorems.empty?
+    = t('proof_attempts.show.no_used_theorems')
+  - else
+    %ul.used-axioms
+      - resource.used_theorems.each do |theorem|
+        %li= link_to theorem, locid_for(theorem)
 
-%h4= t('proof_attempts.show.generated_axioms')
-- if resource.generated_axioms.empty?
-  = t('proof_attempts.show.no_generated_axioms')
-- else
-  %ul.used-axioms
-    - resource.generated_axioms.each do |axiom|
-      %li= axiom
+  %h4= t('proof_attempts.show.generated_axioms')
+  - if resource.generated_axioms.empty?
+    = t('proof_attempts.show.no_generated_axioms')
+  - else
+    %ul.used-axioms
+      - resource.generated_axioms.each do |axiom|
+        %li= axiom
 
-%h4= t('proof_attempts.show.prover')
-= resource.prover
+  %h4= t('proof_attempts.show.prover')
+  = resource.prover
 
-%h4= t('proof_attempts.show.tactic_script')
-%pre= resource.tactic_script
+  %h4= t('proof_attempts.show.tactic_script')
+  %pre= resource.tactic_script
 
-%h4= t('proof_attempts.show.prover_output')
-- if resource.prover_output
-  = link_to t('proof_attempts.show.prover_output'), locid_for(resource.prover_output)
-- else
-  = t('proof_attempts.show.no_prover_output')
+  %h4= t('proof_attempts.show.prover_output')
+  - if resource.prover_output
+    = link_to t('proof_attempts.show.prover_output'), locid_for(resource.prover_output)
+  - else
+    = t('proof_attempts.show.no_prover_output')

--- a/app/views/proof_attempts/show.html.haml
+++ b/app/views/proof_attempts/show.html.haml
@@ -11,40 +11,4 @@
 = render partial: '/shared/state', locals: {resource: resource}
 
 = render partial: 'configuration', locals: {configuration: resource.proof_attempt_configuration}
-
-- if resource.state == 'done'
-  %h4= t('proof_attempts.show.time_taken')
-  = resource.time_taken
-  = t('proof_attempts.show.seconds')
-
-  %h4= t('proof_attempts.show.used_axioms')
-  - if resource.used_axioms.empty?
-    = t('proof_attempts.show.no_used_axioms')
-  - else
-    = render partial: 'sentences_list', locals: {sentences: resource.used_axioms}
-
-  %h4= t('proof_attempts.show.used_theorems')
-  - if resource.used_theorems.empty?
-    = t('proof_attempts.show.no_used_theorems')
-  - else
-    = render partial: 'sentences_list', locals: {sentences: resource.used_theorems}
-
-  %h4= t('proof_attempts.show.generated_axioms')
-  - if resource.generated_axioms.empty?
-    = t('proof_attempts.show.no_generated_axioms')
-  - else
-    %ul.sentences-list
-      - resource.generated_axioms.each do |axiom|
-        %li= axiom
-
-  %h4= t('proof_attempts.show.prover')
-  = resource.prover
-
-  %h4= t('proof_attempts.show.tactic_script')
-  %pre= resource.tactic_script
-
-  %h4= t('proof_attempts.show.prover_output')
-  - if resource.prover_output
-    = link_to t('proof_attempts.show.prover_output'), locid_for(resource.prover_output)
-  - else
-    = t('proof_attempts.show.no_prover_output')
+= render partial: 'result', locals: {resource: resource}

--- a/app/views/proof_attempts/show.html.haml
+++ b/app/views/proof_attempts/show.html.haml
@@ -7,7 +7,6 @@
   = link_to resource.theorem, locid_for(resource.theorem, :proof_attempts)
   = render partial: 'theorems/proof_status', locals: {proof_status: resource.proof_status}
 
-%div.timestamp= resource.updated_at
 = render partial: '/shared/state', locals: {resource: resource}
 
 = render partial: 'configuration', locals: {configuration: resource.proof_attempt_configuration}

--- a/app/views/proof_attempts/show.html.haml
+++ b/app/views/proof_attempts/show.html.haml
@@ -7,11 +7,8 @@
   = link_to resource.theorem, locid_for(resource.theorem, :proof_attempts)
   = render partial: 'theorems/proof_status', locals: {proof_status: resource.proof_status}
 
-%h4= t('state')
+%div.timestamp= resource.updated_at
 = render partial: '/shared/state', locals: {resource: resource}
-
-%h4= t('proof_attempts.show.created_at')
-= resource.created_at
 
 %h4= t('proof_attempts.show.time_taken')
 = resource.time_taken

--- a/app/views/proof_attempts/show.html.haml
+++ b/app/views/proof_attempts/show.html.haml
@@ -10,6 +10,8 @@
 %div.timestamp= resource.updated_at
 = render partial: '/shared/state', locals: {resource: resource}
 
+= render partial: 'configuration', locals: {configuration: resource.proof_attempt_configuration}
+
 - if resource.state == 'done'
   %h4= t('proof_attempts.show.time_taken')
   = resource.time_taken
@@ -19,23 +21,19 @@
   - if resource.used_axioms.empty?
     = t('proof_attempts.show.no_used_axioms')
   - else
-    %ul.used-axioms
-      - resource.used_axioms.each do |axiom|
-        %li= link_to axiom, locid_for(axiom)
+    = render partial: 'sentences_list', locals: {sentences: resource.used_axioms}
 
   %h4= t('proof_attempts.show.used_theorems')
   - if resource.used_theorems.empty?
     = t('proof_attempts.show.no_used_theorems')
   - else
-    %ul.used-axioms
-      - resource.used_theorems.each do |theorem|
-        %li= link_to theorem, locid_for(theorem)
+    = render partial: 'sentences_list', locals: {sentences: resource.used_theorems}
 
   %h4= t('proof_attempts.show.generated_axioms')
   - if resource.generated_axioms.empty?
     = t('proof_attempts.show.no_generated_axioms')
   - else
-    %ul.used-axioms
+    %ul.sentences-list
       - resource.generated_axioms.each do |axiom|
         %li= axiom
 

--- a/app/views/proof_attempts/show.html.haml
+++ b/app/views/proof_attempts/show.html.haml
@@ -3,7 +3,7 @@
 = ontology_nav ontology, :theorems
 
 %h3
-  = t('proof_attempts.show.head')
+  = t('proof_attempts.show.headline')
   = link_to resource.theorem, locid_for(resource.theorem, :proof_attempts)
   = render partial: 'theorems/proof_status', locals: {proof_status: resource.proof_status}
 

--- a/app/views/shared/_state.html.haml
+++ b/app/views/shared/_state.html.haml
@@ -1,6 +1,8 @@
 #state_infos
   %span.ontology-state
     = state_tag(resource)
+  - if updated_at = resource.updated_at
+    %span.updated-at= raw "(#{timestamp(updated_at)})"
 
 - if resource.state == 'failed' && retriable?(resource) && can?(:write, repository)
   = link_to 'Retry', retry_resource_chain, method: :post, class: 'btn btn-xs btn-primary', data: {disable_with: t(:wait)}

--- a/app/views/shared/_state.html.haml
+++ b/app/views/shared/_state.html.haml
@@ -1,12 +1,12 @@
-#state_infos.well
-  .ontology-state
+#state_infos
+  %span.ontology-state
     = state_tag(resource)
 
-    - if resource.state == 'failed' && retriable?(resource) && can?(:write, repository)
-      = link_to 'Retry', retry_resource_chain, method: :post, class: 'btn btn-xs btn-primary', data: {disable_with: t(:wait)}
-    - elsif resource.state == 'pending'
-      .pending_message
-        Our servers are currently busy, please come back later.
+- if resource.state == 'failed' && retriable?(resource) && can?(:write, repository)
+  = link_to 'Retry', retry_resource_chain, method: :post, class: 'btn btn-xs btn-primary', data: {disable_with: t(:wait)}
+- elsif resource.state == 'pending'
+  .pending_message
+    Our servers are currently busy, please come back later.
 
 - if resource.state == 'failed' && resource.last_error
   = format_error_message resource.last_error

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -163,19 +163,8 @@ en:
       prover: Prover
       status: Proof Status
     show:
-      head: Proof Attempt of
-      time_taken: Time taken
-      used_axioms: Axioms Used
-      no_used_axioms: None
-      used_theorems: Previously Proven Theorems Used
-      no_used_theorems: None
-      generated_axioms: Generated Axioms Used
-      no_generated_axioms: None
-      prover: Prover
-      tactic_script: Tactic script
-      prover_output: Prover output
-      no_prover_output: There is no prover output.
-      seconds: seconds
+      headline: Proof Attempt of
+      no_sentences: None
     configuration:
       headline: Configuration
       timeout:
@@ -189,6 +178,24 @@ en:
         headline: Selected theorems to prove
       logic_mapping:
         headline: Selected logic mapping
+    result:
+      headline: Result
+      time_taken:
+        headline: Time taken
+        text: "%{time_taken} seconds"
+      used_prover:
+        headline: Used prover
+      tactic_script:
+        headline: Tactic script
+      used_axioms:
+        headline: Used axioms
+      used_theorems:
+        headline: Used theorems
+      generated_axioms:
+        headline: Generated axioms used
+      prover_output:
+        headline: Prover output
+        link_text: Show prover output
   prover_outputs:
     show:
       head_html: "Prover Output for %{theorem}'s %{proof_attempt_text}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,7 +164,6 @@ en:
       status: Proof Status
     show:
       head: Proof Attempt of
-      created_at: Date
       time_taken: Time taken
       used_axioms: Axioms Used
       no_used_axioms: None

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,6 +196,11 @@ en:
       prover_output:
         headline: Prover output
         link_text: Show prover output
+    tactic_script:
+      time_limit:
+        text: "Time limit: %{time_limit}"
+      extra_options:
+        headline: "Extra options:"
   prover_outputs:
     show:
       head_html: "Prover Output for %{theorem}'s %{proof_attempt_text}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -176,6 +176,19 @@ en:
       prover_output: Prover output
       no_prover_output: There is no prover output.
       seconds: seconds
+    configuration:
+      headline: Configuration
+      timeout:
+        headline: Timeout
+        text: "%{timeout} seconds"
+      prover:
+        headline: Prover
+      axioms:
+        headline: Selected axioms
+      goals:
+        headline: Selected theorems to prove
+      logic_mapping:
+        headline: Selected logic mapping
   prover_outputs:
     show:
       head_html: "Prover Output for %{theorem}'s %{proof_attempt_text}"

--- a/features/step_definitions/ontology_state_steps.rb
+++ b/features/step_definitions/ontology_state_steps.rb
@@ -17,7 +17,7 @@ When(/^we change the state of the ontology to: (\w+)$/) do |state|
 end
 
 Then(/^the page should change the state on its own$/) do
-  el_css = 'small.evaluation-state'
+  el_css = '.evaluation-state'
   field = 'data-id'
   field_klass = 'data-klass'
   wait_for_ajax

--- a/features/step_definitions/ontology_versions_steps.rb
+++ b/features/step_definitions/ontology_versions_steps.rb
@@ -11,6 +11,6 @@ end
 
 Then(/^i should see the corresponding versions$/) do
   id = @ontology.versions.first.id
-  selector = %(small.evaluation-state[data-id="#{id}"][data-klass="OntologyVersion"])
+  selector = %(.evaluation-state[data-id="#{id}"][data-klass="OntologyVersion"])
   expect(page).to have_css(selector)
 end


### PR DESCRIPTION
This shall fix #1283. The new proof attempt show page is much cleaner and hides information that is not existent. Also, if a configuration is present, its details are shown.

The branch of this pull request is based on:
* ~~1284-show_theorem_and_proof_attempt_state (#1312)~~
* ~~add_tactic_script_model (#1311)~~
* ~~1256-add_proving_related_serializers (#1289)~~

~~The first commit of this branch is:~~
~~Make state updater box look like a label.	d21a94f~~