### PR TITLE
Lots of deployment fixes

### DIFF
--- a/config/initializers/paths.rb
+++ b/config/initializers/paths.rb
@@ -1,8 +1,7 @@
 module PathsInitializer
   DEFAULT_PATHS = {git_repositories: 'repositories',
                    symlinks: 'git_daemon',
-                   commits: 'commits',
-                   git_home: 'git'}
+                   commits: 'commits'}
   class << self
     def expand(path)
       Dir.chdir(Rails.root) { Pathname.new(path).expand_path }
@@ -22,7 +21,6 @@ module PathsInitializer
     def empty_initialization(config)
       config.data_root = nil
       config.git_root = nil
-      config.git_home = nil
       config.symlink_path = nil
       config.commits_path = nil
     end
@@ -34,7 +32,6 @@ module PathsInitializer
       config.git_root = prepare(Settings.paths.git_repositories, DEFAULT_PATHS[:git_repositories])
       config.symlink_path = prepare(Settings.paths.symlinks, DEFAULT_PATHS[:symlinks])
       config.commits_path = prepare(Settings.paths.commits, DEFAULT_PATHS[:commits])
-      config.git_home = prepare(Settings.paths.git_home, DEFAULT_PATHS[:git_home])
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -71,19 +71,16 @@ exception_notifier:
     - exception-recipient@example.com
 
 # The following paths can be absolute paths
-# or relative paths to the project root
+# or relative paths (relative to the project root)
 paths:
   # General data.
   data: data
-  # git repositories (names are numbers/ids)
-  # May be nil - then paths.data/repositories is used
-  git_repositories: data/repositories
+  # git repositories (names of repositories are numbers/ids)
+  git_repositories: # nil - then data/repositories is used
   # named symlinks to the git repositories
-  # May be nil - then paths.data/git_daemon is used
-  symlinks: data/git_daemon
+  symlinks: # nil - then data/git_daemon is used
   # cache for files that needed to be checked out from the git repositories
-  # May be nil - then paths.data/commits is used
-  commits: data/commits
+  commits: # nil - then data/commits is used
 
 hets:
   # This is the path to the hets executable we use in `rake hets:*` and for the

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -84,10 +84,6 @@ paths:
   # cache for files that needed to be checked out from the git repositories
   # May be nil - then paths.data/commits is used
   commits: data/commits
-  # home directory of the git user
-  #   needed for handling of ssh keys in ~git/.ssh/authorized_keys
-  # May be nil - then paths.data/git is used
-  git_home: ~git
 
 hets:
   # This is the path to the hets executable we use in `rake hets:*` and for the

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -6,8 +6,5 @@ git:
 
 display_head_commit: true
 
-paths:
-  git_home: tmp/git
-
 asynchronous_execution:
   log_level: INFO

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -10,4 +10,3 @@ paths:
   git_repositories: tmp/data/git
   symlinks: tmp/data/git_daemon
   commits: tmp/data/commits
-  git_home: tmp/git

--- a/doc/productive_deployment.md
+++ b/doc/productive_deployment.md
@@ -203,8 +203,8 @@ You can deploy this codebase to your server with:
 For security reasons, we don't directly manipulate the git-user's `authorized_keys` file in the Ontohub code.
 Instead, we use a separate executable `cp_keys` which copies an `authorized_keys` file to the git-user's `.ssh` directory and prevails the correct permissions on that file.
 
-The executable, which is located at `${paths.git_home}/.ssh/cp_keys`, is called with no arguments.
-It copies the file `${paths.data}/.ssh/authorized_keys` to `${paths.git_home}/.ssh/authorized_keys`.
+The executable, which is located at `${paths.data}/.ssh/cp_keys`, is called with no arguments.
+It copies the file `${paths.data}/.ssh/authorized_keys` to `${paths.data}/.ssh/authorized_keys`.
 The target file's owner must be the git-user and the permissions must be set as usual for an `authorized_keys` file.
 
 We prepared C-code for this task for Linux machines.
@@ -213,7 +213,7 @@ It needs to be edited to have the paths from the `settings[.local].yml` hardcode
 
 We also prepared a rake task to edit and compile the executable for you:
 ```
-RAILS_ENV=production bundle exec rake git:compile_cp_keys
+RAILS_ENV=production GIT_HOME=/home/git bundle exec rake git:compile_cp_keys
 ```
 Although this takes some work off your shoulders, it also prints what you need to do.
 This task is only for convenience.

