### PR TITLE
Refactoring get rid of rspec deprecations

### DIFF
--- a/spec/controllers/admin/teams_controller_spec.rb
+++ b/spec/controllers/admin/teams_controller_spec.rb
@@ -5,7 +5,10 @@ describe Admin::TeamsController do
     context 'not signed in' do
       before { get :index }
 
-      it { should set_the_flash.to(/admin privileges/) }
+      it 'sets the flash' do
+        expect(flash[:error]).to match(/admin privileges/)
+      end
+
       it { should respond_with :redirect }
     end
 
@@ -15,7 +18,10 @@ describe Admin::TeamsController do
         get :index
       end
 
-      it { should set_the_flash.to(/admin privileges/) }
+      it 'sets the flash' do
+        expect(flash[:error]).to match(/admin privileges/)
+      end
+
       it { should respond_with :redirect }
     end
 

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -5,7 +5,9 @@ describe Admin::UsersController do
     context 'not signed in' do
       before { get :index }
 
-      it { should set_the_flash.to(/admin privileges/) }
+      it 'sets the flash' do
+        expect(flash[:error]).to match(/admin privileges/)
+      end
       it { should respond_with :redirect }
     end
 
@@ -15,7 +17,9 @@ describe Admin::UsersController do
         get :index
       end
 
-      it { should set_the_flash.to(/admin privileges/) }
+      it 'sets the flash' do
+        expect(flash[:error]).to match(/admin privileges/)
+      end
       it { should respond_with :redirect }
     end
 

--- a/spec/controllers/diffs_controller_spec.rb
+++ b/spec/controllers/diffs_controller_spec.rb
@@ -59,7 +59,10 @@ describe DiffsController do
         before { get :show, repository_id: repository.to_param, ref: 'master' }
         it { should respond_with :found }
         it { should redirect_to root_path }
-        it { should set_the_flash.to(/not authorized/) }
+
+        it 'sets the flash' do
+          expect(flash[:alert]).to match(/not authorized/)
+        end
       end
     end
 
@@ -68,7 +71,10 @@ describe DiffsController do
         before { get :show, repository_id: repository.to_param, ref: 'master' }
         it { should respond_with :found }
         it { should redirect_to root_path }
-        it { should set_the_flash.to(/not authorized/) }
+
+        it 'sets the flash' do
+          expect(flash[:alert]).to match(/not authorized/)
+        end
       end
     end
   end

--- a/spec/controllers/files_controller_spec.rb
+++ b/spec/controllers/files_controller_spec.rb
@@ -149,7 +149,7 @@ describe FilesController do
             expect(repository.path_exists? filepath).to be(true)
           end
           it "should actually not have added a file" do
-            pending "this should be another controller action"
+            skip "this should be another controller action"
           end
         end
       end

--- a/spec/controllers/files_controller_spec.rb
+++ b/spec/controllers/files_controller_spec.rb
@@ -162,14 +162,20 @@ describe FilesController do
       context "new" do
         before { get :new, repository_id: repository.to_param }
         it { should respond_with :redirect }
-        it { should set_the_flash.to(/not authorized/) }
+
+        it 'sets the flash' do
+          expect(flash[:alert]).to match(/not authorized/)
+        end
       end
 
       context "create" do
         context "without file" do
           before { post :create, repository_id: repository.to_param }
           it { should respond_with :redirect }
-          it { should set_the_flash.to(/not authorized/) }
+
+          it 'sets the flash' do
+            expect(flash[:alert]).to match(/not authorized/)
+          end
         end
 
         context "with file" do
@@ -183,7 +189,10 @@ describe FilesController do
             }
           }
           it { should respond_with :redirect }
-          it { should set_the_flash.to(/not authorized/) }
+
+          it 'sets the flash' do
+            expect(flash[:alert]).to match(/not authorized/)
+          end
         end
       end
     end

--- a/spec/controllers/files_controller_spec.rb
+++ b/spec/controllers/files_controller_spec.rb
@@ -102,9 +102,6 @@ describe FilesController do
             end
 
             it { should respond_with :found }
-            it "should not show an error" do
-              expect(flash[:error]).to be(nil)
-            end
             it "should show a success message" do
               expect(flash[:success]).not_to be(nil)
             end
@@ -119,9 +116,6 @@ describe FilesController do
             end
 
             it { should respond_with :success }
-            it "should set an error message for the message field" do
-              expect { flash[:error].messages[:message] }.not_to be(nil)
-            end
             it "should not show a success message" do
               expect(flash[:success]).to be(nil)
             end

--- a/spec/controllers/files_controller_spec.rb
+++ b/spec/controllers/files_controller_spec.rb
@@ -103,10 +103,10 @@ describe FilesController do
 
             it { should respond_with :found }
             it "should not show an error" do
-              expect(flash[:error]).to be_nil
+              expect(flash[:error]).to be(nil)
             end
             it "should show a success message" do
-              expect(flash[:success]).not_to be_nil
+              expect(flash[:success]).not_to be(nil)
             end
           end
 
@@ -120,10 +120,10 @@ describe FilesController do
 
             it { should respond_with :success }
             it "should set an error message for the message field" do
-              expect { flash[:error].messages[:message] }.not_to be_nil
+              expect { flash[:error].messages[:message] }.not_to be(nil)
             end
             it "should not show a success message" do
-              expect(flash[:success]).to be_nil
+              expect(flash[:success]).to be(nil)
             end
           end
         end
@@ -140,13 +140,13 @@ describe FilesController do
 
           it { should respond_with :found }
           it "should not show an error" do
-            expect(flash[:error]).to be_nil
+            expect(flash[:error]).to be(nil)
           end
           it "should show a success message" do
-            expect(flash[:success]).not_to be_nil
+            expect(flash[:success]).not_to be(nil)
           end
           it "should have added a file" do
-            expect(repository.path_exists? filepath).to be_true
+            expect(repository.path_exists? filepath).to be(true)
           end
           it "should actually not have added a file" do
             pending "this should be another controller action"

--- a/spec/controllers/language_adjoint_controller_spec.rb
+++ b/spec/controllers/language_adjoint_controller_spec.rb
@@ -32,7 +32,10 @@ describe LanguageAdjointsController do
       before { get :show, id: adjoint.id, mapping_id: mapping.id }
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'on get to new' do
@@ -106,7 +109,10 @@ describe LanguageAdjointsController do
       before { get :edit, id: adjoint.id, mapping_id: mapping.id }
       it { should respond_with :success }
       it { should render_template :edit }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
   end
 
