### PR TITLE
1351 remove iri field

### DIFF
--- a/app/models/ontology.rb
+++ b/app/models/ontology.rb
@@ -30,7 +30,11 @@ class Ontology < ActiveRecord::Base
 
   delegate :permission?, to: :repository
 
-  strip_attributes :only => [:name, :iri]
+  strip_attributes :only => [:name]
+
+  def iri
+    "#{Hostname.url_authority}#{locid}"
+  end
 
   def repository
     @repository ||= Repository.find(repository_id)
@@ -52,11 +56,6 @@ class Ontology < ActiveRecord::Base
     else
       name
     end
-  end
-
-  def iri_for_child(child_name)
-    child_name = child_name[1..-2] if child_name[0] == '<'
-    child_name.include?("://") ? child_name : "#{iri}?#{child_name}"
   end
 
   def locid_for_child(child_name)

--- a/app/models/ontology/associations_and_attributes.rb
+++ b/app/models/ontology/associations_and_attributes.rb
@@ -35,7 +35,7 @@ module Ontology::AssociationsAndAttributes
     has_and_belongs_to_many :projects
     has_and_belongs_to_many :tasks
 
-    attr_accessible :iri, :locid
+    attr_accessible :locid
     attr_accessible :name, :description, :acronym, :documentation,
                     :has_file,
                     :logic_id,

--- a/app/models/ontology/class_methods_and_scopes.rb
+++ b/app/models/ontology/class_methods_and_scopes.rb
@@ -87,13 +87,24 @@ module Ontology::ClassMethodsAndScopes
     end
 
     def find_with_iri(iri)
-      ontology = where('iri LIKE ?', '%' << iri).first
+      locid = iri_to_locid(iri)
+      ontology = where('locid LIKE ?', '%' << locid).first
       if ontology.nil?
         ontology = AlternativeIri.where('iri LIKE ?', '%' << iri).
           first.try(:ontology)
       end
 
       ontology
+    end
+
+    private
+    def iri_to_locid(iri)
+      if iri.start_with?('/')
+        # iri can be considered as locid
+        iri
+      else
+        "/#{iri.split('/', 4).last}"
+      end
     end
   end
 end

--- a/app/models/ontology/mappings.rb
+++ b/app/models/ontology/mappings.rb
@@ -9,8 +9,8 @@ class Ontology
     end
 
     module Methods
-      def iri_for_child(*args)
-        proxy_association.owner.iri_for_child(*args)
+      def locid_for_child(*args)
+        proxy_association.owner.locid_for_child(*args)
       end
 
       def determine_mapping_type(typename)
@@ -29,10 +29,10 @@ class Ontology
       def update_or_create_from_hash(hash, _user, timestamp = Time.now)
         raise ArgumentError, 'No hash given.' unless hash.is_a? Hash
         # hash['name'] # maybe nil, in this case, we need to generate a name
-        mapping_iri   = iri_for_child(hash['name'] || hash['linkid'])
+        mapping_iri   = locid_for_child(hash['name'] || hash['linkid'])
         mapping_name  = hash['name']
-        source_iri = hash['source_iri'] || iri_for_child(hash['source'])
-        target_iri = hash['target_iri'] || iri_for_child(hash['target'])
+        source_iri = hash['source_iri'] || locid_for_child(hash['source'])
+        target_iri = hash['target_iri'] || locid_for_child(hash['target'])
 
         source = Ontology.find_with_iri(source_iri) || (raise ArgumentError,
           "source #{Settings.OMS} not found: #{source_iri}")

--- a/app/models/ontology/validations.rb
+++ b/app/models/ontology/validations.rb
@@ -2,8 +2,7 @@ module Ontology::Validations
   extend ActiveSupport::Concern
 
   included do
-    validates :iri, uniqueness: true, if: :iri_changed?
-    validates :iri, format: {with: URI.regexp(Settings.allowed_iri_schemes)}
+    validates :locid, uniqueness: true, if: :locid_changed?
 
     validates :documentation,
       allow_blank: true,

