### PR TITLE
1376 make ontohub org database consistent

### DIFF
--- a/db/data/20140823134218_set_basepath_where_nil.rb
+++ b/db/data/20140823134218_set_basepath_where_nil.rb
@@ -1,6 +1,6 @@
 class SetBasepathWhereNil < ActiveRecord::Migration
   def self.up
-    OntologyVersion.where(basepath: nil).find_each do |ov|
+    OntologyVersion.where(basepath: nil).includes(:ontology).find_each do |ov|
       ov.basepath = ov.ontology.read_attribute(:basepath)
       ov.file_extension = ov.ontology.read_attribute(:file_extension)
       ov.save!

--- a/db/data/20140823134218_set_basepath_where_nil.rb
+++ b/db/data/20140823134218_set_basepath_where_nil.rb
@@ -1,0 +1,14 @@
+class SetBasepathWhereNil < ActiveRecord::Migration
+  def self.up
+    OntologyVersion.where(basepath: nil).find_each do |ov|
+      ov.basepath = ov.ontology.read_attribute(:basepath)
+      ov.file_extension = ov.ontology.read_attribute(:file_extension)
+      ov.save!
+    end
+  end
+
+  def self.down
+    # Nothing to do
+    # This migration restores consistency. It should not be reversed.
+  end
+end

--- a/db/data/20141102203932_update_display_text_for_obo_sentences.rb
+++ b/db/data/20141102203932_update_display_text_for_obo_sentences.rb
@@ -3,7 +3,7 @@ class UpdateDisplayTextForOboSentences < ActiveRecord::Migration
     obo_ontologies = Ontology.joins(:ontology_version).
       where(ontology_versions: {file_extension: '.obo'})
     obo_ontologies.each do |ontology|
-      ontology.sentences.select([:id, :text]).find_each(&:set_display_text!)
+      ontology.sentences.select(%i(id text)).find_each(&:set_display_text!)
     end
   end
 

--- a/db/data/20141102203932_update_display_text_for_obo_sentences.rb
+++ b/db/data/20141102203932_update_display_text_for_obo_sentences.rb
@@ -3,7 +3,7 @@ class UpdateDisplayTextForOboSentences < ActiveRecord::Migration
     obo_ontologies = Ontology.joins(:ontology_version).
       where(ontology_versions: {file_extension: '.obo'})
     obo_ontologies.each do |ontology|
-      ontology.sentences.find_each { |s| s.set_display_text! }
+      ontology.sentences.select([:id, :text]).find_each(&:set_display_text!)
     end
   end
 

--- a/db/data/20150311194246_associate_provers_with_ontology_versions.rb
+++ b/db/data/20150311194246_associate_provers_with_ontology_versions.rb
@@ -18,12 +18,12 @@ class AssociateProversWithOntologyVersions < ActiveRecord::Migration
     ontology_version.retrieve_available_provers
   rescue Net::ReadTimeout
     if max_attempts > 0
-      puts "Timeout, trying again: OntologyVersion #{ontology_version.id}"
+      $stderr.puts "Timeout, trying again: OntologyVersion #{ontology_version.id}"
       retry_provers_retrieval(ontology_version, max_attempts - 1)
     else
-      puts "Timeout, limit reached: OntologyVersion #{ontology_version.id}"
+      $stderr.puts "Timeout, limit reached: OntologyVersion #{ontology_version.id}"
     end
   rescue ::StandardError => e
-    puts "Errored at OntologyVersion #{ontology_version.id}"
+    $stderr.puts "Errored at OntologyVersion #{ontology_version.id}"
   end
 end

--- a/db/data/20150311194246_associate_provers_with_ontology_versions.rb
+++ b/db/data/20150311194246_associate_provers_with_ontology_versions.rb
@@ -15,17 +15,15 @@ class AssociateProversWithOntologyVersions < ActiveRecord::Migration
   protected
 
   def self.retry_provers_retrieval(ontology_version, max_attempts)
-    begin
-      ontology_version.retrieve_available_provers
-    rescue Net::ReadTimeout
-      if max_attempts > 0
-        puts "Timeout, trying again: OntologyVersion #{ontology_version.id}"
-        retry_provers_retrieval(ontology_version, max_attempts - 1)
-      else
-        puts "Timeout, limit reached: OntologyVersion #{ontology_version.id}"
-      end
-    rescue ::StandardError => e
-      puts "Errored at OntologyVersion #{ontology_version.id}"
+    ontology_version.retrieve_available_provers
+  rescue Net::ReadTimeout
+    if max_attempts > 0
+      puts "Timeout, trying again: OntologyVersion #{ontology_version.id}"
+      retry_provers_retrieval(ontology_version, max_attempts - 1)
+    else
+      puts "Timeout, limit reached: OntologyVersion #{ontology_version.id}"
     end
+  rescue ::StandardError => e
+    puts "Errored at OntologyVersion #{ontology_version.id}"
   end
 end

--- a/db/data/20150311194246_associate_provers_with_ontology_versions.rb
+++ b/db/data/20150311194246_associate_provers_with_ontology_versions.rb
@@ -1,12 +1,31 @@
 class AssociateProversWithOntologyVersions < ActiveRecord::Migration
   def self.up
-    OntologyVersion.find_each(&:retrieve_available_provers)
+    OntologyVersion.find_each do |ontology_version|
+      retry_provers_retrieval(ontology_version, 3)
+    end
   end
 
   def self.down
     OntologyVersion.find_each do |ontology_version|
       ontology_version.provers = []
       ontology_version.save!
+    end
+  end
+
+  protected
+
+  def self.retry_provers_retrieval(ontology_version, max_attempts)
+    begin
+      ontology_version.retrieve_available_provers
+    rescue Net::ReadTimeout
+      if max_attempts > 0
+        puts "Timeout, trying again: OntologyVersion #{ontology_version.id}"
+        retry_provers_retrieval(ontology_version, max_attempts - 1)
+      else
+        puts "Timeout, limit reached: OntologyVersion #{ontology_version.id}"
+      end
+    rescue ::StandardError => e
+      puts "Errored at OntologyVersion #{ontology_version.id}"
     end
   end
 end


### PR DESCRIPTION
This shall fix #1376.

Actually, only the first commit (Set basepath where it is nil.	 671a2be) restores consistency. The other ones make sure that the data migrations pass. Since failing data migrations were the main reason of the issue, I put them into this PR as well.

Note:
The data migrations should be run manually with `RAILS_ENV=production nohup rake data:migrate &` to see the IDs of the failing OntologyVersions (see the third commit's message).

--

This way, 138 + 4350 OntologyVersions don't get a list of provers (timeout + other error).

You can find the file containing the logged failing IDs at `develop.ontohub.org:~ontohub/data_migration_provers_failures`