@@ -118,7 +124,10 @@ describe LanguageAdjointsController do
       before { get :show, id: adjoint.id, mapping_id: mapping.id }
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'on get to new' do
@@ -179,7 +188,10 @@ describe LanguageAdjointsController do
     context 'on GET to EDIT' do
       before { get :edit, id: adjoint.id, translation_id: mapping.id }
       it { should respond_with :redirect }
-      it { should set_the_flash.to(/not authorized/i) }
+
+      it 'sets the flash' do
+        expect(flash[:alert]).to match(/not authorized/)
+      end
     end
   end
 
@@ -188,14 +200,20 @@ describe LanguageAdjointsController do
       before { get :show, id: adjoint.id, translation_id: mapping.id }
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'on get to new' do
       before { get :new, translation_id: mapping.id }
 
       it { should respond_with :redirect }
-      it { should set_the_flash }
+
+      it 'sets the flash' do
+        expect(flash[:alert]).to match(/not authorized/)
+      end
     end
 
     context 'on POST to CREATE' do

--- a/spec/controllers/language_adjoint_controller_spec.rb
+++ b/spec/controllers/language_adjoint_controller_spec.rb
@@ -55,7 +55,7 @@ describe LanguageAdjointsController do
         let!(:adjoint_from_db) { LanguageAdjoint.find_by_iri('http://test.de') }
 
         it 'should exist' do
-          expect(adjoint_from_db).not_to be_nil
+          expect(adjoint_from_db).not_to be(nil)
         end
 
         it 'should have correct translation' do
@@ -81,7 +81,7 @@ describe LanguageAdjointsController do
         let!(:adjoint_from_db) { LanguageAdjoint.find_by_iri('http://test2.de') }
 
         it 'should exist' do
-          expect(adjoint_from_db).not_to be_nil
+          expect(adjoint_from_db).not_to be(nil)
         end
 
         it 'should have correct translation' do
@@ -98,7 +98,7 @@ describe LanguageAdjointsController do
       before { delete :destroy, id: adjoint.id, mapping_id: mapping.id }
 
       it 'remove the record' do
-        expect(LanguageAdjoint.find_by_id(adjoint.id)).to be_nil
+        expect(LanguageAdjoint.find_by_id(adjoint.id)).to be(nil)
       end
     end
 
@@ -141,7 +141,7 @@ describe LanguageAdjointsController do
         let!(:adjoint_from_db) { LanguageAdjoint.find_by_iri('http://test.de') }
 
         it 'should exist' do
-          expect(adjoint_from_db).not_to be_nil
+          expect(adjoint_from_db).not_to be(nil)
         end
 
         it 'should have correct translation' do
@@ -164,7 +164,7 @@ describe LanguageAdjointsController do
       end
 
       it 'not change the record' do
-        expect(LanguageAdjoint.find_by_iri('http://test2.de')).to be_nil
+        expect(LanguageAdjoint.find_by_iri('http://test2.de')).to be(nil)
       end
     end
 
@@ -208,7 +208,7 @@ describe LanguageAdjointsController do
       end
 
       it 'not create the record' do
-        expect(LanguageAdjoint.find_by_iri("http://test.de")).to be_nil
+        expect(LanguageAdjoint.find_by_iri("http://test.de")).to be(nil)
       end
     end
 
@@ -222,7 +222,7 @@ describe LanguageAdjointsController do
       end
 
       it 'not change the record' do
-        expect(LanguageAdjoint.find_by_iri('http://test2.de')).to be_nil
+        expect(LanguageAdjoint.find_by_iri('http://test2.de')).to be(nil)
       end
     end
 

--- a/spec/controllers/language_mappings_controller_spec.rb
+++ b/spec/controllers/language_mappings_controller_spec.rb
@@ -16,7 +16,10 @@ describe LanguageMappingsController do
       before { get :show, id: mapping.id, language_id: source_language.id }
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'on get to new' do
@@ -91,7 +94,10 @@ describe LanguageMappingsController do
       before { get :edit, id: mapping.id, language_id: source_language.id }
       it { should respond_with :success }
       it { should render_template :edit }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
   end
 
@@ -105,7 +111,10 @@ describe LanguageMappingsController do
       before { get :show, id: mapping.id, language_id: source_language.id }
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'on get to new' do
@@ -168,7 +177,10 @@ describe LanguageMappingsController do
     context 'on GET to EDIT' do
       before { get :edit, id: mapping.id, language_id: source_language.id }
       it { should respond_with :redirect }
-      it { should set_the_flash.to(/not authorized/i) }
+
+      it 'sets the flash' do
+        expect(flash[:alert]).to match(/not authorized/)
+      end
     end
   end
 
@@ -177,14 +189,20 @@ describe LanguageMappingsController do
       before { get :show, id: mapping.id, language_id: source_language.id }
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'on get to new' do
       before { get :new, language_id: source_language.id }
 
       it { should respond_with :redirect }
-      it { should set_the_flash }
+
+      it 'sets the flash' do
+        expect(flash[:alert]).to match(/not authorized/)
+      end
     end
   end
 

--- a/spec/controllers/language_mappings_controller_spec.rb
+++ b/spec/controllers/language_mappings_controller_spec.rb
@@ -39,7 +39,7 @@ describe LanguageMappingsController do
         let!(:mapping_from_db) { LanguageMapping.find_by_iri('http://test.de') }
 
         it 'should exist' do
-          expect(mapping_from_db).not_to be_nil
+          expect(mapping_from_db).not_to be(nil)
         end
 
         it 'should have correct source' do
@@ -66,7 +66,7 @@ describe LanguageMappingsController do
         let!(:mapping_from_db) { LanguageMapping.find_by_iri('http://test2.de') }
 
         it 'should exist' do
-          expect(mapping_from_db).not_to be_nil
+          expect(mapping_from_db).not_to be(nil)
         end
 
         it 'should have correct source' do
@@ -83,7 +83,7 @@ describe LanguageMappingsController do
       before { delete :destroy, id: mapping.id, language_id: source_language.id }
 
       it 'remove the record' do
