### PR TITLE
1384 validate existence of the cp keys binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,7 @@ config/environments/*.local.rb
 
 spec/fixtures/vcr/hets-out
 # Ignore custom compiled binaries
-bin/cp_keys
+data/git/.ssh/cp_keys
 
 spec/fixtures/ontologies/xml
 

--- a/doc/productive_deployment.md
+++ b/doc/productive_deployment.md
@@ -167,11 +167,8 @@ exception_notifier.exception_recepients
 paths
 ```
 
-Whenever you change the `paths` in the settings, you need to run
-`RAILS_ENV=production bundle exec rake git:compile_cp_keys` in order to have
-the git-ssh interaction working correctly, because the `paths` from the
-settings are compiled into the binary which manipulates the authorized_keys
-file.
+Remember to adjust your `cp_keys` executable (see [Set up Git-SSH requirements](#set-up-git-ssh-requirements)) whenever you change the paths in the settings.
+This is needed to have the git-ssh interaction working correctly.
 
 ##### Settings for deployment with capistrano
 
@@ -199,6 +196,29 @@ You can deploy this codebase to your server with:
     bundle exec cap production deploy
 
 (This should work&trade; now without any errors).
+
+
+## Set up Git-SSH requirements
+
+For security reasons, we don't directly manipulate the git-user's `authorized_keys` file in the Ontohub code.
+Instead, we use a separate executable `cp_keys` which copies an `authorized_keys` file to the git-user's `.ssh` directory and prevails the correct permissions on that file.
+
+The executable, which is located at `${paths.git_home}/.ssh/cp_keys`, is called with no arguments.
+It copies the file `${paths.data}/.ssh/authorized_keys` to `${paths.git_home}/.ssh/authorized_keys`.
+The target file's owner must be the git-user and the permissions must be set as usual for an `authorized_keys` file.
+
+We prepared C-code for this task for Linux machines.
+The source file is located at `script/cp_keys.c` and it contains an extensive comment on how to compile it and set it up.
+It needs to be edited to have the paths from the `settings[.local].yml` hardcoded.
+
+We also prepared a rake task to edit and compile the executable for you:
+```
+RAILS_ENV=production bundle exec rake git:compile_cp_keys
+```
+Although this takes some work off your shoulders, it also prints what you need to do.
+This task is only for convenience.
+If you want to have a secure environment, or if you don't run a standard (Ubuntu) Linux, we highly recommend to go through the file `script/cp_keys.c` and at least read its documenting comments.
+
 
 ## Configuration
 
@@ -351,7 +371,7 @@ after that you have to set up the git Deamon which will be explained next.
 SSH access is provided by the `git` user.
 Every action started by a `git push` will be executed as this user, invoked
 by the `~git/.ssh/authorized_keys`, which is manipulated by the `cp_keys` binary.
-See [Changing Settings](#changing-settings) for details.
+See [Set up Git-SSH requirements](#set-up-git-ssh-requirements) for details.
 
 #### Service
 

--- a/lib/authorized_keys_manager.rb
+++ b/lib/authorized_keys_manager.rb
@@ -57,7 +57,7 @@ class AuthorizedKeysManager
 
     def copy_authorized_keys_to_git_home
       GIT_HOME_SSH_DIR.mkpath
-      system(Rails.root.join('bin', 'cp_keys').to_s)
+      system(GIT_HOME_SSH_DIR.join('cp_keys').to_s)
     end
   end
 end

--- a/lib/settings_validation_wrapper.rb
+++ b/lib/settings_validation_wrapper.rb
@@ -234,7 +234,7 @@ class SettingsValidationWrapper
 
   def initialize
     # define a value for the cp_keys location
-    @cp_keys = Ontohub::Application.config.git_home.join('.ssh', 'cp_keys')
+    @cp_keys = Pathname.new(Settings.paths.git_home).join('.ssh', 'cp_keys').to_s
   end
 
   def cp_keys=(_path)

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -41,8 +41,11 @@ namespace :git do
 
   desc 'Compile cp_keys binary'
   task :compile_cp_keys => :environment do
+    target_dir = Ontohub::Application.config.git_home.join('.ssh')
+    target_dir.mkpath
+
     source_file = Rails.root.join('script', 'cp_keys.c')
-    target_path = Rails.root.join('bin', 'cp_keys').to_s
+    target_path = target_dir.join('cp_keys').to_s
 
     reconfigured_source_tempfile = reconfigure_cp_keys(source_file)
     compile_gcc(reconfigured_source_tempfile.path, target_path)


### PR DESCRIPTION
This shall fix #1384 and #1386. It further adds a reasonable default email address to the production.yml.