### PR TITLE
Fix run seeds when offline

### DIFF
--- a/db/seeds/070-oops.rb
+++ b/db/seeds/070-oops.rb
@@ -1,9 +1,9 @@
 def handle_error(e, reason)
-  puts <<MSG
-  Could not seed "oops" because #{reason}.
-  #{e.class}: #{e.message}
-  Continuing with other data.
-MSG
+  puts <<-MSG.squish
+    Could not seed "oops" because #{reason}.
+    #{e.class}: #{e.message}
+    Continuing with other data.
+  MSG
 end
 
 # Add OOPS! requests and responses to pizza ontology.

--- a/db/seeds/070-oops.rb
+++ b/db/seeds/070-oops.rb
@@ -1,18 +1,32 @@
+def handle_error(e, reason)
+  puts <<MSG
+  Could not seed "oops" because #{reason}.
+  #{e.class}: #{e.message}
+  Continuing with other data.
+MSG
+end
+
 # Add OOPS! requests and responses to pizza ontology.
 ontology = Ontology.where(name: "Pizza").first!
 version  = ontology.versions.first
-if version
-  request  = version.build_request({state: 'done'}, without_protection: true)
-  request.save!
+begin
+  if version
+    request  = version.build_request({state: 'done'}, without_protection: true)
+    request.save!
 
-  responses = %w(Pitfall Warning Warning Suggestion).map do |type|
-    request.responses.create! \
-    name:         Faker::Name.name,
-    code:         0,
-    description:  Faker::Lorem.paragraph,
-    element_type: type
+    responses = %w(Pitfall Warning Warning Suggestion).map do |type|
+      request.responses.create! \
+      name:         Faker::Name.name,
+      code:         0,
+      description:  Faker::Lorem.paragraph,
+      element_type: type
+    end
   end
-end
-ontology.symbols.all.select do |symbol|
-  symbol.oops_responses = responses.sample(rand(responses.count))
+  ontology.symbols.all.select do |symbol|
+    symbol.oops_responses = responses.sample(rand(responses.count))
+  end
+rescue SocketError => e
+  handle_error(e, 'you are offline')
+rescue RestClient::Exception => e
+  handle_error(e, 'of a client error')
 end

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -25,8 +25,7 @@ def download_from_ontohub_meta(source_file, target_file)
     if system("wget -O #{temp_file} #{source_url}")
       filepath = temp_file
     else
-      puts
-        'No connection to ontohub.org. Using local file for the current task.'
+      puts 'No connection to ontohub.org. Using local file for the current task.'
     end
   end
   version = meta_repository.

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -18,13 +18,16 @@ def download_from_ontohub_meta(source_file, target_file)
   user = User.where(admin: true).first
   filepath = "#{Rails.root}/spec/fixtures/seeds/#{target_file}"
   basename = File.basename(filepath)
-  source_url =
-    "https://ontohub.org/repositories/meta/master/download/#{source_file}"
-  temp_file = Tempfile.new([target_file, File.extname(target_file)]).path
-  if system("wget -O #{temp_file} #{source_url}")
-    filepath = temp_file 
-  else
-    puts 'No connection to ontohub.org. Using fixture for the current task.'
+  if ENV['DOWNLOAD_FIXTURES']
+    source_url =
+      "https://ontohub.org/repositories/meta/master/download/#{source_file}"
+    temp_file = Tempfile.new([target_file, File.extname(target_file)]).path
+    if system("wget -O #{temp_file} #{source_url}")
+      filepath = temp_file
+    else
+      puts
+        'No connection to ontohub.org. Using local file for the current task.'
+    end
   end
   version = meta_repository.
     save_file(filepath, basename, "Add #{basename}.", user, do_not_parse: true)

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -16,13 +16,19 @@ end
 def download_from_ontohub_meta(source_file, target_file)
   meta_repository
   user = User.where(admin: true).first
-  filepath = "#{Rails.root}/spec/fixtures/ontologies/#{target_file}"
-  system("wget -O #{filepath} https://ontohub.org/repositories/meta/master/download/#{source_file}")
+  filepath = "#{Rails.root}/spec/fixtures/seeds/#{target_file}"
   basename = File.basename(filepath)
+  source_url =
+    "https://ontohub.org/repositories/meta/master/download/#{source_file}"
+  temp_file = Tempfile.new([target_file, File.extname(target_file)]).path
+  if system("wget -O #{temp_file} #{source_url}")
+    filepath = temp_file 
+  else
+    puts 'No connection to ontohub.org. Using fixture for the current task.'
+  end
   version = meta_repository.
     save_file(filepath, basename, "Add #{basename}.", user, do_not_parse: true)
   version.parse
-  system("rm #{filepath}")
   version.ontology
 end
 

--- a/script/rebuild-ontohub
+++ b/script/rebuild-ontohub
@@ -34,8 +34,7 @@ execute_or_die() {
 abort_unless_invoker_installed
 initialize_new_invoker_instance
 
-for i in "$@"
-do
+for i in "$@"; do
 case $i in
     -d|--download-fixtures)
     export DOWNLOAD_FIXTURES=true
@@ -50,8 +49,7 @@ case $i in
   shift
 done
 
-if [[ !($RESTART_INVOKER_ONLY) ]]
-then
+if [[ !($RESTART_INVOKER_ONLY) ]]; then
   execute_or_die "bundle exec rake elasticsearch:wipe"
   execute_or_die "bundle exec rake db:migrate:clean"
   execute_or_die "redis-cli flushdb"

--- a/script/rebuild-ontohub
+++ b/script/rebuild-ontohub
@@ -40,6 +40,9 @@ case $i in
     -d|--download-fixtures)
     export DOWNLOAD_FIXTURES=true
     ;;
+    -i|--invoker-only)
+    INVOKER_ONLY=true
+    ;;
     *)
     # unknown option
     ;;
@@ -47,8 +50,11 @@ case $i in
   shift
 done
 
-execute_or_die "bundle exec rake elasticsearch:wipe"
-execute_or_die "bundle exec rake db:migrate:clean"
-execute_or_die "redis-cli flushdb"
-execute_or_die "bundle exec rake git:compile_cp_keys"
-execute_or_die "bundle exec rake db:seed"
+if [[ !($INVOKER_ONLY) ]]
+then
+  execute_or_die "bundle exec rake elasticsearch:wipe"
+  execute_or_die "bundle exec rake db:migrate:clean"
+  execute_or_die "redis-cli flushdb"
+  execute_or_die "bundle exec rake git:compile_cp_keys"
+  execute_or_die "bundle exec rake db:seed"
+fi

--- a/script/rebuild-ontohub
+++ b/script/rebuild-ontohub
@@ -34,6 +34,19 @@ execute_or_die() {
 abort_unless_invoker_installed
 initialize_new_invoker_instance
 
+for i in "$@"
+do
+case $i in
+    -d|--download-fixtures)
+    export DOWNLOAD_FIXTURES=true
+    ;;
+    *)
+    # unknown option
+    ;;
+  esac
+  shift
+done
+
 execute_or_die "bundle exec rake elasticsearch:wipe"
 execute_or_die "bundle exec rake db:migrate:clean"
 execute_or_die "redis-cli flushdb"

--- a/script/rebuild-ontohub
+++ b/script/rebuild-ontohub
@@ -40,8 +40,8 @@ case $i in
     -d|--download-fixtures)
     export DOWNLOAD_FIXTURES=true
     ;;
-    -i|--invoker-only)
-    INVOKER_ONLY=true
+    -r|--restart)
+    RESTART_INVOKER_ONLY=true
     ;;
     *)
     # unknown option
@@ -50,7 +50,7 @@ case $i in
   shift
 done
 
-if [[ !($INVOKER_ONLY) ]]
+if [[ !($RESTART_INVOKER_ONLY) ]]
 then
   execute_or_die "bundle exec rake elasticsearch:wipe"
   execute_or_die "bundle exec rake db:migrate:clean"