-        expect(LanguageMapping.find_by_id(mapping.id)).to be_nil
+        expect(LanguageMapping.find_by_id(mapping.id)).to be(nil)
       end
     end
 
@@ -129,7 +129,7 @@ describe LanguageMappingsController do
         let!(:mapping_from_db) { LanguageMapping.find_by_iri('http://test.de') }
 
         it 'should exist' do
-          expect(mapping_from_db).not_to be_nil
+          expect(mapping_from_db).not_to be(nil)
         end
 
         it 'should have correct source' do
@@ -153,7 +153,7 @@ describe LanguageMappingsController do
       end
 
       it 'not change the record' do
-        expect(LanguageMapping.find_by_iri('http://test2.de')).to be_nil
+        expect(LanguageMapping.find_by_iri('http://test2.de')).to be(nil)
       end
     end
 
@@ -199,7 +199,7 @@ describe LanguageMappingsController do
     end
 
     it 'not create the record' do
-      expect(LanguageMapping.find_by_iri('http://test.de')).to be_nil
+      expect(LanguageMapping.find_by_iri('http://test.de')).to be(nil)
     end
   end
 
@@ -214,7 +214,7 @@ describe LanguageMappingsController do
     end
 
     it 'not change the record' do
-      expect(LanguageMapping.find_by_iri('http://test2.de')).to be_nil
+      expect(LanguageMapping.find_by_iri('http://test2.de')).to be(nil)
     end
   end
 

--- a/spec/controllers/languages_controller_spec.rb
+++ b/spec/controllers/languages_controller_spec.rb
@@ -10,7 +10,10 @@ describe LanguagesController do
 
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'signed in as Language-Owner' do
@@ -21,7 +24,10 @@ describe LanguagesController do
 
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
   end
 
@@ -30,7 +36,10 @@ describe LanguagesController do
 
     it { should respond_with :success }
     it { should render_template :index }
-    it { should_not set_the_flash }
+
+    it 'does not set the flash' do
+      expect(flash).to be_empty
+    end
   end
 
   context 'on POST to create' do
@@ -48,8 +57,10 @@ describe LanguagesController do
     end
 
     it { should respond_with :redirect }
-    it { should set_the_flash.to(/created/i) }
 
+    it 'sets the flash' do
+      expect(flash[:notice]).to match(/created/i)
+    end
   end
 
   context 'on POST to update' do
@@ -72,7 +83,10 @@ describe LanguagesController do
       end
 
       it { should respond_with :redirect }
-      it { should set_the_flash.to(/successfully updated/i) }
+
+      it 'sets the flash' do
+        expect(flash[:notice]).to match(/successfully updated/i)
+      end
     end
 
     context 'not signed in' do
@@ -91,7 +105,10 @@ describe LanguagesController do
       end
 
       it { should respond_with :redirect }
-      it { should_not set_the_flash.to(/successfully updated/i) }
+
+      it 'sets the flash' do
+        expect(flash[:alert]).not_to match(/successfully updated/i)
+      end
     end
 
     context 'not permitted' do
@@ -113,7 +130,10 @@ describe LanguagesController do
       end
 
       it { should respond_with :redirect }
-      it { should_not set_the_flash.to(/successfully updated/i) }
+
+      it 'sets the flash' do
+        expect(flash[:alert]).not_to match(/successfully updated/i)
+      end
     end
 
   end
@@ -130,7 +150,10 @@ describe LanguagesController do
       end
 
       it { should respond_with :redirect }
-      it { should set_the_flash.to(/successfully destroyed/i) }
+
+      it 'sets the flash' do
+        expect(flash[:notice]).to match(/successfully destroyed/i)
+      end
     end
 
     context 'not signed in' do
@@ -141,7 +164,10 @@ describe LanguagesController do
       end
 
       it { should respond_with :redirect }
-      it { should_not set_the_flash.to(/successfully destroyed/i) }
+
+      it 'sets the flash' do
+        expect(flash[:alert]).not_to match(/successfully destroyed/i)
+      end
     end
 
     context 'not permitted' do
@@ -156,7 +182,10 @@ describe LanguagesController do
       end
 
       it { should respond_with :redirect }
-      it { should_not set_the_flash.to(/successfully destroyed/i) }
+
+      it 'sets the flash' do
+        expect(flash[:alert]).not_to match(/successfully destroyed/i)
+      end
     end
 
   end

--- a/spec/controllers/logic_adjoint_controller_spec.rb
+++ b/spec/controllers/logic_adjoint_controller_spec.rb
@@ -55,7 +55,7 @@ describe LogicAdjointsController do
         let!(:adjoint_from_db) { LogicAdjoint.find_by_iri('http://test.de') }
 
         it 'should exist' do
-          expect(adjoint_from_db).not_to be_nil
+          expect(adjoint_from_db).not_to be(nil)
         end
 
         it 'should have correct translation' do
@@ -81,7 +81,7 @@ describe LogicAdjointsController do
         let!(:adjoint_from_db) { LogicAdjoint.find_by_iri('http://test2.de') }
 
         it 'should exist' do
-          expect(adjoint_from_db).not_to be_nil
+          expect(adjoint_from_db).not_to be(nil)
         end
 
         it 'should have correct translation' do
@@ -98,7 +98,7 @@ describe LogicAdjointsController do
       before { delete :destroy, id: adjoint.id, mapping_id: mapping.id }
 
       it 'remove the record' do
-        expect(LogicAdjoint.find_by_id(adjoint.id)).to be_nil
+        expect(LogicAdjoint.find_by_id(adjoint.id)).to be(nil)
       end
     end
 
@@ -141,7 +141,7 @@ describe LogicAdjointsController do
         let!(:adjoint_from_db) { LogicAdjoint.find_by_iri('http://test.de') }
 
         it 'should exist' do
-          expect(adjoint_from_db).not_to be_nil
+          expect(adjoint_from_db).not_to be(nil)
         end
 
         it 'should have correct translation' do
@@ -164,7 +164,7 @@ describe LogicAdjointsController do
       end
 
       it 'not change the record' do
-        expect(LogicAdjoint.find_by_iri('http://test2.de')).to be_nil
+        expect(LogicAdjoint.find_by_iri('http://test2.de')).to be(nil)
       end
     end
 
@@ -208,7 +208,7 @@ describe LogicAdjointsController do
       end
 
       it 'not create the record' do
