### PR TITLE
Fix settings validations for the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,4 @@ before_script:
   - sudo apt-get install libsane libgphoto2-2 hets-core subversion udrawgraph git-svn
   - sudo hets -update
   - RAILS_ENV=test bundle exec rake db:migrate || true
+  - mkdir -p tmp/{git,data/{git,git_daemon,commits}}

--- a/lib/settings_validator.rb
+++ b/lib/settings_validator.rb
@@ -11,7 +11,7 @@ class SettingsValidator
       plain_errors = settings_validations_wrapper.errors.messages
       formatted_errors = format_errors(plain_errors)
       print_errors(formatted_errors)
-      exit
+      exit 1
     end
   end
 


### PR DESCRIPTION
Whenever the settings validations failed, travis and jenkins were green.
However, the settings validations fail because of missing directories. Those are now created in both, travis and jenkins (see also https://github.com/ontohub/ontohub-ci/commit/b7e0d081c62210c8b2712626ee01cc8634650eca).