### PR TITLE
Specify GIT_HOME environment variable for rebuild script

### DIFF
--- a/doc/developer_installation_on_mac_os_x_lion_and_up.md
+++ b/doc/developer_installation_on_mac_os_x_lion_and_up.md
@@ -154,6 +154,17 @@ brew install hets --with-wrapper
 
 If there is a new version released you can update hets through the homebrew process (`brew upgrade`).
 
+## Extra executables
+
+The SSH-Key handling requires an additional executable `data/.ssh/cp_keys` to exist.
+This can be compiled easily from the supplied C-code with (in the ontohub directory)
+
+    GIT_HOME=$(pwd)/tmp/git bundle exec rake git:compile_cp_keys
+
+Providing the `GIT_HOME` variable is mandatory for this rake task.
+It will print a message about changing permissions, but you don't need to do as the message says as long as you are in a development environment.
+It is only important for securing production systems.
+
 ## setup
 
 You can start everything needed with (in the ontohub directory):

--- a/doc/developer_installation_on_ubuntu.md
+++ b/doc/developer_installation_on_ubuntu.md
@@ -146,6 +146,17 @@ tests. You only need to install the package:
 sudo apt-get install -y phantomjs
 ```
 
+## Extra executables
+
+The SSH-Key handling requires an additional executable `data/.ssh/cp_keys` to exist.
+This can be compiled easily from the supplied C-code with (in the ontohub directory)
+
+    GIT_HOME=$(pwd)/tmp/git bundle exec rake git:compile_cp_keys
+
+Providing the `GIT_HOME` variable is mandatory for this rake task.
+It will print a message about changing permissions, but you don't need to do as the message says as long as you are in a development environment.
+It is only important for securing production systems.
+
 ## setup
 
 In ontohub directory:

--- a/script/rebuild-ontohub
+++ b/script/rebuild-ontohub
@@ -111,7 +111,9 @@ print_colored_or_not() {
 run_invoker="1"
 colored_output="1"
 
-rails_root="$(dirname $0)/.."
+cwd="$(pwd)"
+rails_root=$(cd "$(dirname $0)/.."; pwd)
+cd $cwd
 export GIT_HOME="${GIT_HOME:-$rails_root/tmp/git}"
 
 for i in "$@"; do

--- a/script/rebuild-ontohub
+++ b/script/rebuild-ontohub
@@ -111,6 +111,9 @@ print_colored_or_not() {
 run_invoker="1"
 colored_output="1"
 
+rails_root="$(dirname $0)/.."
+export GIT_HOME="${GIT_HOME:-$rails_root/tmp/git}"
+
 for i in "$@"; do
 case $i in
     -d|--download-fixtures)


### PR DESCRIPTION
The GIT_HOME environment variable was not set in the rebuild script.
This adds a default value.