### PR TITLE
Fix and allow exceptions for rebuild ontohub

### DIFF
--- a/script/rebuild-ontohub
+++ b/script/rebuild-ontohub
@@ -58,8 +58,7 @@ abort_cmd() {
   exit 1
 }
 
-abort_unless_invoker_installed
-initialize_new_invoker_instance
+run_invoker="1"
 
 for i in "$@"; do
 case $i in
@@ -69,12 +68,20 @@ case $i in
     -r|--restart)
     RESTART_INVOKER_ONLY=true
     ;;
+    --no-invoker)
+    run_invoker="0"
+    ;;
     *)
     # unknown option
     ;;
   esac
   shift
 done
+
+if [[ "$run_invoker" -eq "1" ]]; then
+  abort_unless_invoker_installed
+  initialize_new_invoker_instance
+fi
 
 if [[ !($RESTART_INVOKER_ONLY) ]]; then
   execute_or_die_unless_match "bundle exec rake elasticsearch:wipe" "Elasticsearch::Transport::Transport::Errors::NotFound"

--- a/script/rebuild-ontohub
+++ b/script/rebuild-ontohub
@@ -31,6 +31,24 @@ execute_or_die() {
   fi
 }
 
+execute_or_die_unless_match() {
+  cmd="$1"
+  expression="$2"
+  echo ">>> Executing '$cmd'"
+  result="$($cmd 2>&1)"
+  state="$?"
+  if [[ "$state" -ne "0" ]]; then
+    echo "$result" | grep -q "$expression"
+    matchstate="$?"
+    if [[ "$matchstate" -ne "0" ]]; then
+      echo ">>> Failed to execute '$cmd', aborting further commands."
+      exit 1
+    else
+      echo ">>> Failed to execute '$cmd', but ignoring the result."
+    fi
+  fi
+}
+
 abort_unless_invoker_installed
 initialize_new_invoker_instance
 
@@ -50,7 +68,7 @@ case $i in
 done
 
 if [[ !($RESTART_INVOKER_ONLY) ]]; then
-  execute_or_die "bundle exec rake elasticsearch:wipe"
+  execute_or_die_unless_match "bundle exec rake elasticsearch:wipe" "Elasticsearch::Transport::Transport::Errors::NotFound"
   execute_or_die "bundle exec rake db:migrate:clean"
   execute_or_die "redis-cli flushdb"
   execute_or_die "bundle exec rake git:compile_cp_keys"

--- a/script/rebuild-ontohub
+++ b/script/rebuild-ontohub
@@ -24,6 +24,9 @@ execute_or_die() {
   execute_or_die_unless_match "$cmd" ""
 }
 
+# An empty expression will not be checked. This in fact means, that there is no
+# check for 'empty-output', but seeing as that should probably be never the
+# case it is a good way to combine both execute_or... versions
 execute_or_die_unless_match() {
   cmd="$1"
   expression="$2"
@@ -39,6 +42,9 @@ execute_or_die_unless_match() {
   fi
 }
 
+# Currently the match cannot be a 'normal' regular expression.
+# This however can be changed by adding a 'P' to the switches list for the
+# grep-command.
 check_and_handle_result_text() {
   result="$1"
   expression="$2"

--- a/script/rebuild-ontohub
+++ b/script/rebuild-ontohub
@@ -21,14 +21,7 @@ initialize_new_invoker_instance() {
 
 execute_or_die() {
   cmd="$1"
-  echo ">>> Executing '$cmd'"
-  result="$($cmd 2>&1)"
-  state="$?"
-  if [[ "$state" -ne "0" ]]; then
-    echo "$result"
-    echo ">>> Failed to execute '$cmd', aborting further commands."
-    exit 1
-  fi
+  execute_or_die_unless_match "$cmd" ""
 }
 
 execute_or_die_unless_match() {
@@ -38,15 +31,31 @@ execute_or_die_unless_match() {
   result="$($cmd 2>&1)"
   state="$?"
   if [[ "$state" -ne "0" ]]; then
-    echo "$result" | grep -q "$expression"
-    matchstate="$?"
-    if [[ "$matchstate" -ne "0" ]]; then
-      echo ">>> Failed to execute '$cmd', aborting further commands."
-      exit 1
+    if [[ -n "$expression" ]]; then
+      check_and_handle_result_text "$result" "$expression" "$cmd"
     else
-      echo ">>> Failed to execute '$cmd', but ignoring the result."
+      abort_cmd "$cmd"
     fi
   fi
+}
+
+check_and_handle_result_text() {
+  result="$1"
+  expression="$2"
+  cmd="$3"
+  echo "$result" | grep -q "$expression"
+  matchstate="$?"
+  if [[ "$matchstate" -ne "0" ]]; then
+    abort_cmd "$cmd"
+  else
+    echo ">>> Failed to execute '$cmd', but ignoring the result."
+  fi
+}
+
+abort_cmd() {
+  cmd="$1"
+  echo ">>> Failed to execute '$cmd', aborting further commands."
+  exit 1
 }
 
 abort_unless_invoker_installed


### PR DESCRIPTION
Shall improve the rebuild-ontohub script.

- Execution does not cease if the elasticsearch-wiper gets a 404 response (which basically means that the cache was already wiped)
- Adds the new command to allow such special cases
- Adds the `--no-invoker` switch, which will result in the script doing the following
  - no check if invoker is installed
  - no start of invoker
  - no restart of invoker