### PR TITLE
Use less verbose test output formatter

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
---format documentation
+--require ./spec/support/documentation_progress_formatter.rb
+--format DocumentationProgressFormatter

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - 'gem install bundler'
 
 script:
-  - SPEC_OPTS="--format documentation" ELASTIC_TEST_PORT=9200 bundle exec rake
+  - SPEC_OPTS='--format documentation' CUCUMBER_OPTS='--format pretty' ELASTIC_TEST_PORT=9200 bundle exec rake
 
 before_script:
   - psql -c 'create database ontohub_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - 'gem install bundler'
 
 script:
-  - ELASTIC_TEST_PORT=9200 bundle exec rake
+  - SPEC_OPTS="--format documentation" ELASTIC_TEST_PORT=9200 bundle exec rake
 
 before_script:
   - psql -c 'create database ontohub_test;' -U postgres

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,7 +1,7 @@
 <%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --tags ~@wip"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'ScenarioProgressFormatter'} --tags ~@wip"
 %>
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -15,6 +15,7 @@ Capybara.default_wait_time = 5
 
 class Cucumber::Rails::World
   require Rails.root.join('spec', 'support', 'common_helper_methods.rb')
+  require Rails.root.join('spec', 'support', 'scenario_progress_formatter.rb')
 
   def locid_for(resource, *commands, **query_components)
     iri = "#{resource.locid}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,7 @@ class ActionController::TestRequest
 end
 
 require Rails.root.join('spec', 'support', 'common_helper_methods.rb')
+require Rails.root.join('spec', 'support', 'documentation_progress_formatter.rb')
 
 def stub_cp_keys
   allow(AuthorizedKeysManager).to receive(:copy_authorized_keys_to_git_home)

--- a/spec/support/documentation_progress_formatter.rb
+++ b/spec/support/documentation_progress_formatter.rb
@@ -1,0 +1,63 @@
+require "rspec/core/formatters/base_text_formatter"
+
+class DocumentationProgressFormatter < RSpec::Core::Formatters::BaseTextFormatter
+  MAX_GROUP_LEVEL = 2
+
+  def initialize(output)
+    super(output)
+    @group_level = 0
+  end
+
+  def example_group_started(example_group)
+    super(example_group)
+
+    if @group_level < MAX_GROUP_LEVEL
+      output.puts if @group_level == 0
+      output.puts
+      output.print "#{current_indentation}#{example_group.description.strip}"
+      output.print ' '
+    end
+
+    @group_level += 1
+  end
+
+  def example_group_finished(example_group)
+    @group_level -= 1
+  end
+
+  def stop
+    output.puts
+    output.puts
+  end
+
+  def example_passed(example)
+    super(example)
+    output.print passed_output(example)
+  end
+
+  def example_pending(example)
+    super(example)
+    output.print pending_output(example)
+  end
+
+  def example_failed(example)
+    super(example)
+    output.print failure_output(example)
+  end
+
+  def failure_output(example)
+    failure_color('F')
+  end
+
+  def passed_output(example)
+    success_color('.')
+  end
+
+  def pending_output(example)
+    pending_color('*')
+  end
+
+  def current_indentation
+    '  ' * @group_level
+  end
+end

--- a/spec/support/scenario_progress_formatter.rb
+++ b/spec/support/scenario_progress_formatter.rb
@@ -2,8 +2,27 @@ require 'cucumber/formatter/progress'
 
 class ScenarioProgressFormatter < Cucumber::Formatter::Progress
   SCENARIO_INDENT = 2
+  EXCEPTION_INDENT = SCENARIO_INDENT + 2
+
+  def initialize(runtime, path_or_io, options)
+    super(runtime, path_or_io, options)
+    @failed_scenario_steps = []
+  end
 
   def after_feature_element(feature_element)
+    super(feature_element)
+    @io.puts
+    @io.flush
+  end
+
+  def before_feature_element(feature_element)
+    super(feature_element)
+    @processed_steps = [@current_feature]
+    @failed = false
+  end
+
+  def after_feature_element(feature_element)
+    @failed_scenario_steps << @processed_steps if @failed
     super(feature_element)
     @io.puts
     @io.flush
@@ -17,25 +36,41 @@ class ScenarioProgressFormatter < Cucumber::Formatter::Progress
   def before_steps(*_args)
     super(*_args)
     @io.print(' ')
+    @io.flush
   end
 
   def tag_name(tag_name)
     tag = format_string(tag_name, :tag).indent(SCENARIO_INDENT)
+    @processed_steps << tag
     @io.puts(tag)
     @io.flush
   end
 
   def feature_name(keyword, name)