-        expect(LogicAdjoint.find_by_iri("http://test.de")).to be_nil
+        expect(LogicAdjoint.find_by_iri("http://test.de")).to be(nil)
       end
     end
 
@@ -222,7 +222,7 @@ describe LogicAdjointsController do
       end
 
       it 'not change the record' do
-        expect(LogicAdjoint.find_by_iri('http://test2.de')).to be_nil
+        expect(LogicAdjoint.find_by_iri('http://test2.de')).to be(nil)
       end
     end
 

--- a/spec/controllers/logic_adjoint_controller_spec.rb
+++ b/spec/controllers/logic_adjoint_controller_spec.rb
@@ -32,7 +32,10 @@ describe LogicAdjointsController do
       before { get :show, id: adjoint.id, mapping_id: mapping.id }
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'on get to new' do
@@ -106,7 +109,10 @@ describe LogicAdjointsController do
       before { get :edit, id: adjoint.id, mapping_id: mapping.id }
       it { should respond_with :success }
       it { should render_template :edit }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
   end
 
@@ -118,7 +124,10 @@ describe LogicAdjointsController do
       before { get :show, id: adjoint.id, mapping_id: mapping.id }
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'on get to new' do
@@ -179,7 +188,10 @@ describe LogicAdjointsController do
     context 'on GET to EDIT' do
       before { get :edit, id: adjoint.id, translation_id: mapping.id }
       it { should respond_with :redirect }
-      it { should set_the_flash.to(/not authorized/i) }
+
+      it 'sets the flash' do
+        expect(flash[:alert]).to match(/not authorized/)
+      end
     end
   end
 
@@ -188,14 +200,20 @@ describe LogicAdjointsController do
       before { get :show, id: adjoint.id, translation_id: mapping.id }
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'on get to new' do
       before { get :new, translation_id: mapping.id }
 
       it { should respond_with :redirect }
-      it { should set_the_flash }
+
+      it 'sets the flash' do
+        expect(flash[:alert]).to match(/not authorized/)
+      end
     end
 
     context 'on POST to CREATE' do

--- a/spec/controllers/logic_mappings_controller_spec.rb
+++ b/spec/controllers/logic_mappings_controller_spec.rb
@@ -40,7 +40,7 @@ describe LogicMappingsController do
         let!(:mapping_from_db) { LogicMapping.find_by_iri('http://test.de') }
 
         it 'should exist' do
-          expect(mapping_from_db).not_to be_nil
+          expect(mapping_from_db).not_to be(nil)
         end
 
         it 'should have correct source' do
@@ -67,7 +67,7 @@ describe LogicMappingsController do
         let!(:mapping_from_db) { LogicMapping.find_by_iri('http://test2.de') }
 
         it 'should exist' do
-          expect(mapping_from_db).not_to be_nil
+          expect(mapping_from_db).not_to be(nil)
         end
 
         it 'should have correct source' do
@@ -84,7 +84,7 @@ describe LogicMappingsController do
       before { delete :destroy, id: mapping.to_param, logic_id: source_logic.id }
 
       it 'remove the record' do
-        expect(LogicMapping.find_by_id(mapping.id)).to be_nil
+        expect(LogicMapping.find_by_id(mapping.id)).to be(nil)
       end
     end
 
@@ -128,7 +128,7 @@ describe LogicMappingsController do
         let!(:mapping_from_db) { LogicMapping.find_by_iri('http://test.de') }
 
         it 'should exist' do
-          expect(mapping_from_db).not_to be_nil
+          expect(mapping_from_db).not_to be(nil)
         end
 
         it 'should have correct source' do
@@ -152,7 +152,7 @@ describe LogicMappingsController do
       end
 
       it 'not change the record' do
-        expect(LogicMapping.find_by_iri('http://test2.de')).to be_nil
+        expect(LogicMapping.find_by_iri('http://test2.de')).to be(nil)
       end
     end
 
@@ -198,7 +198,7 @@ describe LogicMappingsController do
     end
 
     it 'not create the record' do
-      expect(LogicMapping.find_by_iri('http://test.de')).to be_nil
+      expect(LogicMapping.find_by_iri('http://test.de')).to be(nil)
     end
   end
 
@@ -213,7 +213,7 @@ describe LogicMappingsController do
     end
 
     it 'not change the record' do
-      expect(LogicMapping.find_by_iri('http://test2.de')).to be_nil
+      expect(LogicMapping.find_by_iri('http://test2.de')).to be(nil)
     end
   end
 

--- a/spec/controllers/logic_mappings_controller_spec.rb
+++ b/spec/controllers/logic_mappings_controller_spec.rb
@@ -16,7 +16,10 @@ describe LogicMappingsController do
       before { get :show, id: mapping.to_param, logic_id: source_logic.id }
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'on get to new' do
@@ -92,7 +95,10 @@ describe LogicMappingsController do
       before { get :edit, id: mapping.to_param, logic_id: source_logic.id }
       it { should respond_with :success }
       it { should render_template :edit }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
   end
 
@@ -104,7 +110,10 @@ describe LogicMappingsController do
       before { get :show, id: mapping.to_param, logic_id: source_logic.id }
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'on get to new' do
@@ -167,7 +176,10 @@ describe LogicMappingsController do
     context 'on GET to EDIT' do
       before { get :edit, id: mapping.to_param, logic_id: source_logic.id }
       it { should respond_with :redirect }
-      it { should set_the_flash.to(/not authorized/i) }
+
+      it 'sets the flash' do
+        expect(flash[:alert]).to match(/not authorized/)
+      end
     end
   end
 
@@ -176,14 +188,20 @@ describe LogicMappingsController do
       before { get :show, id: mapping.to_param, logic_id: source_logic.id }
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'on get to new' do
       before { get :new, logic_id: source_logic.id }
 
       it { should respond_with :redirect }
-      it { should set_the_flash }
+
+      it 'sets the flash' do
+        expect(flash[:alert]).to match(/not authorized/)
+      end
     end
   end
 

--- a/spec/controllers/logics_controller_spec.rb
+++ b/spec/controllers/logics_controller_spec.rb
@@ -11,7 +11,10 @@ describe LogicsController do
 
         it { should respond_with :success }
         it { should render_template :show }
-        it { should_not set_the_flash }
+
+        it 'does not set the flash' do
+          expect(flash).to be_empty
+        end
       end
 
       context 'signed in as Logic-Owner' do