--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -88,9 +88,8 @@ module Repository::Git
 
     if !ontology
       basepath = File.basepath(ontology_version_options.filepath)
-      iri = generate_iri(basepath)
       locid = generate_locid(basepath)
-      ontology = create_ontology(ontology_version_options.filepath, iri, locid)
+      ontology = create_ontology(ontology_version_options.filepath, locid)
     end
 
     ontology
@@ -102,12 +101,11 @@ module Repository::Git
       without_parent.first
   end
 
-  def create_ontology(filepath, iri, locid)
+  def create_ontology(filepath, locid)
     ontology = corresponding_ontology_klass(filepath).new
 
     ontology.basepath = File.basepath(filepath)
     ontology.file_extension = File.extname(filepath)
-    ontology.iri = iri
     ontology.locid = locid
     ontology.name = filepath.split('/')[-1].split(".")[0].capitalize
     ontology.repository = self
@@ -243,10 +241,6 @@ module Repository::Git
 
   def master_file?(ontology, ontology_version_options)
     ontology.path == ontology_version_options.pre_saving_filepath
-  end
-
-  def generate_iri(basepath)
-    "http://#{Ontohub::Application.config.fqdn}#{generate_locid(basepath)}"
   end
 
   def generate_locid(basepath)

--- a/db/migrate/20150607113504_remove_iri_from_ontology.rb
+++ b/db/migrate/20150607113504_remove_iri_from_ontology.rb
@@ -1,0 +1,9 @@
+class RemoveIriFromOntology < ActiveRecord::Migration
+  def up
+    remove_column :ontologies, :iri
+  end
+
+  def down
+    add_column :ontologies, :iri, :string, null: false
+  end
+end

--- a/lib/external_repository.rb
+++ b/lib/external_repository.rb
@@ -6,7 +6,7 @@ class ExternalRepository
     def create_ontology(internal_iri, name: internal_iri)
       options = {
         name: name,
-        iri: determine_iri(internal_iri),
+        locid: determine_locid(internal_iri),
         basepath: determine_path(internal_iri, :basepath),
         file_extension: determine_path(internal_iri, :extension),
         repository_id: repository.id,
@@ -25,8 +25,12 @@ class ExternalRepository
                                 message, user)
     end
 
+    def determine_locid(external_iri)
+      "/#{repository.path}/#{determine_path(external_iri, :fullpath)}"
+    end
+
     def determine_iri(external_iri)
-      "http://#{Ontohub::Application.config.fqdn}/#{repository.path}/#{determine_path(external_iri, :fullpath)}"
+      "#{Hostname.url_authority}#{determine_locid(external_iri)}"
     end
 
     def determine_path(external_iri, symbol)

--- a/lib/hets/dg/node_evaluation_helper.rb
+++ b/lib/hets/dg/node_evaluation_helper.rb
@@ -36,14 +36,12 @@ module Hets
 
       def procure_child_ontology(internal_iri)
         # generate IRI for child-ontology
-        child_iri = parent_ontology.iri_for_child(internal_iri)
         child_locid = parent_ontology.locid_for_child(internal_iri)
 
         # find or create child-ontology by IRI