--- a/spec/fixtures/seeds/categories.owl
+++ b/spec/fixtures/seeds/categories.owl
@@ -1,0 +1,1158 @@
+<?xml version="1.0"?>
+
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY owl2xml "http://www.w3.org/2006/12/owl2-xml#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY Domain_fields "https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#" >
+]>
+
+
+<rdf:RDF xmlns="https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#"
+     xml:base="https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl"
+     xmlns:Domain_fields="https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl2xml="http://www.w3.org/2006/12/owl2-xml#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <owl:Ontology rdf:about="https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Accounting_and_taxation -->
+
+    <owl:Class rdf:about="&Domain_fields;Accounting_and_taxation">
+        <rdfs:label rdf:datatype="&xsd;string">AccountingAndTaxation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Business_and_administration"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Agriculture -->
+
+    <owl:Class rdf:about="&Domain_fields;Agriculture">
+        <rdfs:label rdf:datatype="&xsd;string">Agriculture</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;AgricultureForestryFsheriesVeterinary"/>
+        <rdfs:comment rdf:datatype="&xsd;string">It includes ontologies that are dealing with the domain subjects related to agriculture.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#AgricultureForestryFsheriesVeterinary -->
+
+    <owl:Class rdf:about="&Domain_fields;AgricultureForestryFsheriesVeterinary">
+        <rdfs:label rdf:datatype="&xsd;string">AgricultureForestryFisheriesVeterinary</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Domain_Field"/>
+        <rdfs:comment rdf:datatype="&xsd;string">It includes ontologies that are dealing with the domain subjects related to agriculture, forestry, fisheries, and veterinary. A closer specification of an ontology domain can facilitate a more accurate ontology search, retrieval, and reuse. Thus, it is recommended to specify the domain-field as specific as possible.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Architecture_and_construction -->
+
+    <owl:Class rdf:about="&Domain_fields;Architecture_and_construction">
+        <rdfs:label rdf:datatype="&xsd;string">ArchitectureAndConstruction</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Engineering_manufacturing_and_construction"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Architecture_and_town_planning -->
+
+    <owl:Class rdf:about="&Domain_fields;Architecture_and_town_planning">
+        <rdfs:label rdf:datatype="&xsd;string">ArchitectureAndTownPlanning</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Architecture_and_construction"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Arts -->
+
+    <owl:Class rdf:about="&Domain_fields;Arts">
+        <rdfs:label rdf:datatype="&xsd;string">Arts</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Arts_and_humanities"/>
+        <rdfs:comment rdf:datatype="&xsd;string">It includes ontologies that are dealing with the domain subjects related to arts.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Arts_and_humanities -->
+
+    <owl:Class rdf:about="&Domain_fields;Arts_and_humanities">
+        <rdfs:label rdf:datatype="&xsd;string">ArtsAndHumanities</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Domain_Field"/>
+        <rdfs:comment rdf:datatype="&xsd;string">It includes ontologies that are dealing with the domain subjects related to arts and humanities.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Audio-visual_and_media_production -->
+
+    <owl:Class rdf:about="&Domain_fields;Audio-visual_and_media_production">
+        <rdfs:label rdf:datatype="&xsd;string">AudioVisualAndMediaProduction</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Arts"/>
+        <rdfs:comment rdf:datatype="&xsd;string">It includes ontologies that are dealing with the subjects related to the audio-visual domain and media production.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Biochemistry -->
+
+    <owl:Class rdf:about="&Domain_fields;Biochemistry">
+        <rdfs:label rdf:datatype="&xsd;string">Biochemistry</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Biology_broad"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Biology -->
+
+    <owl:Class rdf:about="&Domain_fields;Biology">
+        <rdfs:label rdf:datatype="&xsd;string">Biology</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Biology_broad"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Biology_broad -->
+
+    <owl:Class rdf:about="&Domain_fields;Biology_broad">
+        <rdfs:label rdf:datatype="&xsd;string">BiologyBroad</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Natural_science_mathematics_and_statistics"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Building_and_civil_engineering -->
+
+    <owl:Class rdf:about="&Domain_fields;Building_and_civil_engineering">
+        <rdfs:label rdf:datatype="&xsd;string">BuildingAndCivilEngineering</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Architecture_and_construction"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Business_administration_and_law -->
+
+    <owl:Class rdf:about="&Domain_fields;Business_administration_and_law">
+        <rdfs:label rdf:datatype="&xsd;string">BusinessAdministrationAndLaw</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Domain_Field"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Business_and_administration -->
+
+    <owl:Class rdf:about="&Domain_fields;Business_and_administration">
+        <rdfs:label rdf:datatype="&xsd;string">BusinessAndAdministration</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Business_administration_and_law"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Care_of_the_elderly_and_of_disabled_adults -->
+
+    <owl:Class rdf:about="&Domain_fields;Care_of_the_elderly_and_of_disabled_adults">
+        <rdfs:label rdf:datatype="&xsd;string">CareOfElderlyAndDisabledAdults</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Welfare"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Chemical_engineering_and_process -->
+
+    <owl:Class rdf:about="&Domain_fields;Chemical_engineering_and_process">
+        <rdfs:label rdf:datatype="&xsd;string">ChemicalEngineeringAndProcess</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Engineering_and_engineering_trade"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Chemistry -->
+
+    <owl:Class rdf:about="&Domain_fields;Chemistry">
+        <rdfs:label rdf:datatype="&xsd;string">Chemistry</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Physical_science"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Child_care_and_youth_services -->
+
+    <owl:Class rdf:about="&Domain_fields;Child_care_and_youth_services">
+        <rdfs:label rdf:datatype="&xsd;string">ChildCareAndYouthServices</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Welfare"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Community_sanitation -->
+
+    <owl:Class rdf:about="&Domain_fields;Community_sanitation">
+        <rdfs:label rdf:datatype="&xsd;string">CommunitySanitation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Hygiene_and_occupational_health_services"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Computer_science -->
+
+    <owl:Class rdf:about="&Domain_fields;Computer_science">
+        <rdfs:label rdf:datatype="&xsd;string">ComputerScience</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Information_and_Communication_Technology"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Computer_use -->
+
+    <owl:Class rdf:about="&Domain_fields;Computer_use">
+        <rdfs:label rdf:datatype="&xsd;string">ComputerUse</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Information_and_Communication_Technology_narrow"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Crop_and_livestock_production -->
+
+    <owl:Class rdf:about="&Domain_fields;Crop_and_livestock_production">
+        <rdfs:label rdf:datatype="&xsd;string">CropAndLivestockProduction</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Agriculture"/>
+        <rdfs:comment rdf:datatype="&xsd;string">It includes ontologies that are dealing with the domain subjects related to the crop and livestock production.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Database_and_network_design_and_administration -->
+
+    <owl:Class rdf:about="&Domain_fields;Database_and_network_design_and_administration">
+        <rdfs:label rdf:datatype="&xsd;string">DatabaseAndNetworkDesignAndAdministration</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Information_and_Communication_Technology_narrow"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Dentistry -->
+
+    <owl:Class rdf:about="&Domain_fields;Dentistry">
+        <rdfs:label rdf:datatype="&xsd;string">Dentistry</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Health"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Domain_Field -->
+
+    <owl:Class rdf:about="&Domain_fields;Domain_Field">
+        <rdfs:label rdf:datatype="&xsd;string">DomainField</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">The Domain Field consists of pre-defined domain-specific classes that cluster ontologies according to the domain-subject. As some ontologies cover several domains, an ontology can belong to more than one domain field. The OMV recommendation, to follow the DMOZ and ACM specifications of domain subject, is advised in those cases in which none of pre-defined fields captures the ontology subject, in which case such an ontology should be described in metadata during its upload.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Domestic_services -->
+
+    <owl:Class rdf:about="&Domain_fields;Domestic_services">
+        <rdfs:label rdf:datatype="&xsd;string">DomesticServices</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Personal_services"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Earth_science -->
+
+    <owl:Class rdf:about="&Domain_fields;Earth_science">
+        <rdfs:label rdf:datatype="&xsd;string">EarthScience</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Physical_science"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Economics -->
+
+    <owl:Class rdf:about="&Domain_fields;Economics">
+        <rdfs:label rdf:datatype="&xsd;string">Economics</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Social_and_behavioural_science"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Education -->
+
+    <owl:Class rdf:about="&Domain_fields;Education">
+        <rdfs:label rdf:datatype="&xsd;string">Education</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Domain_Field"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Education_narrow -->
+
+    <owl:Class rdf:about="&Domain_fields;Education_narrow">
+        <rdfs:label rdf:datatype="&xsd;string">EducationNarrow</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Education"/>
+        <rdfs:comment rdf:datatype="&xsd;string">It includes ontologies that are dealing with the education of teachers.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Education_science -->
+
+    <owl:Class rdf:about="&Domain_fields;Education_science">
+        <rdfs:label rdf:datatype="&xsd;string">EducationScience</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Education_narrow"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Electricity_and_energy -->
+
+    <owl:Class rdf:about="&Domain_fields;Electricity_and_energy">
+        <rdfs:label rdf:datatype="&xsd;string">ElectricityAndEnergy</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Engineering_and_engineering_trade"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Electronics_and_automation -->
+
+    <owl:Class rdf:about="&Domain_fields;Electronics_and_automation">
+        <rdfs:label rdf:datatype="&xsd;string">ElectronicsAndAutomation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Engineering_and_engineering_trade"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Engineering_and_engineering_trade -->
+
+    <owl:Class rdf:about="&Domain_fields;Engineering_and_engineering_trade">
+        <rdfs:label rdf:datatype="&xsd;string">EngineeringAndEngineeringTrade</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Engineering_manufacturing_and_construction"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Engineering_manufacturing_and_construction -->
+
+    <owl:Class rdf:about="&Domain_fields;Engineering_manufacturing_and_construction">
+        <rdfs:label rdf:datatype="&xsd;string">EngineeringManufacturingAndConstruction</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Domain_Field"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Environment -->
+
+    <owl:Class rdf:about="&Domain_fields;Environment">
+        <rdfs:label rdf:datatype="&xsd;string">Environment</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Natural_science_mathematics_and_statistics"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Environmental_protection_technology -->
+
+    <owl:Class rdf:about="&Domain_fields;Environmental_protection_technology">
+        <rdfs:label rdf:datatype="&xsd;string">EnvironmentalProtectionTechnology</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Engineering_and_engineering_trade"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Environmental_science -->
+
+    <owl:Class rdf:about="&Domain_fields;Environmental_science">
+        <rdfs:label rdf:datatype="&xsd;string">EnvironmentalScience</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Environment"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Fashion_interior_and_industrial_design -->
+
+    <owl:Class rdf:about="&Domain_fields;Fashion_interior_and_industrial_design">
+        <rdfs:label rdf:datatype="&xsd;string">FashionAndInteriorAndIndustrialDesign</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Arts"/>
+        <rdfs:comment rdf:datatype="&xsd;string">The class includes ontologies that deal with design in general, while further specification of the spatial design categories can be found under the class Space, subclass Design.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Finance_banking_and_insurance -->
+
+    <owl:Class rdf:about="&Domain_fields;Finance_banking_and_insurance">
+        <rdfs:label rdf:datatype="&xsd;string">FinanceBankingAndInsurance</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Business_and_administration"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Fine_arts -->
+
+    <owl:Class rdf:about="&Domain_fields;Fine_arts">
+        <rdfs:label rdf:datatype="&xsd;string">FineArts</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Arts"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Fisheries -->
+
+    <owl:Class rdf:about="&Domain_fields;Fisheries">
+        <rdfs:label rdf:datatype="&xsd;string">Fisheries</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;AgricultureForestryFsheriesVeterinary"/>
+        <rdfs:comment rdf:datatype="&xsd;string">It includes ontologies that are dealing with the domain subjects related to fisheries.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Food_processing -->
+
+    <owl:Class rdf:about="&Domain_fields;Food_processing">
+        <rdfs:label rdf:datatype="&xsd;string">FoodProcessing</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;ManufacturingAndProcessing"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Forestry -->
+
+    <owl:Class rdf:about="&Domain_fields;Forestry">
+        <rdfs:label rdf:datatype="&xsd;string">Forestry</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;AgricultureForestryFsheriesVeterinary"/>
+        <rdfs:comment rdf:datatype="&xsd;string">It includes ontologies that are dealing with the domain subjects related to forestry.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Glass_processing -->
+
+    <owl:Class rdf:about="&Domain_fields;Glass_processing">
+        <rdfs:label rdf:datatype="&xsd;string">GlassProcessing</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Material_processing"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Hair_and_beauty_services -->
+
+    <owl:Class rdf:about="&Domain_fields;Hair_and_beauty_services">
+        <rdfs:label rdf:datatype="&xsd;string">HairAndBeautyServices</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Personal_services"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Handicrafts -->
+
+    <owl:Class rdf:about="&Domain_fields;Handicrafts">
+        <rdfs:label rdf:datatype="&xsd;string">Handicrafts</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Arts"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Health -->
+
+    <owl:Class rdf:about="&Domain_fields;Health">
+        <rdfs:label rdf:datatype="&xsd;string">Health</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Health_and_welfare"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Health_and_welfare -->
+
+    <owl:Class rdf:about="&Domain_fields;Health_and_welfare">
+        <rdfs:label rdf:datatype="&xsd;string">HealthAndWelfare</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Domain_Field"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#History_and_archaeology -->
+
+    <owl:Class rdf:about="&Domain_fields;History_and_archaeology">
+        <rdfs:label rdf:datatype="&xsd;string">HistoryAndArchaeology</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Humanities"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Horticulture -->
+
+    <owl:Class rdf:about="&Domain_fields;Horticulture">
+        <rdfs:label rdf:datatype="&xsd;string">Horticulture</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Agriculture"/>
+        <rdfs:comment rdf:datatype="&xsd;string">It includes ontologies that are dealing with the domain subjects related to horticulture.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Hotel_restaurant_and_catering -->
+
+    <owl:Class rdf:about="&Domain_fields;Hotel_restaurant_and_catering">
+        <rdfs:label rdf:datatype="&xsd;string">HotelRestaurantAndCatering</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Personal_services"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Humanities -->
+
+    <owl:Class rdf:about="&Domain_fields;Humanities">
+        <rdfs:label rdf:datatype="&xsd;string">Humanities</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Arts_and_humanities"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Hygiene_and_occupational_health_services -->
+
+    <owl:Class rdf:about="&Domain_fields;Hygiene_and_occupational_health_services">
+        <rdfs:label rdf:datatype="&xsd;string">HygieneAndOccupationalHealthServices</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Services"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#ISO -->
+
+    <owl:Class rdf:about="&Domain_fields;ISO">
+        <rdfs:label rdf:datatype="&xsd;string">ISO</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Standard"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Imaging -->
+
+    <owl:Class rdf:about="&Domain_fields;Imaging">
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Method_and_research_technique"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Information_and_Communication_Technology -->
+
+    <owl:Class rdf:about="&Domain_fields;Information_and_Communication_Technology">
+        <rdfs:label rdf:datatype="&xsd;string">InformationAndCommunicationTechnology</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Domain_Field"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Information_and_Communication_Technology_narrow -->
+
+    <owl:Class rdf:about="&Domain_fields;Information_and_Communication_Technology_narrow">
+        <rdfs:label rdf:datatype="&xsd;string">InformationAndCommunicationTechnologyNarrow</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Information_and_Communication_Technology"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Journalism_and_information -->
+
+    <owl:Class rdf:about="&Domain_fields;Journalism_and_information">
+        <rdfs:label rdf:datatype="&xsd;string">JournalismAndInformation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Social_science_journalism_and_information"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Journalism_and_reporting -->
+
+    <owl:Class rdf:about="&Domain_fields;Journalism_and_reporting">
+        <rdfs:label rdf:datatype="&xsd;string">JournalismAndReporting</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Journalism_and_information"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Language -->
+
+    <owl:Class rdf:about="&Domain_fields;Language">
+        <rdfs:label rdf:datatype="&xsd;string">Language</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Arts_and_humanities"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Language_acquisition -->
+
+    <owl:Class rdf:about="&Domain_fields;Language_acquisition">
+        <rdfs:label rdf:datatype="&xsd;string">LanguageAcquisition</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Language"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Law -->
+
+    <owl:Class rdf:about="&Domain_fields;Law">
+        <rdfs:label rdf:datatype="&xsd;string">Law</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Business_administration_and_law"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Library_information_and_archive -->
+
+    <owl:Class rdf:about="&Domain_fields;Library_information_and_archive">
+        <rdfs:label rdf:datatype="&xsd;string">LibraryInformationAndArchive</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Journalism_and_information"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Literature_and_linguistics -->
+
+    <owl:Class rdf:about="&Domain_fields;Literature_and_linguistics">
+        <rdfs:label rdf:datatype="&xsd;string">LiteratureAndLinguistics</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Language"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Management_and_administration -->
+
+    <owl:Class rdf:about="&Domain_fields;Management_and_administration">
+        <rdfs:label rdf:datatype="&xsd;string">ManagementAndAdministration</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Business_and_administration"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#ManufacturingAndProcessing -->
+
+    <owl:Class rdf:about="&Domain_fields;ManufacturingAndProcessing">
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Engineering_manufacturing_and_construction"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Marketing_and_advertising -->
+
+    <owl:Class rdf:about="&Domain_fields;Marketing_and_advertising">
+        <rdfs:label rdf:datatype="&xsd;string">MarketingAndAdvertising</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Business_and_administration"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Material_processing -->
+
+    <owl:Class rdf:about="&Domain_fields;Material_processing">
+        <rdfs:label rdf:datatype="&xsd;string">MaterialProcessing</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;ManufacturingAndProcessing"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Mathematics -->
+
+    <owl:Class rdf:about="&Domain_fields;Mathematics">
+        <rdfs:label rdf:datatype="&xsd;string">Mathematics</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Mathematics_and_statistics"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Mathematics_and_statistics -->
+
+    <owl:Class rdf:about="&Domain_fields;Mathematics_and_statistics">
+        <rdfs:label rdf:datatype="&xsd;string">MathematicsAndStatistics</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Natural_science_mathematics_and_statistics"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Mechanics_and_metal_trade -->
+
+    <owl:Class rdf:about="&Domain_fields;Mechanics_and_metal_trade">
+        <rdfs:label rdf:datatype="&xsd;string">MechanicsAndMetalTrade</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Engineering_and_engineering_trade"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Medical_diagnostic_and_treatment_technology -->
+
+    <owl:Class rdf:about="&Domain_fields;Medical_diagnostic_and_treatment_technology">
+        <rdfs:label rdf:datatype="&xsd;string">MedicalDiagnosticAndTreatmentTechnology</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Health"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Medicine -->
+
+    <owl:Class rdf:about="&Domain_fields;Medicine">
+        <rdfs:label rdf:datatype="&xsd;string">Medicine</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Health"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Method_and_research_technique -->
+
+    <owl:Class rdf:about="&Domain_fields;Method_and_research_technique">
+        <rdfs:label rdf:datatype="&xsd;string">MethodAndResearchTechnique</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Standard_method_and_research_technique"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Military_and_defence -->
+
+    <owl:Class rdf:about="&Domain_fields;Military_and_defence">
+        <rdfs:label rdf:datatype="&xsd;string">MilitaryAndDefence</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Security_services"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Mining_and_extraction -->
+
+    <owl:Class rdf:about="&Domain_fields;Mining_and_extraction">
+        <rdfs:label rdf:datatype="&xsd;string">MiningAndExtraction</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;ManufacturingAndProcessing"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Motor_vehicle_ship_and_aircraft -->
+
+    <owl:Class rdf:about="&Domain_fields;Motor_vehicle_ship_and_aircraft">
+        <rdfs:label rdf:datatype="&xsd;string">MotorVehicleShipAircraft</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Engineering_and_engineering_trade"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Music_and_performing_arts -->
+
+    <owl:Class rdf:about="&Domain_fields;Music_and_performing_arts">
+        <rdfs:label rdf:datatype="&xsd;string">MusicAndPerformingArts</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Arts"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Natural_environment_and_wildlife -->
+
+    <owl:Class rdf:about="&Domain_fields;Natural_environment_and_wildlife">
+        <rdfs:label rdf:datatype="&xsd;string">NaturalEnvironmentAndWildlife</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Environment"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Natural_science_mathematics_and_statistics -->
+
+    <owl:Class rdf:about="&Domain_fields;Natural_science_mathematics_and_statistics">
+        <rdfs:label rdf:datatype="&xsd;string">NaturalScienceMathematicsAndStatistics</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Domain_Field"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Nursing_and_midwifery -->
+
+    <owl:Class rdf:about="&Domain_fields;Nursing_and_midwifery">
+        <rdfs:label rdf:datatype="&xsd;string">NursingAndMidwifery</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Health"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Occupational_health_and_safety -->
+
+    <owl:Class rdf:about="&Domain_fields;Occupational_health_and_safety">
+        <rdfs:label rdf:datatype="&xsd;string">OccupationalHealthAndSafety</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Hygiene_and_occupational_health_services"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Paper_processing -->
+
+    <owl:Class rdf:about="&Domain_fields;Paper_processing">
+        <rdfs:label rdf:datatype="&xsd;string">PaperProcessing</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Material_processing"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Personal_services -->
+
+    <owl:Class rdf:about="&Domain_fields;Personal_services">
+        <rdfs:label rdf:datatype="&xsd;string">PersonalServices</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Services"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Pharmacy -->
+
+    <owl:Class rdf:about="&Domain_fields;Pharmacy">
+        <rdfs:label rdf:datatype="&xsd;string">Pharmacy</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Health"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Philosophy_and_ethics -->
+
+    <owl:Class rdf:about="&Domain_fields;Philosophy_and_ethics">
+        <rdfs:label rdf:datatype="&xsd;string">PhilosophyAndEthics</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Humanities"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Physical_science -->
+
+    <owl:Class rdf:about="&Domain_fields;Physical_science">
+        <rdfs:label rdf:datatype="&xsd;string">PhysicalScience</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Natural_science_mathematics_and_statistics"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Physics -->
+
+    <owl:Class rdf:about="&Domain_fields;Physics">
+        <rdfs:label rdf:datatype="&xsd;string">Physics</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Physical_science"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Plastic_processing -->
+
+    <owl:Class rdf:about="&Domain_fields;Plastic_processing">
+        <rdfs:label rdf:datatype="&xsd;string">PlasticProcessing</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Material_processing"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Politics_and_civics -->
+
+    <owl:Class rdf:about="&Domain_fields;Politics_and_civics">
+        <rdfs:label rdf:datatype="&xsd;string">PoliticsAndCivics</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Social_and_behavioural_science"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Process -->
+
+    <owl:Class rdf:about="&Domain_fields;Process">
+        <rdfs:label rdf:datatype="&xsd;string">Process</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Space_Time_and_Process"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Protection_of_persons_and_property -->
+
+    <owl:Class rdf:about="&Domain_fields;Protection_of_persons_and_property">
+        <rdfs:label rdf:datatype="&xsd;string">ProtectionOfPersonsAndProperty</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Security_services"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Psychology -->
+
+    <owl:Class rdf:about="&Domain_fields;Psychology">
+        <rdfs:label rdf:datatype="&xsd;string">Psychology</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Social_and_behavioural_science"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Religion_and_theology -->
+
+    <owl:Class rdf:about="&Domain_fields;Religion_and_theology">
+        <rdfs:label rdf:datatype="&xsd;string">ReligionAndTheology</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Humanities"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Secretarial_and_office_work -->
+
+    <owl:Class rdf:about="&Domain_fields;Secretarial_and_office_work">
+        <rdfs:label rdf:datatype="&xsd;string">SecretarialAndOfficeWork</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Business_and_administration"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Security_services -->
+
+    <owl:Class rdf:about="&Domain_fields;Security_services">
+        <rdfs:label rdf:datatype="&xsd;string">SecurityServices</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Services"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Services -->
+
+    <owl:Class rdf:about="&Domain_fields;Services">
+        <rdfs:label rdf:datatype="&xsd;string">Services</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Domain_Field"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Social_and_behavioural_science -->
+
+    <owl:Class rdf:about="&Domain_fields;Social_and_behavioural_science">
+        <rdfs:label rdf:datatype="&xsd;string">SocialAndBehaviouralScience</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Social_science_journalism_and_information"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Social_science_journalism_and_information -->
+
+    <owl:Class rdf:about="&Domain_fields;Social_science_journalism_and_information">
+        <rdfs:label rdf:datatype="&xsd;string">SocialScienceJournalismAndInformation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Domain_Field"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Social_work_and_counselling -->
+
+    <owl:Class rdf:about="&Domain_fields;Social_work_and_counselling">
+        <rdfs:label rdf:datatype="&xsd;string">SocialWorkAndCounselling</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Welfare"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Sociology_and_culture -->
+
+    <owl:Class rdf:about="&Domain_fields;Sociology_and_culture">
+        <rdfs:label rdf:datatype="&xsd;string">SociologyAndCulture</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Social_and_behavioural_science"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Software_and_application_development_and_analysis -->
+
+    <owl:Class rdf:about="&Domain_fields;Software_and_application_development_and_analysis">
+        <rdfs:label rdf:datatype="&xsd;string">SoftwareAndApplicationDevelopmentAndAnalysis</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Information_and_Communication_Technology_narrow"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Space -->
+
+    <owl:Class rdf:about="&Domain_fields;Space">
+        <rdfs:label rdf:datatype="&xsd;string">Space</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Space_Time_and_Process"/>
+        <rdfs:comment rdf:datatype="&xsd;string">Class &apos;Space&apos; includes domain ontologies that are dealing with any of space related topics, e.g. geography, architecture etc.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Space_Time_and_Process -->
+
+    <owl:Class rdf:about="&Domain_fields;Space_Time_and_Process">
+        <rdfs:label rdf:datatype="&xsd;string">SpaceTimeAndProcess</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Domain_Field"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Sport -->
+
+    <owl:Class rdf:about="&Domain_fields;Sport">
+        <rdfs:label rdf:datatype="&xsd;string">Sport</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Personal_services"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Standard -->
+
+    <owl:Class rdf:about="&Domain_fields;Standard">
+        <rdfs:label rdf:datatype="&xsd;string">Standard</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Standard_method_and_research_technique"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Standard_method_and_research_technique -->
+
+    <owl:Class rdf:about="&Domain_fields;Standard_method_and_research_technique">
+        <rdfs:label rdf:datatype="&xsd;string">StandardMethodAndResearchTechnique</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Domain_Field"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Statistics -->
+
+    <owl:Class rdf:about="&Domain_fields;Statistics">
+        <rdfs:label rdf:datatype="&xsd;string">Statistics</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Mathematics_and_statistics"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Teacher_training_with_subject_specialisation -->
+
+    <owl:Class rdf:about="&Domain_fields;Teacher_training_with_subject_specialisation">
+        <rdfs:label rdf:datatype="&xsd;string">TeacherTrainingWithSubjectSpecialisation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Education_narrow"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Teacher_training_without_subject_specialisation -->
+
+    <owl:Class rdf:about="&Domain_fields;Teacher_training_without_subject_specialisation">
+        <rdfs:label rdf:datatype="&xsd;string">TeacherTrainingWithoutSubjectSpecialisation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Education_narrow"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Textile_clothes_footwear_and_leather -->
+
+    <owl:Class rdf:about="&Domain_fields;Textile_clothes_footwear_and_leather">
+        <rdfs:label rdf:datatype="&xsd;string">TextileClothesFootwearLeather</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;ManufacturingAndProcessing"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Therapy_and_rehabilitation -->
+
+    <owl:Class rdf:about="&Domain_fields;Therapy_and_rehabilitation">
+        <rdfs:label rdf:datatype="&xsd;string">TherapyAndRehabilitation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Health"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Time -->
+
+    <owl:Class rdf:about="&Domain_fields;Time">
+        <rdfs:label rdf:datatype="&xsd;string">Time</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Space_Time_and_Process"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Traditional_and_complementary_medicine_and_therapy -->
+
+    <owl:Class rdf:about="&Domain_fields;Traditional_and_complementary_medicine_and_therapy">
+        <rdfs:label rdf:datatype="&xsd;string">TraditionalAndComplementaryMedicineAndTherapy</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Health"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Training_pre-school_teachers -->
+
+    <owl:Class rdf:about="&Domain_fields;Training_pre-school_teachers">
+        <rdfs:label rdf:datatype="&xsd;string">TrainingPreSchoolTeachers</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Education_narrow"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Transport_services -->
+
+    <owl:Class rdf:about="&Domain_fields;Transport_services">
+        <rdfs:label rdf:datatype="&xsd;string">TransportServices</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Services"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Travel_tourism_and_leisure -->
+
+    <owl:Class rdf:about="&Domain_fields;Travel_tourism_and_leisure">
+        <rdfs:label rdf:datatype="&xsd;string">TravelTourismAndLeisure</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Personal_services"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Veterinary -->
+
+    <owl:Class rdf:about="&Domain_fields;Veterinary">
+        <rdfs:label rdf:datatype="&xsd;string">Veterinary</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;AgricultureForestryFsheriesVeterinary"/>
+        <rdfs:comment rdf:datatype="&xsd;string">It includes ontologies that are dealing with the domain subjects related to veterinary.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Welfare -->
+
+    <owl:Class rdf:about="&Domain_fields;Welfare">
+        <rdfs:label rdf:datatype="&xsd;string">Welfare</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Health_and_welfare"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Wholesale_and_retail_sales -->
+
+    <owl:Class rdf:about="&Domain_fields;Wholesale_and_retail_sales">
+        <rdfs:label rdf:datatype="&xsd;string">WholesaleAndRetailSales</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Business_and_administration"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Wood_processing -->
+
+    <owl:Class rdf:about="&Domain_fields;Wood_processing">
+        <rdfs:label rdf:datatype="&xsd;string">WoodProcessing</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Material_processing"/>
+    </owl:Class>
+    
+
+
+    <!-- https://raw.github.com/ontohub/OOR_Ontohub_API/master/Domain_Fields_Core.owl#Work_skill -->
+
+    <owl:Class rdf:about="&Domain_fields;Work_skill">
+        <rdfs:label rdf:datatype="&xsd;string">WorkSkill</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&Domain_fields;Business_and_administration"/>
+    </owl:Class>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 3.4.2) http://owlapi.sourceforge.net -->
+
+