--- a/lib/authorized_keys_manager.rb
+++ b/lib/authorized_keys_manager.rb
@@ -3,9 +3,9 @@ require 'pathname'
 class AuthorizedKeysManager
 
   CONFIG               = Ontohub::Application.config
-  GIT_HOME_SSH_DIR     = CONFIG.git_home.join('.ssh')
   SSH_DIR              = CONFIG.data_root.join('.ssh')
   AUTHORIZED_KEYS_FILE = SSH_DIR.join('authorized_keys')
+  CP_KEYS_EXECUTABLE   = SSH_DIR.join('cp_keys')
   GIT_SHELL_FILE       = Rails.root.join('git', 'bin', 'git-shell').
     # replace capistrano-style release with 'current'-symlink
     sub(%r{/releases/\d+/}, '/current/')
@@ -56,8 +56,7 @@ class AuthorizedKeysManager
     end
 
     def copy_authorized_keys_to_git_home
-      GIT_HOME_SSH_DIR.mkpath
-      system(GIT_HOME_SSH_DIR.join('cp_keys').to_s)
+      system(CP_KEYS_EXECUTABLE.to_s)
     end
   end
 end

--- a/lib/settings_validation_wrapper.rb
+++ b/lib/settings_validation_wrapper.rb
@@ -233,8 +233,10 @@ class SettingsValidationWrapper
   end
 
   def initialize
-    # define a value for the cp_keys location
-    @cp_keys = Pathname.new(Settings.paths.git_home).join('.ssh', 'cp_keys').to_s
+    # Define a value for the cp_keys location.
+    # This must be defined in two places. Make sure this value is synchronized
+    # with AuthorizedKeysManager.cp_keys_executable.
+    @cp_keys = Pathname.new(Settings.paths.data).join('.ssh', 'cp_keys').to_s
   end
 
   def cp_keys=(_path)

--- a/lib/settings_validation_wrapper.rb
+++ b/lib/settings_validation_wrapper.rb
@@ -240,7 +240,7 @@ class SettingsValidationWrapper
   end
 
   def cp_keys=(_path)
-    # Noop - the value is supposed to be hard-coded.
+    # No-Op - the value is supposed to be hard-coded.
     # The validations require the existence of a setter, though.
   end
 

--- a/lib/settings_validation_wrapper.rb
+++ b/lib/settings_validation_wrapper.rb
@@ -20,7 +20,7 @@ class SettingsValidationWrapper
         if failure_condition_met?(key)
           record.errors["yml__paths__#{key}".to_sym] =
             "Implicitly set data directory path '#{dir}' is not a directory."
-        elsif !Settings.paths[key].is_a?(String)
+        elsif !Settings.paths[key].nil? && !Settings.paths[key].is_a?(String)
           record.errors["yml__paths__#{key}".to_sym] = 'Is not a String value.'
         elsif !File.directory?(dir)
           record.errors["yml__paths__#{key}".to_sym] = 'Is not a directory.'

--- a/lib/settings_validator.rb
+++ b/lib/settings_validator.rb
@@ -35,8 +35,10 @@ class SettingsValidator
     opening_line =
       if category == :initializers
         "#{format_initializer_error(key_portions)} #{format_key(key_portions)}"
-      else
+      elsif category == :yml
         format_key(key_portions)
+      else
+        key
       end
     bad_value = value_of(category, key_portions)
     <<-MESSAGE
@@ -81,7 +83,11 @@ class SettingsValidator
   end
 
   def value_of(category, key_portions)
-    object = SettingsValidationWrapper.base(category.to_s)
-    SettingsValidationWrapper.get_value(object, key_portions)
+    if !%i(yml initializers).include?(category)
+      SettingsValidationWrapper.new.send(category)
+    else
+      object = SettingsValidationWrapper.base(category.to_s)
+      SettingsValidationWrapper.get_value(object, key_portions)
+    end
   end
 end

--- a/lib/settings_validator.rb
+++ b/lib/settings_validator.rb
@@ -72,7 +72,7 @@ class SettingsValidator
     key = key_portions.join('.')
     if 'fqdn' == key
       "The FQDN could not be determined. Please set the hostname in #{CONFIG_YML_FILES}"