@@ -22,7 +25,10 @@ describe LogicsController do
 
         it { should respond_with :success }
         it { should render_template :show }
-        it { should_not set_the_flash }
+
+        it 'does not set the flash' do
+          expect(flash).to be_empty
+        end
       end
     end
   end
@@ -32,6 +38,9 @@ describe LogicsController do
 
     it { should respond_with :success }
     it { should render_template :index }
-    it { should_not set_the_flash }
+
+    it 'does not set the flash' do
+      expect(flash).to be_empty
+    end
   end
 end

--- a/spec/controllers/ontologies_controller_spec.rb
+++ b/spec/controllers/ontologies_controller_spec.rb
@@ -60,7 +60,10 @@ describe OntologiesController do
           delete :destroy, repository_id: repository.to_param, id: ontology.id
         end
 
-        it{ should set_the_flash.to(/is imported/) }
+        it 'sets the flash' do
+          expect(flash[:error]).to match(/is imported/)
+        end
+
         it{ should respond_with :found }
         it{ response.should redirect_to [repository, ontology] }
       end

--- a/spec/controllers/ontology_versions_controller_spec.rb
+++ b/spec/controllers/ontology_versions_controller_spec.rb
@@ -39,7 +39,7 @@ describe OntologyVersionsController do
 
       context 'for a single ontology' do
         it 'should assign the right versions' do
-          expect(assigns(:versions)).to_not be_nil
+          expect(assigns(:versions)).to_not be(nil)
         end
       end
     end

--- a/spec/controllers/permissions_controller_spec.rb
+++ b/spec/controllers/permissions_controller_spec.rb
@@ -79,7 +79,10 @@ describe PermissionsController do
       context 'not signed in' do
         before { get :index, repository_id: ontology.repository.to_param }
 
-        it { should set_the_flash.to(/not authorized/) }
+        it 'sets the flash' do
+          expect(flash[:alert]).to match(/not authorized/)
+        end
+
         it { should redirect_to(:root) }
       end
     end

--- a/spec/controllers/proofs_controller_spec.rb
+++ b/spec/controllers/proofs_controller_spec.rb
@@ -34,7 +34,7 @@ describe ProofsController do
         end
 
         it 'set the flash/success' do
-          expect(flash[:success]).not_to be_nil
+          expect(flash[:success]).not_to be(nil)
         end
 
         it { should respond_with :found }
@@ -60,7 +60,7 @@ describe ProofsController do
         end
 
         it 'set the flash/alert' do
-          expect(flash[:alert]).not_to be_nil
+          expect(flash[:alert]).not_to be(nil)
         end
 
         it { should respond_with :found }
@@ -141,7 +141,7 @@ describe ProofsController do
         end
 
         it 'set the flash/success' do
-          expect(flash[:success]).not_to be_nil
+          expect(flash[:success]).not_to be(nil)
         end
 
         it { should respond_with :found }
@@ -169,7 +169,7 @@ describe ProofsController do
         end
 
         it 'set the flash/alert' do
-          expect(flash[:alert]).not_to be_nil
+          expect(flash[:alert]).not_to be(nil)
         end
 
         it { should respond_with :found }

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -24,7 +24,10 @@ describe RepositoriesController do
           delete :destroy, id: repository.to_param
         end
 
-        it{ should set_the_flash.to(/is imported/) }
+        it 'sets the flash' do
+          expect(flash[:error]).to match(/is imported/)
+        end
+
         it{ should respond_with :found }
         it{ response.should redirect_to repository }
       end

--- a/spec/controllers/serializations_controller_spec.rb
+++ b/spec/controllers/serializations_controller_spec.rb
@@ -35,7 +35,7 @@ describe SerializationsController do
       context 'create the record' do
         let!(:serial_from_db) { Serialization.find_by_name('test132') }
         it 'should exist' do
-          expect(serial_from_db).not_to be_nil
+          expect(serial_from_db).not_to be(nil)
         end
 
         it 'should have correct mime type' do
@@ -58,7 +58,7 @@ describe SerializationsController do
       context 'change the record' do
         let!(:serial_from_db) { Serialization.find_by_name('test4325') }
         it 'should exist' do
-          expect(serial_from_db).not_to be_nil
+          expect(serial_from_db).not_to be(nil)
         end
 
         it 'should have correct mime type' do
@@ -75,7 +75,7 @@ describe SerializationsController do
       before { delete :destroy, id: serial.id }
 
       it 'remove the record' do
-        expect(Serialization.find_by_id(serial.id)).to be_nil
+        expect(Serialization.find_by_id(serial.id)).to be(nil)
       end
     end
 
@@ -116,7 +116,7 @@ describe SerializationsController do
       context 'create the record' do
         let!(:serial_from_db) { Serialization.find_by_name('test132') }
         it 'should exist' do
-          expect(serial_from_db).not_to be_nil
+          expect(serial_from_db).not_to be(nil)
         end
 
         it 'should have correct mime type' do
@@ -140,7 +140,7 @@ describe SerializationsController do
       context 'change the record' do
         let!(:serial_from_db) { Serialization.find_by_name('test4325') }
         it 'should exist' do
-          expect(serial_from_db).not_to be_nil
+          expect(serial_from_db).not_to be(nil)
         end
 
         it 'should have correct mime type' do
@@ -157,7 +157,7 @@ describe SerializationsController do
       before { delete :destroy, id: serial.id }
 
       it 'remove the record' do
-        expect(Serialization.find_by_id(serial.id)).to be_nil
+        expect(Serialization.find_by_id(serial.id)).to be(nil)
       end
     end
 
@@ -194,7 +194,7 @@ describe SerializationsController do
       end
 
       it 'not create the record' do
-        expect(Serialization.find_by_name('test2')).to be_nil
+        expect(Serialization.find_by_name('test2')).to be(nil)
       end
     end
     context 'on PUT to Update' do
@@ -207,7 +207,7 @@ describe SerializationsController do
       end
 
       it 'not change the record' do
-        expect(Serialization.find_by_name('test2')).to be_nil
+        expect(Serialization.find_by_name('test2')).to be(nil)
       end
     end
 