-        ontology = parent_ontology.children.find_with_locid(child_locid, child_iri)
+        ontology = parent_ontology.children.find_with_locid(child_locid)
         if ontology.nil?
           options = {
-            iri: child_iri,
             locid: child_locid,
             name: internal_iri,
             basepath: parent_ontology.basepath,

--- a/lib/hets/dg/node_evaluation_helper.rb
+++ b/lib/hets/dg/node_evaluation_helper.rb
@@ -90,7 +90,7 @@ module Hets
           end
         else
           if parent_ontology.distributed?
-            ontohub_iri = parent_ontology.iri_for_child(internal_iri)
+            ontohub_iri = parent_ontology.locid_for_child(internal_iri)
           else
             # we use 0 here, because the first time around, we
             # have ontologies_count 0 which is increased by one

--- a/lib/state_updater.rb
+++ b/lib/state_updater.rb
@@ -47,9 +47,9 @@ module StateUpdater
   end
 
   def update_state!(state, error_message = nil)
-    self.state            = state.to_s
-    self.state_updated_at = Time.now
-    self.last_error       = error_message
-    save!
+    update_attributes!({state: state.to_s,
+                        state_updated_at: Time.now,
+                        last_error: error_message},
+                        without_protection: true)
   end
 end

--- a/spec/factories/ontology_factory.rb
+++ b/spec/factories/ontology_factory.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
 
   sequence :iri do |n|
-    "gopher://host/ontology/#{n}"
+    "gopher://host/object/#{n}"
   end
 
   sequence :name do |n|
@@ -10,7 +10,6 @@ FactoryGirl.define do
 
   factory :ontology do |ontology|
     association :repository
-    iri { FactoryGirl.generate :iri }
     name { FactoryGirl.generate :name }
     basepath { SecureRandom.hex(10) }
     file_extension { '.owl' }

--- a/spec/lib/ontology_batch_parse_worker_spec.rb
+++ b/spec/lib/ontology_batch_parse_worker_spec.rb
@@ -8,7 +8,7 @@ describe OntologyBatchParseWorker do
   let(:balancer) { ConcurrencyBalancer.new }
 
   context 'using the sequential queue' do
-    let(:ontology) { create :single_unparsed_ontology, iri: 'http://example.com/test/sequential_parse' }
+    let(:ontology) { create :single_unparsed_ontology, locid: '/test/sequential_parse' }
     let(:version) { ontology.versions.last }
 
     before do

--- a/spec/lib/worker_spec.rb
+++ b/spec/lib/worker_spec.rb
@@ -8,7 +8,7 @@ describe Worker do
   let(:balancer) { ConcurrencyBalancer.new }
 
   context 'using the sequential queue' do
-    let(:ontology) { create :single_unparsed_ontology, iri: 'http://example.com/test/sequential_parse' }
+    let(:ontology) { create :single_unparsed_ontology, locid: '/test/sequential_parse' }
     let(:version) { ontology.versions.last }
 
     before do

--- a/spec/models/distributed_ontology_spec.rb
+++ b/spec/models/distributed_ontology_spec.rb
@@ -4,19 +4,4 @@ describe DistributedOntology do
   context 'associations' do
     it { should have_many(:children) }
   end
-
-  context 'distributed ontology instance' do
-    let(:ontology) do
-      create :distributed_ontology, iri: 'http://example.com/foo'
-    end
-
-    it 'generate sub iri' do
-      expect(ontology.iri_for_child('bar')).to eq('http://example.com/foo?bar')
-    end
-
-    it 'generate sub iri that already is an iri' do
-      expect(ontology.iri_for_child('http://example.com/dummy')).
-        to eq('http://example.com/dummy')
-    end
-  end
 end

--- a/spec/models/ontology_spec.rb
+++ b/spec/models/ontology_spec.rb
@@ -19,7 +19,6 @@ describe Ontology do
   end
 
   context 'migrations' do
-    it { should have_db_index(:iri).unique(true) }
     it { should have_db_index(:state) }
     it { should have_db_index(:language_id) }
     it { should have_db_index(:logic_id) }
@@ -27,18 +26,10 @@ describe Ontology do
 
   context 'attributes' do
     it { should strip_attribute :name }
-    it { should strip_attribute :iri }
     it { should_not strip_attribute :description }
   end
 
   context 'Validations' do
-    ['http://example.com/', 'https://example.com/', 'file://path/to/file'].
-      each do |val|
-      it { should allow_value(val).for :iri }
-    end
-
-    it { should_not allow_value(nil).for :iri }
-
     [
       'http://example.com/',
       'https://example.com/',


### PR DESCRIPTION
During the course of #1351 i've removed the iri-field from ontologies in ontohub. They are superseded by the locid-field. The iri is now only a method to generate the fully-qualified locid.