### PR TITLE
Report coverage only on default task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,7 @@ Rake::Task['db:test:clone_structure'].prerequisites << 'db:test:purge'
 # Run all test suites per default
 Rake::Task['default'].prerequisites.delete('spec')
 Rake::Task['default'].prerequisites.delete('cucumber')
-task :default => [:'test:abort_if_elasticsearch_is_not_running',
-                  :'test:enable_coverage',
-                  :'test:freshen_fixtures', :spec, :cucumber]
+Rake::Task['default'].enhance([:'test:abort_if_elasticsearch_is_not_running'])
+Rake::Task['default'].enhance([:'test:enable_coverage'])
+Rake::Task['default'].enhance([:'test:freshen_fixtures'])
+task :default => [:spec, :cucumber]

--- a/Rakefile
+++ b/Rakefile
@@ -19,4 +19,5 @@ Rake::Task['db:test:clone_structure'].prerequisites << 'db:test:purge'
 Rake::Task['default'].prerequisites.delete('spec')
 Rake::Task['default'].prerequisites.delete('cucumber')
 task :default => [:'test:abort_if_elasticsearch_is_not_running',
+                  :'test:enable_coverage',
                   :'test:freshen_fixtures', :spec, :cucumber]

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -216,4 +216,9 @@ namespace :test do
       with_running_hets { freshen_proof_fixtures }
     end
   end
+
+  desc 'Enable coverage report (only useful as prerequisite of other tasks)'
+  task :enable_coverage do
+    ENV['COVERAGE'] = 'true'
+  end
 end

--- a/spec/shared_helper.rb
+++ b/spec/shared_helper.rb
@@ -34,7 +34,6 @@ module SharedHelper
   end
 
   def use_simplecov
-    return unless ENV['COVERAGE']
     SimpleCov.start do
       add_group "Models",      "app/models"
       add_group "Controllers", "app/controllers"

--- a/spec/shared_helper.rb
+++ b/spec/shared_helper.rb
@@ -34,6 +34,7 @@ module SharedHelper
   end
 
   def use_simplecov
+    return unless ENV['COVERAGE']
     SimpleCov.start do
       add_group "Models",      "app/models"
       add_group "Controllers", "app/controllers"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../spec/shared_helper", __FILE__)
 
 include SharedHelper
-use_simplecov
+use_simplecov if ENV['COVERAGE']
 
 require File.expand_path("../../config/environment", __FILE__)
 require File.expand_path("../hets_helper", __FILE__)


### PR DESCRIPTION
A simple run of `rspec spec/something_spec.rb:123` spends a lot of time on
generating the coverage report.

This disables the coverage report, except for the default rake task.
If a coverage report is desired even for other tasks, just set the environment variable `COVERAGE`, e.g.:

```
COVERAGE=true rspec
```