--- a/spec/controllers/serializations_controller_spec.rb
+++ b/spec/controllers/serializations_controller_spec.rb
@@ -13,7 +13,10 @@ describe SerializationsController do
 
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'on get to new' do
@@ -83,7 +86,10 @@ describe SerializationsController do
       before { get :edit, id: serial.id }
       it { should respond_with :success }
       it { should render_template :edit }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
   end
 
@@ -95,7 +101,10 @@ describe SerializationsController do
       before { get :show, id: serial.id }
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'on get to new' do
@@ -165,7 +174,10 @@ describe SerializationsController do
       before { get :edit, id: serial.id }
       it { should respond_with :success }
       it { should render_template :edit }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
   end
 
@@ -174,14 +186,20 @@ describe SerializationsController do
       before { get :show, id: serial.id, language_id: language.id }
       it { should respond_with :success }
       it { should render_template :show }
-      it { should_not set_the_flash }
+
+      it 'does not set the flash' do
+        expect(flash).to be_empty
+      end
     end
 
     context 'on get to new' do
       before { get :new, language_id: language.id }
 
       it { should respond_with :redirect }
-      it { should set_the_flash }
+
+      it 'sets the flash' do
+        expect(flash[:alert]).to match(/not authorized/)
+      end
     end
 
     context 'on POST to CREATE' do

--- a/spec/controllers/team_users_controller_spec.rb
+++ b/spec/controllers/team_users_controller_spec.rb
@@ -24,7 +24,11 @@ describe TeamUsersController do
         sign_in user
         get :index, team_id: team.to_param
       end
-      it { should set_the_flash.to(/not authorized/) }
+
+      it 'sets the flash' do
+        expect(flash[:alert]).to match(/not authorized/)
+      end
+
       it { should redirect_to(:root) }
     end
   end

--- a/spec/controllers/teams/permissions_controller_spec.rb
+++ b/spec/controllers/teams/permissions_controller_spec.rb
@@ -8,7 +8,10 @@ describe Teams::PermissionsController do
     context 'not signed in' do
       before { get :index, team_id: team.to_param }
 
-      it { should set_the_flash.to(/not authorized/) }
+      it 'sets the flash' do
+        expect(flash[:alert]).to match(/not authorized/)
+      end
+
       it { should respond_with :redirect }
     end
 

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -5,7 +5,9 @@ describe TeamsController do
     context 'on GET to index' do
       before { get :index }
 
-      it { should set_the_flash.to(/not authorized/) }
+      it 'sets the flash' do
+        expect(flash[:alert]).to match(/not authorized/)
+      end
       it { should redirect_to(:root) }
     end
   end
@@ -57,7 +59,10 @@ describe TeamsController do
           before { delete :destroy, id: team.id }
 
           it { should redirect_to(Team) }
-          it { should set_the_flash.to(/destroyed/) }
+
+          it 'sets the flash' do
+            expect(flash[:notice]).to match(/destroyed/)
+          end
         end
 
         context 'by non-admin' do
@@ -69,7 +74,10 @@ describe TeamsController do
           end
 
           it { should redirect_to(:root) }
-          it { should set_the_flash.to(/not authorized/) }
+
+          it 'sets the flash' do
+            expect(flash[:alert]).to match(/not authorized/)
+          end
         end
       end
     end

--- a/spec/lib/concurrency_balancer_spec.rb
+++ b/spec/lib/concurrency_balancer_spec.rb
@@ -96,7 +96,7 @@ describe ConcurrencyBalancer do
     it "should still release the lock on internal errors" do
       expect { ConcurrencyBalancer.sequential_lock { raise ArgumentError } }.
         to raise_error(ArgumentError)
-      expect(redis.sismember ConcurrencyBalancer::REDIS_KEY, 'iri').to be_false
+      expect(redis.sismember ConcurrencyBalancer::REDIS_KEY, 'iri').to be(false)
     end
   end
 

--- a/spec/lib/proof_spec.rb
+++ b/spec/lib/proof_spec.rb
@@ -147,7 +147,7 @@ describe Proof do
         it 'are created' do
           proof.proof_attempts.each do |proof_attempt|
             expect(proof_attempt.reload.proof_attempt_configuration).
-              not_to be_nil
+              not_to be(nil)
           end
         end
 
@@ -305,7 +305,7 @@ describe Proof do
         it 'are created' do
           proof.proof_attempts.each do |proof_attempt|
             expect(proof_attempt.reload.proof_attempt_configuration).
-              not_to be_nil
+              not_to be(nil)
           end
         end
 

--- a/spec/lib/repository/diff_spec.rb
+++ b/spec/lib/repository/diff_spec.rb
@@ -29,7 +29,7 @@ describe "git diff" do
   end
 
   it 'should detect that the last commit is the HEAD' do
-    expect(repository.is_head?(@commit3)).to be_true
+    expect(repository.is_head?(@commit3)).to be(true)
   end
 
   it 'should have the right file count when using the first commit' do
@@ -45,12 +45,12 @@ describe "git diff" do
   end
 
   it 'should have the type added in the list when using the first commit' do
-    expect(repository.changed_files(@commit1).first.added?).to be_true
+    expect(repository.changed_files(@commit1).first.added?).to be(true)
   end
 
   %w(modified deleted renamed).each do |status|
     it "should have the type #{status} in the list when using the first commit" do
-      expect(repository.changed_files(@commit1).first.send("#{status}?")).to be_false
+      expect(repository.changed_files(@commit1).first.send("#{status}?")).to be(false)
     end
   end
 
@@ -65,7 +65,7 @@ describe "git diff" do
   end
 
   it 'should have the right editable in the list when using the first commit' do
-    expect(repository.changed_files(@commit1).first.editable?).to be_true
+    expect(repository.changed_files(@commit1).first.editable?).to be(true)
   end
 
 
@@ -82,12 +82,12 @@ describe "git diff" do
   end
 
   it 'should have the type modified in the list when using a commit in the middle' do
-    expect(repository.changed_files(@commit2).first.modified?).to be_true
+    expect(repository.changed_files(@commit2).first.modified?).to be(true)
   end
 
   %w(added deleted renamed).each do |status|
     it "should have the type #{status} in the list when using a commit in the middle" do
-      expect(repository.changed_files(@commit2).first.send("#{status}?")).to be_false
+      expect(repository.changed_files(@commit2).first.send("#{status}?")).to be(false)
     end
   end
 
