### PR TITLE
1024 sentence display broken

### DIFF
--- a/app/helpers/sentence_helper.rb
+++ b/app/helpers/sentence_helper.rb
@@ -1,7 +1,7 @@
 module SentenceHelper
 
   def format_for_view(sentence)
-    if sentence.display_text? then
+    if sentence.display_text? && sentence.ontology.logic.name == 'OWL'
       sentence.display_text.gsub(/<([^>]*)>/, "<strong>\\1</strong>" ).html_safe
     else
       "#{sentence.text}".sub(/\s%\(#{sentence.name}\)%/, '')


### PR DESCRIPTION
This shall fix #1024. It now only displays bold text (removing arrow brackets) for OWL. CASL sentences, for example, still keep their "less than" and "greater than" symbols.

Without this variable being set, the rake task `git:compile_cp_keys` (called by the rebuild script) fails.