### PR TITLE
1407 Allow to set an email without the host-part

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -11,7 +11,12 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = Settings.email
+  config.mailer_sender =
+    if Settings.email.include?('@')
+      Settings.email
+    else
+      "#{Settings.email}@#{Ontohub::Application.config.fqdn}"
+    end
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'Devise::Mailer'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,8 +19,9 @@ OMS_qualifier: modeling
 # Optional asset host for delivery of static files (css, images, javascripts)
 # asset_host: assets.example.com
 
-# Sender address for outgoing mail
-email: noreply@example.com
+# Sender address for outgoing mail.
+# The host will be appended automatically if it does not contain an @ character.
+email: noreply
 
 # Mail delivery
 # http://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration

--- a/lib/settings_validation_wrapper.rb
+++ b/lib/settings_validation_wrapper.rb
@@ -153,7 +153,7 @@ class SettingsValidationWrapper
             if: :in_production?
 
   validates :yml__email,
-            email_from_host: {hostname: ->(record) { record.initializers__fqdn }},
+            email_host: {hostname: ->(record) { record.initializers__fqdn }},
             if: :in_production?
 
   validates :yml__exception_notifier__exception_recipients,

--- a/lib/settings_validation_wrapper/validators.rb
+++ b/lib/settings_validation_wrapper/validators.rb
@@ -55,7 +55,7 @@ module SettingsValidationWrapper::Validators
     end
   end
 
-  class EmailFromHostValidator < ActiveModel::EachValidator
+  class EmailHostValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
       fqdn =
         if options[:hostname].respond_to?(:call)
@@ -63,7 +63,11 @@ module SettingsValidationWrapper::Validators
         else
           options[:hostname]
         end
-      unless value.match(/@#{fqdn}\z/)
+      if value.match(/@.*@/)
+        record.errors.add attribute,
+          'email address must have a valid email format.'
+      end
+      if value.include?('@') && !value.match(/@#{fqdn}\z/)
         record.errors.add attribute,
           "email adress must belong to the fully qualified domain name '#{fqdn}'."
       end


### PR DESCRIPTION
Now we can either set `noreply` or `noreply@example.com` as the email
address. If the host-part is omitted, it will be appended automatically.
If the host-part is specified, it must be the same as the FQDN.