### PR TITLE
1325 parse hets json snake case keys 

### DIFF
--- a/app/models/prover.rb
+++ b/app/models/prover.rb
@@ -1,7 +1,7 @@
 class Prover < ActiveRecord::Base
-  attr_accessible :name
+  attr_accessible :name, :display_name
 
   def to_s
-    name
+    display_name
   end
 end

--- a/app/views/proofs/new.html.haml
+++ b/app/views/proofs/new.html.haml
@@ -1,7 +1,7 @@
 %h1= @page_title = t('proofs.new.title', klass: klass, resource: resource)
 = simple_form_for resource, url: form_url_chain do |f|
   #prover-list
-    = f.input :prover_ids, label: t('proofs.new.provers.label'), collection: ontology.current_version.provers, as: :check_boxes, hint: t('proofs.new.provers.none_is_default')
+    = f.input :prover_ids, label: t('proofs.new.provers.label'), collection: ontology.current_version.provers, label_method: :to_s, as: :check_boxes, hint: t('proofs.new.provers.none_is_default')
     .col-lg-2
     .col-lg-10.buttons
       = link_to t('proofs.new.select_all_provers'), '#', class: 'btn btn-xs btn-default select-all'

--- a/config/hets.yml
+++ b/config/hets.yml
@@ -27,7 +27,7 @@ hets_owl_tools:
   - /Applications/Hets.app/Contents/Resources/hets-owl-tools
 
 version_minimum_version: 0.99
-version_minimum_revision: 1425547964
+version_minimum_revision: 1429678296
 
 stack_size: 1G
 

--- a/db/migrate/20150313065037_use_prover_reference_in_proof_attempts.rb
+++ b/db/migrate/20150313065037_use_prover_reference_in_proof_attempts.rb
@@ -5,7 +5,7 @@ class UseProverReferenceInProofAttempts < MigrationWithData
     ProofAttempt.find_each do |proof_attempt|
       attrs = select_attributes(proof_attempt, :prover)
       prover = Prover.where(name: attrs[:prover]).first_or_create!
-      update_attributes!(proof_attempt, prover_id: prover.id)
+      update_columns(proof_attempt, prover_id: prover.id)
     end
 
     remove_columns :proof_attempts, :prover

--- a/db/migrate/20150320135159_create_proof_attempt_configurations.rb
+++ b/db/migrate/20150320135159_create_proof_attempt_configurations.rb
@@ -34,12 +34,13 @@ class CreateProofAttemptConfigurations < MigrationWithData
 
     ProofAttempt.find_each do |proof_attempt|
       config = ProofAttemptConfiguration.new
+      create_unsafe(config)
 
       pa_attrs = select_attributes(proof_attempt, :sentence_id)
       theorem = Theorem.find(pa_attrs[:sentence_id])
       theorem_attrs = select_attributes(theorem, :ontology_id)
 
-      update_attributes!(config, ontology_id: theorem_attrs[:ontology_id])
+      update_columns(config, ontology_id: theorem_attrs[:ontology_id])
 
       update_attributes!(proof_attempt,
                          proof_attempt_configuration_id: config.id)

--- a/db/migrate/20150420141258_add_display_name_to_prover.rb
+++ b/db/migrate/20150420141258_add_display_name_to_prover.rb
@@ -1,0 +1,12 @@
+class AddDisplayNameToProver < MigrationWithData
+  def change
+    add_column :provers, :display_name, :string
+    Prover.find_each do |prover|
+      attrs = select_attributes(prover, :name, :display_name)
+      unless attrs[:display_name]
+        attrs[:display_name] = attrs[:name]
+        update_attributes!(prover, attrs)
+      end
+    end
+  end
+end

--- a/db/migrate/20150420141258_add_display_name_to_prover.rb
+++ b/db/migrate/20150420141258_add_display_name_to_prover.rb
@@ -8,5 +8,6 @@ class AddDisplayNameToProver < MigrationWithData
         update_attributes!(prover, attrs)
       end
     end
+    change_column :provers, :display_name, :string, null: false
   end
 end

--- a/lib/hets/prove/parser.rb
+++ b/lib/hets/prove/parser.rb
@@ -4,11 +4,11 @@ module Hets
       # possible hierarchy beginnings
       NODE = [:array, :object]
       GOAL = [*NODE, 'goals', :array, :object]
