### PR TITLE
Fix ssh key fingerprint generation

### DIFF
--- a/app/models/key/fingerprint.rb
+++ b/app/models/key/fingerprint.rb
@@ -3,7 +3,7 @@ module Key::Fingerprint
 
   included do
     before_validation :generate_fingerpint
-    validates :fingerprint, uniqueness: true
+    validates :fingerprint, uniqueness: true, presence: true
   end
 
 

--- a/app/models/key/fingerprint.rb
+++ b/app/models/key/fingerprint.rb
@@ -16,6 +16,15 @@ module Key::Fingerprint
       file.puts key
       file.rewind
       output = Subprocess.run 'ssh-keygen', '-lf', file.path
+      # Openssh 6.8 changed the format and hash algorithm of the fingerprint.
+      # Now the hash algorithm name is prepended to the fingerprint and the
+      # default algorithm is SHA256 (we need MD5).
+      if output[0..16].include?('SHA256:')
+        # If the parameter -E is used with an older version than 6.8, the
+        # process fails. So we only use it if the know that it is supported.
+        output = Subprocess.run 'ssh-keygen', '-l', '-E', 'md5', '-f', file.path
+        output.sub!('MD5:', '')
+      end
     end
     output.gsub /([\d\h]{2}:)+[\d\h]{2}/ do |match|
       self.fingerprint = match.gsub(":","")


### PR DESCRIPTION
This shall fix #1329.

Openssh changed the fingerprint output format in version 6.8. Now it
defaults to SHA256 (previously MD5) and it prepends `MD5:` or `SHA256:`
to the fingerprint.

With `-E md5` we tell it to use the old fingerprint format. This option
is not recognized by versions before 6.8 and calling `ssh-keygen` with
it lets the process fail. To support the older versions as well
(they are running on our productive deployments), we call it a second
time with correct options if we find ourselves in in an environment with
the newer version.