@@ -102,7 +102,7 @@ describe "git diff" do
   end
 
   it 'should have the right editable in the list when using a commit in the middle' do
-    expect(repository.changed_files(@commit2).first.editable?).to be_true
+    expect(repository.changed_files(@commit2).first.editable?).to be(true)
   end
 
 
@@ -119,12 +119,12 @@ describe "git diff" do
   end
 
   it 'should have the type deleted in the list when using the HEAD' do
-    expect(repository.changed_files.first.deleted?).to be_true
+    expect(repository.changed_files.first.deleted?).to be(true)
   end
 
   %w(added modified renamed).each do |status|
     it "should have the type #{status} in the list when using the HEAD" do
-      expect(repository.changed_files.first.send("#{status}?")).to be_false
+      expect(repository.changed_files.first.send("#{status}?")).to be(false)
     end
   end
 
@@ -138,6 +138,6 @@ describe "git diff" do
   end
 
   it 'should have the right editable in the list when using the HEAD' do
-    expect(repository.changed_files.first.editable?).to be_true
+    expect(repository.changed_files.first.editable?).to be(true)
   end
 end

--- a/spec/lib/repository/files_spec.rb
+++ b/spec/lib/repository/files_spec.rb
@@ -19,7 +19,7 @@ describe 'GitRepositoryFiles' do
   context 'create single commit of a file' do
     before { repository.commit_file(userinfo, content, filepath, message) }
 
-    it { expect(repository.path_exists?(filepath)).to be_true }
+    it { expect(repository.path_exists?(filepath)).to be(true) }
     it { expect(repository.get_file(filepath).name).to eq(filepath.split('/')[-1]) }
     it { expect(repository.get_file(filepath).content).to eq(content) }
     it { expect(repository.get_file(filepath).mime_type).to eq(Mime::Type.lookup('text/plain')) }
@@ -34,7 +34,7 @@ describe 'GitRepositoryFiles' do
       repository.delete_file(userinfo, filepath)
     end
 
-    it { expect(repository.path_exists?(filepath)).to be_false }
+    it { expect(repository.path_exists?(filepath)).to be(false) }
   end
 
   context 'overwrite a file' do
@@ -58,9 +58,9 @@ describe 'GitRepositoryFiles' do
 
     before { repository.commit_file(userinfo, content, fullpath, message) }
 
-    it { expect(repository.points_through_file?(folder)).to be_false }
-    it { expect(repository.points_through_file?(fullpath)).to be_false }
-    it { expect(repository.points_through_file?("#{fullpath}/foo")).to be_true }
+    it { expect(repository.points_through_file?(folder)).to be(false) }
+    it { expect(repository.points_through_file?(fullpath)).to be(false) }
+    it { expect(repository.points_through_file?("#{fullpath}/foo")).to be(true) }
   end
 
   context 'throw Exception on erroneous paths' do

--- a/spec/lib/repository/files_spec.rb
+++ b/spec/lib/repository/files_spec.rb
@@ -96,7 +96,7 @@ describe 'GitRepositoryFiles' do
     end
     #feature not implemented yet:
     it 'feature not implemented yet' do
-      pending { expect(@first_commit_oid).to eq(repository.head_oid) }
+      skip { expect(@first_commit_oid).to eq(repository.head_oid) }
     end
   end
 end

--- a/spec/lib/repository/history_spec.rb
+++ b/spec/lib/repository/history_spec.rb
@@ -151,7 +151,7 @@ describe "git history" do
     context 'state check' do
       it 'should detect that a file has not changed' do
         expect(repository.has_changed?(filepath, commit_add1, commit_add1)).
-          to be_false
+          to be(false)
       end
 
       it 'should detect that a file has changed' do
@@ -160,7 +160,7 @@ describe "git history" do
           [commit_delete1, commit_add2],
           [commit_delete1, commit_delete2] ].each do |previous, current|
           expect(repository.has_changed?(filepath, previous, current)).
-            to be_true
+            to be(true)
         end
       end
     end

--- a/spec/lib/repository/import/git_spec.rb
+++ b/spec/lib/repository/import/git_spec.rb
@@ -28,7 +28,7 @@ describe "git import" do
   end
 
   it 'set imported_at' do
-    expect(repository.reload.imported_at).not_to be_nil
+    expect(repository.reload.imported_at).not_to be(nil)
   end
 
   it 'have all the commits' do

--- a/spec/lib/tarjan_spec.rb
+++ b/spec/lib/tarjan_spec.rb
@@ -14,7 +14,7 @@ describe TarjanTree do
       it 'should have an symbol-tree' do
         ontology.symbol_groups.size.should == 3
         symbols = ontology.symbols.where(name: ["B1","B2","B3"])
-        expect(ontology.symbol_groups.includes(:symbols).where("symbols.id" => symbols).first).not_to be_nil
+        expect(ontology.symbol_groups.includes(:symbols).where("symbols.id" => symbols).first).not_to be(nil)
       end
 
       it 'should have an congruence node' do

--- a/spec/models/code_reference_spec.rb
+++ b/spec/models/code_reference_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 describe CodeReference do
-  pending "add some examples to (or delete) #{__FILE__}"
+  skip "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/hets_instance_spec.rb
+++ b/spec/models/hets_instance_spec.rb
@@ -57,7 +57,7 @@ describe HetsInstance do
       end
 
       it 'should have a non-null version' do
-        expect(hets_instance.version).to_not be_nil
+        expect(hets_instance.version).to_not be(nil)
       end
 
       it 'should have a correct general_version' do
@@ -81,15 +81,15 @@ describe HetsInstance do
       end
 
       it 'should have a nil version' do
-        expect(hets_instance.version).to be_nil
+        expect(hets_instance.version).to be(nil)
       end
 
       it 'should have a nil general_version' do
-        expect(hets_instance.general_version).to be_nil
+        expect(hets_instance.general_version).to be(nil)
       end
 
       it 'should have a nil specific version' do
-        expect(hets_instance.specific_version).to be_nil
+        expect(hets_instance.specific_version).to be(nil)
       end
     end
   end

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -35,7 +35,7 @@ describe Mapping do
           end
 
           it 'has a mapping-version set' do
-            expect(mapping.mapping_version).to_not be_nil
+            expect(mapping.mapping_version).to_not be(nil)
           end
 
           it 'has a mapping-version that points to the current mapping-version' do

