### PR TITLE
1399 allow to configure sidekiq log level

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -98,6 +98,8 @@ module Ontohub
     config.after_initialize do
       SettingsValidator.new.validate!
       SettingsInterpreter.new.call
+      Sidekiq::Logging.logger.level =
+        Kernel.const_get("Logger::#{Settings.asynchronous_execution.log_level}")
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,6 +50,11 @@ max_combined_diff_size: 1_048_576
 # Timeout for ontology parsing jobs in hours
 ontology_parse_timeout: 6
 
+asynchronous_execution:
+  # possible values for log level (in ascending order of verbosity):
+  # UNKNOWN, FATAL, ERROR, WARN, INFO, DEBUG
+  log_level: WARN
+
 # Footer links and texts
 footer:
   - text: Foo Institute

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -8,3 +8,6 @@ display_head_commit: true
 
 paths:
   git_home: tmp/git
+
+asynchronous_execution:
+  log_level: INFO

--- a/lib/settings_validation_wrapper.rb
+++ b/lib/settings_validation_wrapper.rb
@@ -183,6 +183,9 @@ class SettingsValidationWrapper
   validates :yml__hets__time_between_updates,
             numericality: {greater_than_or_equal_to: 1}
 
+  validates :yml__asynchronous_execution__log_level,
+            inclusion: {in: %w(UNKNOWN FATAL ERROR WARN INFO DEBUG)}
+
   def self.base(first_portion)
     case first_portion
     when 'yml'


### PR DESCRIPTION
This shall fix #1399.

It is not possible to disable *all* INFO log entries and have settings validations at the same time. The execution order is:
* sidekiq bootup (printing info log entries)
* settings validation
* setting the log level

It is only the bootup log that still has the info level.