### PR TITLE
1371 print better readable settings validation errors

### DIFF
--- a/app/models/repository/symlink.rb
+++ b/app/models/repository/symlink.rb
@@ -4,21 +4,19 @@
 module Repository::Symlink
   extend ActiveSupport::Concern
 
-  PATH = Ontohub::Application.config.symlink_path
-
   included do
     after_save     :symlink_update, if: :path_changed?
     before_destroy :symlink_remove
   end
 
   def symlink_name
-    PATH.join("#{path}.git")
+    Ontohub::Application.config.symlink_path.join("#{path}.git")
   end
 
   protected
 
   def symlink_update
-    PATH.mkpath
+    Ontohub::Application.config.symlink_path.mkpath
     symlink_remove
     symlink_name.make_symlink local_path
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -97,6 +97,7 @@ module Ontohub
 
     config.after_initialize do
       SettingsValidator.new.validate!
+      SettingsInterpreter.new.call
     end
   end
 end

--- a/config/initializers/paths.rb
+++ b/config/initializers/paths.rb
@@ -1,4 +1,3 @@
-
 module PathsInitializer
   class << self
     def expand(path)
@@ -9,6 +8,18 @@ module PathsInitializer
       path.sub(%r(/releases/\d+/), "/current/")
     end
 
+    # Only defines methods to prevent NoMethodErrors
+    # To be called before settings validation.
+    def empty_initialization(config)
+      config.data_root = nil
+      config.git_root = nil
+      config.git_home = nil
+      config.symlink_path = nil
+      config.commits_path = nil
+    end
+
+    # Actually performs initialization
+    # To be called after settings validation
     def perform_initialization(config)
       config.data_root = cleanup_release(expand(Settings.paths.data))
       config.git_root = cleanup_release(expand(Settings.paths.git_repositories))
@@ -21,6 +32,6 @@ end
 
 if defined?(Ontohub::Application)
   Ontohub::Application.configure do |app|
-    PathsInitializer.perform_initialization(app.config)
+    PathsInitializer.empty_initialization(app.config)
   end
 end

--- a/lib/settings_interpreter.rb
+++ b/lib/settings_interpreter.rb
@@ -1,0 +1,9 @@
+class SettingsInterpreter
+  def call
+    if defined?(Ontohub::Application)
+      Ontohub::Application.configure do |app|
+        PathsInitializer.perform_initialization(app.config)
+      end
+    end
+  end
+end

--- a/lib/settings_validation_wrapper.rb
+++ b/lib/settings_validation_wrapper.rb
@@ -25,6 +25,7 @@ class SettingsValidationWrapper
                 yml__paths__git_repositories
                 yml__paths__symlinks
                 yml__paths__commits
+                yml__paths__git_home
                 yml__git__verify_url
                 yml__git__default_branch
                 yml__git__push_priority__commits
@@ -45,12 +46,7 @@ class SettingsValidationWrapper
                 yml__hets__server_options
                 yml__hets__env__LANG
 
-                initializers__fqdn
-                initializers__data_root
-                initializers__git_home
-                initializers__git_root
-                initializers__symlink_path
-                initializers__commits_path)
+                initializers__fqdn)
 
   PRESENCE_IN_PRODUCTION = %i(yml__hets__executable_path
                               yml__hets__instances_count)
@@ -87,6 +83,7 @@ class SettingsValidationWrapper
               yml__paths__git_repositories
               yml__paths__symlinks
               yml__paths__commits
+              yml__paths__git_home
               yml__git__verify_url
               yml__git__default_branch
               yml__git__fallbacks__committer_name
@@ -104,11 +101,11 @@ class SettingsValidationWrapper
              yml__hets__cmd_line_options
              yml__hets__server_options)
 