--- a/spec/models/ontology_spec.rb
+++ b/spec/models/ontology_spec.rb
@@ -253,7 +253,7 @@ describe Ontology do
       end
 
       it 'should have an ontology-version' do
-        expect(ontology.ontology_version).to_not be_nil
+        expect(ontology.ontology_version).to_not be(nil)
       end
 
     end
@@ -300,11 +300,11 @@ describe Ontology do
   #   end
 
   #   it 'should have an ontology-version' do
-  #     expect(ontology.ontology_version).to_not be_nil
+  #     expect(ontology.ontology_version).to_not be(nil)
   #   end
 
   #   it 'should have a referenced ontology with an ontology-version' do
-  #     expect(referenced_ontology.ontology_version).to_not be_nil
+  #     expect(referenced_ontology.ontology_version).to_not be(nil)
   #   end
   # end
 
@@ -429,7 +429,7 @@ describe Ontology do
     end
 
     it 'should create a combined ontology' do
-      expect(combined).to_not be_nil
+      expect(combined).to_not be(nil)
     end
 
     context 'kinds' do

--- a/spec/models/ontology_version_spec.rb
+++ b/spec/models/ontology_version_spec.rb
@@ -68,11 +68,11 @@ describe OntologyVersion do
       end
 
       it 'should have state_updated_at' do
-        expect(ontology_version.state_updated_at).to_not be_nil
+        expect(ontology_version.state_updated_at).to_not be(nil)
       end
 
       it 'should contain a commit' do
-        expect(commit).to_not be_nil
+        expect(commit).to_not be(nil)
       end
 
       it 'should contain a commit which refers to commit_oid' do

--- a/spec/models/repository/save_file_spec.rb
+++ b/spec/models/repository/save_file_spec.rb
@@ -25,7 +25,7 @@ describe 'Repository saving a file' do
       end
 
       it 'create the file in the git repository' do
-        expect(repository.git.path_exists?(target_path)).to be_true
+        expect(repository.git.path_exists?(target_path)).to be(true)
       end
 
       it 'create the file with correct contents in the git repository' do

--- a/spec/models/repository/symlink_spec.rb
+++ b/spec/models/repository/symlink_spec.rb
@@ -10,7 +10,7 @@ describe Repository::Symlink do
 
     describe 'repository destroy' do
       before { repository.destroy }
-      it("symlink removed"){ repository.symlink_name.exist?.should be_false }
+      it("symlink removed"){ repository.symlink_name.exist?.should be(false) }
     end
   end
 

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -72,7 +72,7 @@ describe Repository do
       let(:permission) { repository.permissions.first }
 
       it 'permission should not be nil' do
-        expect(permission).not_to be_nil
+        expect(permission).not_to be(nil)
       end
 
       it 'permission should have subject' do

--- a/spec/models/sentence_spec.rb
+++ b/spec/models/sentence_spec.rb
@@ -66,7 +66,7 @@ describe Sentence do
       before { parse_ontology(user, ontology, 'owl/generations.owl') }
 
       it 'should have display_text set' do
-        expect(sentence.display_text).to_not be_nil
+        expect(sentence.display_text).to_not be(nil)
       end
 
       it "should not contain symbols' iris" do

--- a/spec/models/symbol_mapping_spec.rb
+++ b/spec/models/symbol_mapping_spec.rb
@@ -15,7 +15,7 @@ describe SymbolMapping do
       let(:ontology) { dist_ontology.children.find_by_name('test') }
 
       it 'should not contain the mapped symbol' do
-        expect(ontology.symbols.find_by_name('Human')).to be_nil
+        expect(ontology.symbols.find_by_name('Human')).to be(nil)
       end
 
     end

--- a/spec/models/symbol_spec.rb
+++ b/spec/models/symbol_spec.rb
@@ -74,7 +74,7 @@ describe OntologyMember::Symbol do
         end
 
         it 'should have iri set to nil' do
-          expect(symbol.iri).to be_nil
+          expect(symbol.iri).to be(nil)
         end
       end
     end
@@ -123,11 +123,11 @@ describe OntologyMember::Symbol do
         before { ontology.symbols.update_or_create_from_hash(symbol_hash) }
 
         it 'should have display_name not set to nil' do
-          expect(symbol.display_name).to_not be_nil
+          expect(symbol.display_name).to_not be(nil)
         end
 
         it 'should have the iri set to nil' do
-          expect(symbol.iri).to be_nil
+          expect(symbol.iri).to be(nil)
         end
       end
     end

--- a/spec/models/translated_sentence_spec.rb
+++ b/spec/models/translated_sentence_spec.rb
@@ -10,7 +10,7 @@ describe TranslatedSentence do
     context 'translated sentences should be created correctly' do
 
       it 'should contain a translated sentence for AudiA4 is Audi' do
-        expect(TranslatedSentence.where(translated_text: 'Class: AudiA4 SubClassOf: Car')).not_to be_nil
+        expect(TranslatedSentence.where(translated_text: 'Class: AudiA4 SubClassOf: Car')).not_to be(nil)
       end
 
     end

--- a/spec/models/url_map_spec.rb
+++ b/spec/models/url_map_spec.rb
@@ -51,7 +51,7 @@ describe UrlMap do
       describe 'source not unique' do
         it do
           url_map2 = url_map.dup
-          url_map2.errors.should_not be_nil
+          url_map2.errors.should_not be(nil)
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -34,26 +34,26 @@ describe User do
     end
 
     it 'have email' do
-      expect(user.email).not_to be_nil
+      expect(user.email).not_to be(nil)
     end
 
     it 'have name' do
-      expect(user.name).not_to be_nil
+      expect(user.name).not_to be(nil)
     end
 
     it 'not have deleted_at' do
-      expect(user.deleted_at).to be_nil
+      expect(user.deleted_at).to be(nil)
     end
 
     context 'after deletion' do
       before { user.delete }
 
       it 'have blank email' do
-        expect(user.email).to be_nil
+        expect(user.email).to be(nil)
       end
 
       it 'have deleted_at' do
-        expect(user.deleted_at).not_to be_nil
+        expect(user.deleted_at).not_to be(nil)
       end
     end
 


### PR DESCRIPTION
This removes deprecated method calls in our specs. It only changes what is not already done in #1317. When #1317 and this PR are merged, rspec should no longer print deprecation warnings.