--- a/spec/fixtures/seeds/proof_statuses.owl
+++ b/spec/fixtures/seeds/proof_statuses.owl
@@ -1,0 +1,1315 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY owl2xml "http://www.w3.org/2006/12/owl2-xml#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY SZS "http://http://ontohub.org/meta/SZS.owl#" >
+]>
+
+<rdf:RDF xmlns="http://http://ontohub.org/meta/SZS.owl#"
+     xml:base="http://http://ontohub.org/meta/SZS.owl"
+     xmlns:SZS="http://http://ontohub.org/meta/SZS.owl#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl2xml="http://www.w3.org/2006/12/owl2-xml#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <owl:Ontology rdf:about="http://http://ontohub.org/meta/SZS.owl"/>
+
+    <owl:ObjectProperty rdf:about="#hasLabel">
+        <rdf:type rdf:resource="&owl;FunctionalProperty"/>
+        <rdfs:range rdf:resource="#Label"/>
+    </owl:ObjectProperty>
+
+
+    <owl:Class rdf:about="&SZS;Output_Status">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#OutputStatus"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;Problem_Status">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#ProblemStatus"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment rdf:datatype="&xsd;string">The output from current ATP systems varies widely in quantity, quality, and
+meaning.  At the low end of the scale, systems that search for a refutation of
+a set of clauses may output only an assurance that a refutation exists (the
+wonderful "yes" output). At the high end of the scale a system may output a
+natural deduction proof of a problem expressed in FOF. In some cases the
+output is misleading, e.g., when a CNF based system claims that a FOF input
+problem is "unsatisfiable" it typically means that the negated CNF of the
+problem is unsatisfiable.
+
+In order to use ATP systems' results, e.g., as input to other tools, it is
+necessary that the ATP systems correctly and precisely specify what has been
+established. To this end the SZS problem status ontology has been established.
+The ontology was based on initial work done to establish communication
+protocols for systems on the MathWeb Software Bus. The ontology is shown
+below.
+
+The ontology assumes that the input F is of the form Ax => C, where Ax is a
+set (conjunction) of axioms and C is a single conjecture formula. This is a
+common standard usage of ATP systems.
++ The status value indicates the relationship between Ax and C.
++ By showing that F is valid, an ATP system shows that C is a theorem (a
+  logical consequence) of Ax, i.e., Ax |= C, where |= is the standard first
+  order entailment.
++ If F is not valid, there are several other possible relationships between Ax
+  and C, as shown in the ontology.
+
+If F is not of the form Ax => C, it is treated as a single monolithic
+conjecture formula (even if it is an "axiom" or "set of axioms" from the user
+view point). This is equivalent to Ax being TRUE. In this case not all of the
+statuses are appropriate, and those that are possible are marked with a * in
+the ontology.
++ Systems that report Theorem for a monolithic formula must have established
+  Tautology.
++ A set of axioms is treated as a conjecture formed from the conjunction of the
+  formulae.
++ This is the scenario for a set of clauses.</rdfs:comment>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;SUC">
+        <rdfs:label rdf:datatype="&xsd;string">Success</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">The logical data has been processed successfully.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Problem_Status"/>
+    </owl:Class>
+
+
+    <owl:Class rdf:about="&SZS;UNP">
+        <rdfs:label rdf:datatype="&xsd;string">UnsatisfiabilityPreserving</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">If there does not exist a model of Ax then there does not exist a model of
+C, i.e., if Ax is unsatisfiable then C is unsatisfiable.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SUC"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;SAP">
+        <rdfs:label rdf:datatype="&xsd;string">SatisfiabilityPreserving</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">If there exists a model of Ax then there exists a model of C, i.e., if Ax
+is satisfiable then C is satisfiable.
+- F is satisfiable.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SUC"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;ESA">
+        <rdfs:label rdf:datatype="&xsd;string">EquiSatisfiable</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">There exists a model of Ax iff there exists a model of C, i.e., Ax is
+(un)satisfiable iff C is (un)satisfiable.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;UNP"/>
+        <rdfs:subClassOf rdf:resource="&SZS;SAP"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;SAT">
+        <rdfs:label rdf:datatype="&xsd;string">Satisfiable</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some interpretations are models of Ax, and
+some models of Ax are models of C.
+- F is satisfiable, and ~F is not valid.
+- Possible dataforms are Models of Ax | C.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;ESA"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;FSA">
+        <rdfs:label rdf:datatype="&xsd;string">FinitelySatisfiable</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some finite interpretations are finite models of Ax, and
+some finite models of Ax are finite models of C.
+- F is satisfiable, and ~F is not valid.
+- Possible dataforms are FiniteModels of Ax | C.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SAT"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;FTH">
+        <rdfs:label rdf:datatype="&xsd;string">FiniteTheorem</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">All finite models of Ax are finite models of C.
+- Any models of Ax | ~C are infinite.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SUC"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;THM">
+        <rdfs:label rdf:datatype="&xsd;string">Theorem</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">All models of Ax are models of C.
+- F is valid, and C is a theorem of Ax.
+- Possible dataforms are Proofs of C from Ax.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SAP"/>
+        <rdfs:subClassOf rdf:resource="&SZS;FTH"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;STH">
+        <rdfs:label rdf:datatype="&xsd;string">SatisfiableTheorem</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some interpretations are models of Ax, and
+all models of Ax are models of C.
+- F is valid, and C is a theorem of Ax.
+- Possible dataforms are Models of Ax with Proofs of C from Ax.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;THM"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;EQV">
+        <rdfs:label rdf:datatype="&xsd;string">Equivalent</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some interpretations are models of Ax,
+all models of Ax are models of C, and
+all models of C are models of Ax.
+- F is valid, C is a theorem of Ax, and Ax is a theorem of C.
+- Possible dataforms are Proofs of C from Ax and of Ax from C.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SAT"/>
+        <rdfs:subClassOf rdf:resource="&SZS;STH"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;TAC">
+        <rdfs:label rdf:datatype="&xsd;string">TautologousConclusion</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some interpretations are models of Ax, and
+all interpretations are models of C.
+- F is valid, and C is a tautology.
+- Possible dataforms are Proofs of C.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SAT"/>
+        <rdfs:subClassOf rdf:resource="&SZS;STH"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;WEC">
+        <rdfs:label rdf:datatype="&xsd;string">WeakerConclusion</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some interpretations are models of Ax,
+all models of Ax are models of C, and
+some models of C are not models of Ax.
+- See Theorem and Satisfiable.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#warning"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SAT"/>
+        <rdfs:subClassOf rdf:resource="&SZS;STH"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;ETH">
+        <rdfs:label rdf:datatype="&xsd;string">EquivalentTheorem</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some, but not all, interpretations are models of Ax,
+all models of Ax are models of C, and
+all models of C are models of Ax.
+- See Equivalent.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;EQV"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;TAU">
+        <rdfs:label rdf:datatype="&xsd;string">Tautology</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">All interpretations are models of Ax, and
+all interpretations are models of C.
+- F is valid, ~F is unsatisfiable, and C is a tautology.
+- Possible dataforms are Proofs of Ax and of C.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;EQV"/>
+        <rdfs:subClassOf rdf:resource="&SZS;TAC"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;WTC">
+        <rdfs:label rdf:datatype="&xsd;string">WeakerTautologousConclusion</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some, but not all, interpretations are models of Ax, and
+all interpretations are models of C.
+- F is valid, and C is a tautology.
+- See TautologousConclusion and WeakerConclusion.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;TAC"/>
+        <rdfs:subClassOf rdf:resource="&SZS;WEC"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;WTH">
+        <rdfs:label rdf:datatype="&xsd;string">WeakerTheorem</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some interpretations are models of Ax,
+all models of Ax are models of C,
+some models of C are not models of Ax, and
+some interpretations are not models of C.
+- See Theorem and Satisfiable.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#warning"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;WEC"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;CAX">
+        <rdfs:label rdf:datatype="&xsd;string">ContradictoryAxioms</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">No interpretations are models of Ax.
+- F is valid, and anything is a theorem of Ax.
+- Possible dataforms are Refutations of Ax.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#warning"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;THM"/>
+        <rdfs:subClassOf rdf:resource="&SZS;CTH"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;SCA">
+        <rdfs:label rdf:datatype="&xsd;string">SatisfiableConclusionContradictoryAxioms</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">No interpretations are models of Ax, and
+some interpretations are models of C.
+- See ContradictoryAxioms.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#warning"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;CAX"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;TCA">
+        <rdfs:label rdf:datatype="&xsd;string">TautologousConclusionContradictoryAxioms</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">No interpretations are models of Ax, and
+all interpretations are models of C.
+- See TautologousConclusion and SatisfiableConclusionContradictoryAxioms.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#warning"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SCA"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;WCA">
+        <rdfs:label rdf:datatype="&xsd;string">WeakerConclusionContradictoryAxioms</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">No interpretations are models of Ax, and
+some, but not all, interpretations are models of C.
+- See SatisfiableConclusionContradictoryAxioms and
+SatisfiableCounterConclusionContradictoryAxioms.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#warning"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SCA"/>
+        <rdfs:subClassOf rdf:resource="&SZS;SCC"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;CUP">
+        <rdfs:label rdf:datatype="&xsd;string">CounterUnsatisfiabilityPreserving</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">If there does not exist a model of Ax then there does not exist a model of
+~C, i.e., if Ax is unsatisfiable then ~C is unsatisfiable.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SUC"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;CSP">
+        <rdfs:label rdf:datatype="&xsd;string">CounterSatisfiabilityPreserving</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">If there exists a model of Ax then there exists a model of ~C, i.e., if Ax
+is satisfiable then ~C is satisfiable.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SUC"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;ECS">
+        <rdfs:label rdf:datatype="&xsd;string">EquiCounterSatisfiable</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">There exists a model of Ax iff there exists a model of ~C, i.e., Ax is
+(un)satisfiable iff ~C is (un)satisfiable.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#success"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;CSP"/>
+        <rdfs:subClassOf rdf:resource="&SZS;CUP"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;CSA">
+        <rdfs:label rdf:datatype="&xsd;string">CounterSatisfiable</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some interpretations are models of Ax, and
+some models of Ax are models of ~C.
+- F is not valid, ~F is satisfiable, and C is not a theorem of Ax.
+- Possible dataforms are Models of Ax | ~C.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#danger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;ECS"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;FCS">
+        <rdfs:label rdf:datatype="&xsd;string">FinitelyCounterSatisfiable</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some finite interpretations are finite models of Ax, and
+some finite models of Ax are finite models of ~C.
+- F is not valid, ~F is satisfiable, and C is not a theorem of Ax.
+- Possible dataforms are FiniteModels of Ax | ~C.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#danger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;CSA"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;CTH">
+        <rdfs:label rdf:datatype="&xsd;string">CounterTheorem</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">All models of Ax are models of ~C.
+- F is not valid, and ~C is a theorem of Ax.
+- Possible dataforms are Proofs of ~C from Ax.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#danger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;CSP"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;SCT">
+        <rdfs:label rdf:datatype="&xsd;string">SatisfiableCounterTheorem</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some interpretations are models of Ax, and
+all models of Ax are models of ~C.
+- F is valid, and ~C is a theorem of Ax.
+- Possible dataforms are Models of Ax with Proofs of ~C from Ax.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#danger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;CTH"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;CEQ">
+        <rdfs:label rdf:datatype="&xsd;string">CounterEquivalent</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some interpretations are models of Ax,
+all models of Ax are models of ~C, and
+all models of ~C are models of Ax
+(i.e., all interpretations are models of Ax xor of C).
+- F is not valid, and ~C is a theorem of Ax.
+- Possible dataforms are Proofs of ~C from Ax and of Ax from ~C.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#danger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;CSA"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;UNC">
+        <rdfs:label rdf:datatype="&xsd;string">UnsatisfiableConclusion</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some interpretations are models of Ax, and
+all interpretations are models of ~C
+(i.e., no interpretations are models of C).
+- F is not valid, and ~C is a tautology.
+- Possible dataforms are Proofs of ~C.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#danger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SCT"/>
+        <rdfs:subClassOf rdf:resource="&SZS;CSA"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;WCC">
+        <rdfs:label rdf:datatype="&xsd;string">WeakerCounterConclusion</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some interpretations are models of Ax, and
+all models of Ax are models of ~C, and
+some models of ~C are not models of Ax.
+- See CounterTheorem and CounterSatisfiable.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#danger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SCT"/>
+        <rdfs:subClassOf rdf:resource="&SZS;CSA"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;ECT">
+        <rdfs:label rdf:datatype="&xsd;string">EquivalentCounterTheorem</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some, but not all, interpretations are models of Ax,
+all models of Ax are models of ~C, and
+all models of ~C are models of Ax.
+- See CounterEquivalent.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#danger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;CEQ"/>
+        <rdfs:subClassOf rdf:resource="&SZS;FUN"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;FUN">
+        <rdfs:label rdf:datatype="&xsd;string">FinitelyUnsatisfiable</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">All finite interpretations are finite models of Ax, and
+all finite interpretations are finite models of ~C
+(i.e., no finite interpretations are finite models of C).</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#danger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SUC"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;UNS">
+        <rdfs:label rdf:datatype="&xsd;string">Unsatisfiable</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">All interpretations are models of Ax, and
+all interpretations are models of ~C.
+(i.e., no interpretations are models of C).
+- F is unsatisfiable, ~F is valid, and ~C is a tautology.
+- Possible dataforms are Proofs of Ax and of C, and Refutations of F.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#danger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;UNC"/>
+        <rdfs:subClassOf rdf:resource="&SZS;FUN"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;WUC">
+        <rdfs:label rdf:datatype="&xsd;string">WeakerUnsatisfiableConclusion</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some, but not all, interpretations are models of Ax, and
+all interpretations are models of ~C.
+- See Unsatisfiable and WeakerCounterConclusion.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#danger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;WCC"/>
+        <rdfs:subClassOf rdf:resource="&SZS;UNC"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;WCT">
+        <rdfs:label rdf:datatype="&xsd;string">WeakerCounterTheorem</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some interpretations are models of Ax,
+all models of Ax are models of ~C,
+some models of ~C are not models of Ax, and
+some interpretations are not models of ~C.
+- See CounterSatisfiable.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#danger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;WCC"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;SCC">
+        <rdfs:label rdf:datatype="&xsd;string">SatisfiableCounterConclusionContradictoryAxioms</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">No interpretations are models of Ax, and
+some interpretations are models of ~C.
+- See ContradictoryAxioms.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#danger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;CAX"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;UCA">
+        <rdfs:label rdf:datatype="&xsd;string">UnsatisfiableConclusionContradictoryAxioms</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">No interpretations are models of Ax, and
+all interpretations are models of ~C
+(i.e., no interpretations are models of C).
+- See UnsatisfiableConclusion and
+- SatisfiableCounterConclusionContradictoryAxioms.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#danger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SCC"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;NOC">
+        <rdfs:label rdf:datatype="&xsd;string">NoConsequence</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Some interpretations are models of Ax,
+some models of Ax are models of C, and
+some models of Ax are models of ~C.
+- F is not valid, F is satisfiable, ~F is not valid, ~F is satisfiable, and
+C is not a theorem of Ax.
+- Possible dataforms are pairs of models, one Model of Ax | C and one Model
+of Ax | ~C.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#danger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SAT"/>
+        <rdfs:subClassOf rdf:resource="&SZS;CSA"/>
+    </owl:Class>
+
+
+    <owl:Class rdf:about="&SZS;NOS">
+        <rdfs:label rdf:datatype="&xsd;string">NoSuccess</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">The logical data has not been processed successfully (yet).</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Problem_Status"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;OPN">
+        <rdfs:label rdf:datatype="&xsd;string">Open</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A success value has never been established.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;NOS"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;UNK">
+        <rdfs:label rdf:datatype="&xsd;string">Unknown</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Success value unknown, and no assumption has been made.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;NOS"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;ASS">
+        <rdfs:label rdf:datatype="&xsd;string">Assumed(UNK,SUC)</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">The success ontology value S has been assumed because the actual value is
+unknown for the no-success ontology reason U. U is taken from the
+subontology starting at Unknown in the no-success ontology.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;NOS"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;STP">
+        <rdfs:label rdf:datatype="&xsd;string">Stopped</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software attempted to process the data, and stopped without a success status.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;UNK"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;ERR">
+        <rdfs:label rdf:datatype="&xsd;string">Error</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software stopped due to an error.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;STP"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;OSE">
+        <rdfs:label rdf:datatype="&xsd;string">OSError</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software stopped due to an operating system error.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;ERR"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;INE">
+        <rdfs:label rdf:datatype="&xsd;string">InputError</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software stopped due to an input error.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#warning"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;ERR"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;USE">
+        <rdfs:label rdf:datatype="&xsd;string">UsageError</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software stopped due to an ATP system usage error.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;INE"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;SYE">
+        <rdfs:label rdf:datatype="&xsd;string">SyntaxError</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software stopped due to an input syntax error.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#warning"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;INE"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;SEE">
+        <rdfs:label rdf:datatype="&xsd;string">SemanticError</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software stopped due to an input semantic error.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#warning"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;INE"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;TYE">
+        <rdfs:label rdf:datatype="&xsd;string">TypeError</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software stopped due to an input type error (for typed logical data).</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#warning"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;SEE"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;FOR">
+        <rdfs:label rdf:datatype="&xsd;string">Forced</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software was forced to stop by an external force.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;STP"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;USR">
+        <rdfs:label rdf:datatype="&xsd;string">User</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software was forced to stop by the user.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;FOR"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;RSO">
+        <rdfs:label rdf:datatype="&xsd;string">ResourceOut</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software stopped because some resource ran out.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;FOR"/>
+        <rdfs:subClassOf rdf:resource="&SZS;GUP"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;TMO">
+        <rdfs:label rdf:datatype="&xsd;string">Timeout</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software stopped because the CPU time limit ran out.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;RSO"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;MMO">
+        <rdfs:label rdf:datatype="&xsd;string">MemoryOut</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software stopped because the memory limit ran out.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;RSO"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;GUP">
+        <rdfs:label rdf:datatype="&xsd;string">GaveUp</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software gave up of its own accord.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;STP"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;INC">
+        <rdfs:label rdf:datatype="&xsd;string">Incomplete</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software gave up because it's incomplete.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;GUP"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;IAP">
+        <rdfs:label rdf:datatype="&xsd;string">Inappropriate</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software gave up because it cannot process this type of data.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;GUP"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;INP">
+        <rdfs:label rdf:datatype="&xsd;string">InProgress</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software is still running.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;UNK"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;NTT">
+        <rdfs:label rdf:datatype="&xsd;string">NotTried</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software has not tried to process the data.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;UNK"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;NTY">
+        <rdfs:label rdf:datatype="&xsd;string">NotTriedYet</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Software has not tried to process the data yet, but might in the future.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#primary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;NTT"/>
+    </owl:Class>
+
+
+    <owl:Class rdf:about="&SZS;LDa">
+        <rdfs:label rdf:datatype="&xsd;string">LogicalData</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Logical data.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Output_Status"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;Sln">
+        <rdfs:label rdf:datatype="&xsd;string">Solution</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A solution.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;LDa"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;Prf">
+        <rdfs:label rdf:datatype="&xsd;string">Proof</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A proof.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Sln"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;Der">
+        <rdfs:label rdf:datatype="&xsd;string">Derivation</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A derivation (inference steps ending in the theorem, in the Hilbert style).</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Prf"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;Ref">
+        <rdfs:label rdf:datatype="&xsd;string">Refutation</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A refutation (starting with Ax U ~C and ending in FALSE).</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Prf"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;CRf">
+        <rdfs:label rdf:datatype="&xsd;string">CNFRefutation</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A refutation in clause normal form, including, for FOF Ax or C, the
+translation from FOF to CNF (without the FOF to CNF translation it's an
+IncompleteProof).</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Ref"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;Int">
+        <rdfs:label rdf:datatype="&xsd;string">Interpretation</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">An interpretation.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Sln"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;DIn">
+        <rdfs:label rdf:datatype="&xsd;string">DomainInterpretation</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">An interpretation expressed as a domain, a mapping for functions, and a
+relation for predicates.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Int"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;FIn">
+        <rdfs:label rdf:datatype="&xsd;string">FiniteInterpretation</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A domain interpretation with a finite domain.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;DIn"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;IIn">
+        <rdfs:label rdf:datatype="&xsd;string">InfiniteInterpretation</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A domain interpretation with an infinite domain.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;DIn"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;HIn">
+        <rdfs:label rdf:datatype="&xsd;string">HerbrandInterpretation</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A Herbrand interpretation.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;DIn"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;Mod">
+        <rdfs:label rdf:datatype="&xsd;string">Model</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A model.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Int"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;DMo">
+        <rdfs:label rdf:datatype="&xsd;string">DomainModel</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A model expressed as a domain, a mapping for functions, and a relation for
+predicates.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;DIn"/>
+        <rdfs:subClassOf rdf:resource="&SZS;Mod"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;FMo">
+        <rdfs:label rdf:datatype="&xsd;string">FiniteModel</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A domain model with a finite domain.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;FIn"/>
+        <rdfs:subClassOf rdf:resource="&SZS;DMo"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;IMo">
+        <rdfs:label rdf:datatype="&xsd;string">InfiniteModel</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A domain model with an infinite domain.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;DMo"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;HMo">
+        <rdfs:label rdf:datatype="&xsd;string">HerbrandModel</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A Herbrand model.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;DMo"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;Sat">
+        <rdfs:label rdf:datatype="&xsd;string">Saturation</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A model expressed as a saturating set of formulae.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Mod"/>
+        <rdfs:subClassOf rdf:resource="&SZS;Lof"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;Lof">
+        <rdfs:label rdf:datatype="&xsd;string">ListOfFormulae</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A list of formulae.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Sln"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;Lth">
+        <rdfs:label rdf:datatype="&xsd;string">ListOfTHF</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A list of THF formulae.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Lof"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;Ltf">
+        <rdfs:label rdf:datatype="&xsd;string">ListOfTFF</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A list of TFF formulae.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Lof"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;Lfo">
+        <rdfs:label rdf:datatype="&xsd;string">ListOfFOF</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A list of FOF formulae.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Lof"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;Lcn">
+        <rdfs:label rdf:datatype="&xsd;string">ListOfCNF</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A list of CNF formulae.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;Lof"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;NSo">
+        <rdfs:label rdf:datatype="&xsd;string">NotASolution</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Something that is not a well formed solution.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;LDa"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;Ass">
+        <rdfs:label rdf:datatype="&xsd;string">Assurance</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Only an assurance of the success ontology value.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;NSo"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;IPr">
+        <rdfs:label rdf:datatype="&xsd;string">IncompleteProof</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">A proof with some part missing.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;NSo"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;IIn">
+        <rdfs:label rdf:datatype="&xsd;string">IncompleteInterpretation</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">An interpretation with some part missing.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;NSo"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;Non">
+        <rdfs:label rdf:datatype="&xsd;string">None</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">Nothing.</rdfs:comment>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasLabel"/>
+                <owl:someValuesFrom rdf:resource="#info"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&SZS;LDa"/>
+    </owl:Class>
+
+
+    <owl:Class rdf:about="&SZS;Label">
+        <rdfs:label rdf:datatype="&xsd;string">Label</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="#success"/>
+                    <rdf:Description rdf:about="#warning"/>
+                    <rdf:Description rdf:about="#danger"/>
+                    <rdf:Description rdf:about="#info"/>
+                    <rdf:Description rdf:about="#primary"/>
+                    <rdf:Description rdf:about="#default"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;success">
+        <rdfs:label rdf:datatype="&xsd;string">success</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&SZS;Label"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;warning">
+        <rdfs:label rdf:datatype="&xsd;string">warning</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&SZS;Label"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;danger">
+        <rdfs:label rdf:datatype="&xsd;string">danger</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&SZS;Label"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;info">
+        <rdfs:label rdf:datatype="&xsd;string">info</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&SZS;Label"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;primary">
+        <rdfs:label rdf:datatype="&xsd;string">primary</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&SZS;Label"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&SZS;default">
+        <rdfs:label rdf:datatype="&xsd;string">default</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&SZS;Label"/>
+    </owl:Class>
+</rdf:RDF>
+


### PR DESCRIPTION
Seeds depended on an internet connection. With this change they don't:
* Proof statuses and categories have fixtures. They are only used if the download from ontohub.org failed.
* Oops is skipped if either a SocketError (no connection at all) or a RestClient error (e.g. 404 or similar) occurs.

In both cases a message with the error is printed to stdout.