-    elsif %w(data_root git_home git_root symlink_path commits_path).include?(key)
+    elsif %w(data_root git_root symlink_path commits_path).include?(key)
       'Please check the paths keys in the settings -'
     else
       # other possible values: %w(consider_all_requests_local secret_token log_level)

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -1,7 +1,7 @@
 namespace :git do
   def reconfigure_cp_keys(source_file)
     data_root = Ontohub::Application.config.data_root
-    git_home = Ontohub::Application.config.git_home
+    git_home = ENV['GIT_HOME']
 
     reconfigured_source = File.read(source_file).
       sub(/^#define DATA_ROOT .*$/, "#define DATA_ROOT \"#{data_root}\"").
@@ -41,6 +41,13 @@ namespace :git do
 
   desc 'Compile cp_keys binary'
   task :compile_cp_keys => :environment do
+    unless ENV['GIT_HOME']
+      $stderr.puts 'Please specify the environment variable GIT_HOME.'
+      $stderr.puts "It must contain the absolute path to the git user's home."
+      $stderr.puts 'Exiting.'
+      exit 1
+    end
+
     target_dir = AuthorizedKeysManager::SSH_DIR
     target_dir.mkpath
 

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -48,7 +48,7 @@ namespace :git do
       exit 1
     end
 
-    target_dir = AuthorizedKeysManager::SSH_DIR
+    target_dir = AuthorizedKeysManager.ssh_dir
     target_dir.mkpath
 
     source_file = Rails.root.join('script', 'cp_keys.c')
@@ -66,11 +66,11 @@ namespace :git do
 
   desc 'Create authorized_keys file and set its permissions'
   task :prepare_authorized_keys => :environment do
-    AuthorizedKeysManager::SSH_DIR.mkpath
-    if !File.exists?(AuthorizedKeysManager::AUTHORIZED_KEYS)
-      puts "Creating the file #{AuthorizedKeysManager::AUTHORIZED_KEYS}."
-      FileUtils.touch(AuthorizedKeysManager::AUTHORIZED_KEYS)
-      set_permissions('0640', AuthorizedKeysManager::AUTHORIZED_KEYS.to_s,
+    AuthorizedKeysManager.ssh_dir.mkpath
+    if !File.exists?(AuthorizedKeysManager.authorized_keys)
+      puts "Creating the file #{AuthorizedKeysManager.authorized_keys}."
+      FileUtils.touch(AuthorizedKeysManager.authorized_keys)
+      set_permissions('0640', AuthorizedKeysManager.authorized_keys.to_s,
                       'the webserver-running user.')
     end
   end

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -41,7 +41,7 @@ namespace :git do
 
   desc 'Compile cp_keys binary'
   task :compile_cp_keys => :environment do
-    target_dir = Ontohub::Application.config.git_home.join('.ssh')
+    target_dir = AuthorizedKeysManager::SSH_DIR
     target_dir.mkpath
 
     source_file = Rails.root.join('script', 'cp_keys.c')

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -66,13 +66,11 @@ namespace :git do
 
   desc 'Create authorized_keys file and set its permissions'
   task :prepare_authorized_keys => :environment do
-    SSH_DIR = Ontohub::Application.config.data_root.join('.ssh')
-    AUTHORIZED_KEYS = SSH_DIR.join('authorized_keys')
-    SSH_DIR.mkpath
-    if !File.exists?(AUTHORIZED_KEYS)
-      puts "Creating the file #{AUTHORIZED_KEYS}."
-      FileUtils.touch(AUTHORIZED_KEYS)
-      set_permissions('0640', AUTHORIZED_KEYS.to_s,
+    AuthorizedKeysManager::SSH_DIR.mkpath
+    if !File.exists?(AuthorizedKeysManager::AUTHORIZED_KEYS)
+      puts "Creating the file #{AuthorizedKeysManager::AUTHORIZED_KEYS}."
+      FileUtils.touch(AuthorizedKeysManager::AUTHORIZED_KEYS)
+      set_permissions('0640', AuthorizedKeysManager::AUTHORIZED_KEYS.to_s,
                       'the webserver-running user.')
     end
   end


### PR DESCRIPTION
This shall
* fix #1414
* fix #1415
* print a more useful error message if the cp_keys executable is missing. Previously, this printed a bad key and a bad value (only a good error message itself)