### PR TITLE
Use correct table for JOIN

### DIFF
--- a/app/models/oops_response.rb
+++ b/app/models/oops_response.rb
@@ -4,7 +4,7 @@ class OopsResponse < ActiveRecord::Base
 
   scope :global, ->() do
     table = 'oops_responses_symbols'
-    joins("LEFT JOIN #{table} ON #{table}.id = #{table}.oops_response_id").
+    joins("LEFT JOIN #{table} ON oops_responses.id = #{table}.oops_response_id").
       where("#{table}.symbol_id" => nil)
   end
 


### PR DESCRIPTION
Shall fix #1338.

When introducing `table`, we accidentally replaced the wrong table name
with the `table` variable.