-  DIRECTORY_PRODUCTION = %i(initializers__data_root
-                            initializers__git_home
-                            initializers__git_root
-                            initializers__symlink_path
-                            initializers__commits_path)
+  DIRECTORY_PRODUCTION = %i(yml__paths__data
+                            yml__paths__git_repositories
+                            yml__paths__symlinks
+                            yml__paths__commits
+                            yml__paths__git_home)
 
   ELEMENT_PRESENT = %i(yml__allowed_iri_schemes
                        yml__hets__cmd_line_options

--- a/lib/settings_validation_wrapper/validators.rb
+++ b/lib/settings_validation_wrapper/validators.rb
@@ -10,6 +10,10 @@ module SettingsValidationWrapper::Validators
 
   class DirectoryValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
+      begin
+        Dir.chdir(Rails.root) { value = Pathname.new(value).expand_path }
+      rescue
+      end
       unless File.directory?(value)
         record.errors.add attribute, 'is not a directory'
       end

--- a/lib/settings_validation_wrapper/validators.rb
+++ b/lib/settings_validation_wrapper/validators.rb
@@ -10,12 +10,17 @@ module SettingsValidationWrapper::Validators
 
   class DirectoryValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
+      error = nil
       begin
         Dir.chdir(Rails.root) { value = Pathname.new(value).expand_path }
-      rescue
+      rescue ::StandardError => e
+        error = e
       end
       unless File.directory?(value)
         record.errors.add attribute, 'is not a directory'
+      end
+      if error
+        record.errors.add attribute, error.message
       end
     end
   end

--- a/lib/settings_validator.rb
+++ b/lib/settings_validator.rb
@@ -1,6 +1,10 @@
 class SettingsValidator
   class SettingsValidator::ValidationError < ::StandardError; end
 
+  CONFIG_YML_FILES =
+    "config/settings[.local].yml or config/settings/#{Rails.env}[.local].yml"
+  CONFIG_INITIALIZER_FILES = "config/environments/#{Rails.env}[.local].rb"
+
   def validate!
     settings_validations_wrapper = SettingsValidationWrapper.new
     unless settings_validations_wrapper.valid?
@@ -14,7 +18,8 @@ class SettingsValidator
   protected
 
   def print_errors(formatted_errors)
-    $stderr.puts 'The settings are invalid. Please check your settings*.yml'
+    $stderr.puts "The settings are invalid. Please check your #{CONFIG_YML_FILES}"
+    $stderr.puts 'The following errors were detected:'
     $stderr.puts
     formatted_errors.each { |error| $stderr.puts error }
     $stderr.puts
@@ -27,8 +32,14 @@ class SettingsValidator
 
   def format_error(key, messages)
     category, key_portions = key_info(key)
+    opening_line =
+      if category == :initializers
+        "#{format_initializer_error(key_portions)} #{format_key(key_portions)}"
+      else
+        format_key(key_portions)
+      end
     <<-MESSAGE.strip_heredoc
-      #{format_key(key_portions)}:
+      #{opening_line}:
       #{format_messages(messages)}
     MESSAGE
   end
@@ -48,5 +59,17 @@ class SettingsValidator
 
   def format_message(message)
     "  #{message}"
+  end
+
+  def format_initializer_error(key_portions)
+    key = key_portions.join('.')
+    if 'fqdn' == key
+      "The FQDN could not be determined. Please set the hostname in #{CONFIG_YML_FILES}"
+    elsif %w(data_root git_home git_root symlink_path commits_path).include?(key)
+      'Please check the paths keys in the settings -'
+    else
+      # other possible values: %w(consider_all_requests_local secret_token log_level)
+      "Please set a valid value in the #{CONFIG_INITIALIZER_FILES} for"
+    end
   end
 end

--- a/lib/settings_validator.rb
+++ b/lib/settings_validator.rb
@@ -60,6 +60,10 @@ class SettingsValidator
   end
 
   def format_message(message)
+    if message == 'is not included in the list'
+      message =
+        "#{message} (see the comments in the config/settings.yml at this key)"
+    end
     "  #{message}"
   end
 

--- a/lib/settings_validator.rb
+++ b/lib/settings_validator.rb
@@ -38,9 +38,11 @@ class SettingsValidator
       else
         format_key(key_portions)
       end
+    bad_value = value_of(category, key_portions)
     <<-MESSAGE.strip_heredoc
       #{opening_line}:
       #{format_messages(messages)}
+        Value: #{value_of(category, key_portions)}
     MESSAGE
   end
 
@@ -71,5 +73,10 @@ class SettingsValidator
       # other possible values: %w(consider_all_requests_local secret_token log_level)
       "Please set a valid value in the #{CONFIG_INITIALIZER_FILES} for"
     end
+  end
+
+  def value_of(category, key_portions)
+    object = SettingsValidationWrapper.base(category.to_s)
+    SettingsValidationWrapper.get_value(object, key_portions)
   end
 end

--- a/lib/settings_validator.rb
+++ b/lib/settings_validator.rb
@@ -39,10 +39,11 @@ class SettingsValidator
         format_key(key_portions)
       end
     bad_value = value_of(category, key_portions)
-    <<-MESSAGE.strip_heredoc
-      #{opening_line}:
-      #{format_messages(messages)}
-        Value: #{value_of(category, key_portions)}
+    <<-MESSAGE
+#{opening_line}:
+#{format_messages(messages)}
+  Value: #{value_of(category, key_portions)}
+
     MESSAGE
   end
 

--- a/lib/settings_validator.rb
+++ b/lib/settings_validator.rb
@@ -4,8 +4,49 @@ class SettingsValidator
   def validate!
     settings_validations_wrapper = SettingsValidationWrapper.new
     unless settings_validations_wrapper.valid?
-      raise ValidationError.new(settings_validations_wrapper.errors.
-        messages.inspect)
+      plain_errors = settings_validations_wrapper.errors.messages
+      formatted_errors = format_errors(plain_errors)
+      print_errors(formatted_errors)
+      exit
     end
+  end
+
+  protected
+
+  def print_errors(formatted_errors)
+    $stderr.puts 'The settings are invalid. Please check your settings*.yml'
+    $stderr.puts
+    formatted_errors.each { |error| $stderr.puts error }
+    $stderr.puts
+    $stderr.puts 'Stopping the application.'
+  end
+
+  def format_errors(errors)
+    errors.map { |key, messages| format_error(key, messages) }
+  end
+
+  def format_error(key, messages)
+    category, key_portions = key_info(key)
+    <<-MESSAGE.strip_heredoc
+      #{format_key(key_portions)}:
+      #{format_messages(messages)}
+    MESSAGE
+  end
+
+  def key_info(key)
+    category, *portions = key.to_s.split('__')
+    [category.to_sym, portions]
+  end
+
+  def format_key(portions)
+    portions.join('.')
+  end
+
+  def format_messages(messages)
+    messages.map { |message| format_message(message) }.join("\n")
+  end
+
+  def format_message(message)
+    "  #{message}"
   end
 end


### PR DESCRIPTION
This shall fix #1371. After some settings alterations the output looks something like:

```
❯ RAILS_ENV=production rails c
Rails Error: Unable to access log file. Please ensure that /Users/eugen/Work/Ontohub/ontohub/log/production.log exists and is chmod 0666. The log level has been raised to WARN and the output directed to STDERR until the problem is fixed.
Creating scope :state. Overwriting existing method Repository.state.
Creating scope :accessible_by. Overwriting existing method Repository.accessible_by.
The settings are invalid. Please check your config/settings[.local].yml or config/settings/production[.local].yml
The following errors were detected:

Please check the paths keys in the settings - data_root:
  is not a directory
  Value: /tmp/abc/data
Please check the paths keys in the settings - git_home:
  is not a directory
  Value: /git
Please check the paths keys in the settings - git_root:
  is not a directory
  Value: /tmp/abc/data/repositories
Please check the paths keys in the settings - symlink_path:
  is not a directory
  Value: /tmp/abc/data/git_daemon
Please check the paths keys in the settings - commits_path:
  is not a directory
  Value: /tmp/abc/data/commits
email:
  email adress must belong to the fully qualified domain name 'ontohub.org'.
  Value: noreply@example.com
allow_unconfirmed_access_for_days:
  must be greater than or equal to 0
  Value: -3
max_read_filesize:
  must be greater than 1024
  Value: -524288
max_combined_diff_size:
  must be greater than 2048
  Value: -1048576
Please set a valid value in the config/environments/production[.local].rb for log_level:
  is not included in the list (see the comments in the config/settings.yml at this key)
  Value: hans
hets.executable_path:
  must be an executable file: /usr/bin/hets
  Value: /usr/bin/hets

Stopping the application.
```

Note that I run rails in production environment to enable **all** the validations.