### PR TITLE
1374 Improve migration performance

### DIFF
--- a/db/migrate/20150311125212_make_sentences_to_axioms.rb
+++ b/db/migrate/20150311125212_make_sentences_to_axioms.rb
@@ -1,12 +1,12 @@
 class MakeSentencesToAxioms < MigrationWithData
   def up
-    Sentence.unscoped.where(type: nil).find_each do |sentence|
+    Sentence.unscoped.where(type: nil).select(:id).find_each do |sentence|
       update_attributes!(sentence, type: 'Axiom')
     end
   end
 
   def down
-    Sentence.unscoped.where(type: 'Axiom').find_each do |sentence|
+    Sentence.unscoped.where(type: 'Axiom').select(:id).find_each do |sentence|
       update_attributes!(sentence, type: nil)
     end
   end


### PR DESCRIPTION
This shall fix #1374. I tried to use the garbage collection invoking method, but that's slower than simply restricting the select statement to the one needed column.

The other migrations don't seem to be problematic on the ontohub.org data.