-      TACTIC_SCRIPT = [*GOAL, 'tacticScript', :object]
-      TACTIC_SCRIPT_EXTRA_OPTIONS = [*TACTIC_SCRIPT, 'extraOptions', :array]
-      USED_TIME = [*GOAL, 'usedTime', :object]
+      TACTIC_SCRIPT = [*GOAL, 'tactic_script', :object]
+      TACTIC_SCRIPT_EXTRA_OPTIONS = [*TACTIC_SCRIPT, 'extra_options', :array]
+      USED_TIME = [*GOAL, 'used_time', :object]
       USED_TIME_COMPONENTS = [*USED_TIME, 'components', :object]
-      USED_AXIOMS = [*GOAL, 'usedAxioms', :array]
+      USED_AXIOMS = [*GOAL, 'used_axioms', :array]
 
       BRANCHES = %w(NODE GOAL TACTIC_SCRIPT TACTIC_SCRIPT_EXTRA_OPTIONS
                     USED_TIME USED_TIME_COMPONENTS USED_AXIOMS)

--- a/lib/hets/provers/importer.rb
+++ b/lib/hets/provers/importer.rb
@@ -12,8 +12,8 @@ module Hets
       def import
         hash = JSON.parse(io.read)
         provers = hash['provers']
-        provers.each do |prover_name|
-          prover = Prover.where(name: prover_name).first_or_create!
+        provers.each do |prover_hash|
+          prover = Prover.where(prover_hash).first_or_create!
           unless ontology_version.provers.include?(prover)
             ontology_version.provers << prover
           end

--- a/lib/hets/provers/importer.rb
+++ b/lib/hets/provers/importer.rb
@@ -16,8 +16,7 @@ module Hets
         provers.each do |prover_hash|
           prover_hash.select! { |k, _v| ALLOWED_KEYS.include?(k) }
           prover = Prover.where(name: prover_hash.delete('name')).
-            first_or_create!
-          prover.update_attributes!(prover_hash)
+            first_or_create!(prover_hash)
           unless ontology_version.provers.include?(prover)
             ontology_version.provers << prover
           end

--- a/lib/hets/provers/importer.rb
+++ b/lib/hets/provers/importer.rb
@@ -1,6 +1,7 @@
 module Hets
   module Provers
     class Importer
+      ALLOWED_KEYS = %w(name display_name)
       attr_accessor :ontology_version, :io
 
       # io needs to be an instance of IO or a Tempfile.
@@ -13,7 +14,10 @@ module Hets
         hash = JSON.parse(io.read)
         provers = hash['provers']
         provers.each do |prover_hash|
-          prover = Prover.where(prover_hash).first_or_create!
+          prover_hash.select! { |k, _v| ALLOWED_KEYS.include?(k) }
+          prover = Prover.where(name: prover_hash.delete('name')).
+            first_or_create!
+          prover.update_attributes!(prover_hash)
           unless ontology_version.provers.include?(prover)
             ontology_version.provers << prover
           end

--- a/spec/factories/prover_factory.rb
+++ b/spec/factories/prover_factory.rb
@@ -5,10 +5,12 @@ FactoryGirl.define do
 
   factory :prover do
     name { 'SPASS' }
+    display_name { 'SPASS Prover' }
 
     trait :with_sequenced_name do
       after(:build) do |prover|
         prover.name = generate :prover_name
+        prover.display_name = prover.name.sub('-', ' ')
       end
     end
   end

--- a/spec/models/prover_spec.rb
+++ b/spec/models/prover_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Prover do
   let(:prover) { create :prover }
-  it 'to_s is the name' do
-    expect(prover.to_s).to eq(prover.name)
+  it 'to_s is the display_name' do
+    expect(prover.to_s).to eq(prover.display_name)
   end
 end


### PR DESCRIPTION
This shall fix #1325 and also use the new `display_name` of Hets' provers list.

Hets now outputs JSON with snake case (instead of camel case) object keys. Our parsers need to be adjusted to this.

--
*Because our CI services use the bleeding-edge version of Hets, they will always fail without the changes of this branch.*