### PR TITLE
Suppress Rspec verbose output

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,13 @@ require File.expand_path('../config/application', __FILE__)
 
 Ontohub::Application.load_tasks
 
+# Prevent Rspec to print file list unless enforced by the environment.
+if defined?(RSpec) && ENV['SPEC_VERBOSE'] != 'true'
+  task(:spec).clear
+  RSpec::Core::RakeTask.new(:spec) do |t|
+    t.verbose = false
+  end
+end
 
 # Remove load_schema/load_structure in tests, as db:migrate:clean
 # will take care of everything.


### PR DESCRIPTION
At the beginning of each run of `rake`, the long `db:migrate:clean` output as well as the list of the spec files annoyed me a little. This change hides that output. The important things, such as the spec progression and the spec report are still shown.