+    @current_feature = "Feature: #{name}"
     @io.puts("#{keyword}: #{name}")
     @io.flush
   end
 
   def background_name(keyword, name, file_colon_line, source_indent)
+    @processed_steps << "Background: #{name}"
     print_feature_element_name(keyword, name, file_colon_line, source_indent)
   end
 
   def scenario_name(keyword, name, file_colon_line, source_indent)
+    @processed_steps << "Scenario: #{name}"
     print_feature_element_name(keyword, name, file_colon_line, source_indent)
+  end
+
+  def step_name(keyword, step_match, status, source_indent, background, file_colon_line)
+    name_to_report = format_step(keyword, step_match, status, source_indent)
+    @processed_steps << "Step: #{name_to_report}"
+  end
+
+  def exception(exception, status)
+    return if @hide_this_step
+    @processed_steps << format_exception(exception, status, EXCEPTION_INDENT)
+    @failed = true
   end
 
   private
@@ -46,5 +81,40 @@ class ScenarioProgressFormatter < Cucumber::Formatter::Progress
     @io.print(line)
     @io.print(' [...]') if names[1..-1].present?
     @io.flush
+  end
+
+  def print_summary(features)
+    print_steps(:pending)
+    print_failure_details
+    print_stats(features, @options)
+    print_snippets(@options)
+    print_passing_wip(@options)
+  end
+
+  def print_failure_details
+    if @failed_scenario_steps.any?
+      @io.puts(format_string("(::) steps of failed scenarios (::)", :failed))
+      @io.puts
+      @io.flush
+    end
+
+    @failed_scenario_steps.each do |failed_scenario|
+      failed_scenario.each do |step|
+        @io.puts step.indent(SCENARIO_INDENT)
+      end
+      @io.puts
+    end
+    @io.puts
+    @io.flush
+  end
+
+  def format_exception(e, status, indent)
+    message = "#{e.message} (#{e.class})".force_encoding("UTF-8")
+    if ENV['CUCUMBER_TRUNCATE_OUTPUT']
+      message = linebreaks(message, ENV['CUCUMBER_TRUNCATE_OUTPUT'].to_i)
+    end
+
+    string = "#{message}\n#{e.backtrace.join("\n")}".indent(indent)
+    format_string(string, status)
   end
 end

--- a/spec/support/scenario_progress_formatter.rb
+++ b/spec/support/scenario_progress_formatter.rb
@@ -1,0 +1,50 @@
+require 'cucumber/formatter/progress'
+
+class ScenarioProgressFormatter < Cucumber::Formatter::Progress
+  SCENARIO_INDENT = 2
+
+  def after_feature_element(feature_element)
+    super(feature_element)
+    @io.puts
+    @io.flush
+  end
+
+  def after_background(background)
+    @io.puts
+    @io.flush
+  end
+
+  def before_steps(*_args)
+    super(*_args)
+    @io.print(' ')
+  end
+
+  def tag_name(tag_name)
+    tag = format_string(tag_name, :tag).indent(SCENARIO_INDENT)
+    @io.puts(tag)
+    @io.flush
+  end
+
+  def feature_name(keyword, name)
+    @io.puts("#{keyword}: #{name}")
+    @io.flush
+  end
+
+  def background_name(keyword, name, file_colon_line, source_indent)
+    print_feature_element_name(keyword, name, file_colon_line, source_indent)
+  end
+
+  def scenario_name(keyword, name, file_colon_line, source_indent)
+    print_feature_element_name(keyword, name, file_colon_line, source_indent)
+  end
+
+  private
+
+  def print_feature_element_name(keyword, name, file_colon_line, source_indent)
+    names = name.empty? ? [name] : name.split("\n")
+    line = "#{keyword}: #{names[0]}".indent(SCENARIO_INDENT)
+    @io.print(line)
+    @io.print(' [...]') if names[1..-1].present?
+    @io.flush
+  end
+end


### PR DESCRIPTION
The quite verbose formatter annoyed me a little because it printed way more information than we needed. This pull request adds formatters that combine the strengths of the very verbose formatters `documentation` (for rspec) and `pretty` (for cucumber) and of the too little printing formatter `progress`.

Those are only active by default on development machines. I made sure that the verbose formatters are used on travis and jenkins.

#### rspec
![screen shot 2015-04-25 at 11 12 33](https://cloud.githubusercontent.com/assets/339751/7332376/a43730c2-eb3c-11e4-97bd-b6b2d31e2ad4.png)

#### cucumber
![screen shot 2015-04-25 at 11 13 34](https://cloud.githubusercontent.com/assets/339751/7332377/a69079fa-eb3c-11e4-893f-d61b97f45f67.png)
