### PR TITLE
Overwrite arrays in config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,11 +41,9 @@ end
 gem 'haml-rails', '~> 0.4'
 
 # Project configuration
-# Official version above and including 0.4 requires Rails
-# which is a problem in git-hooks.
 # The specified commit is from a fork and allows to overwrite arrays.
 # It has been pull-requested:
-# https://github.com/railsconfig/rails_config/pull/99
+# https://github.com/railsconfig/rails_config/pull/103
 gem 'rails_config', github: 'dtaniwaki/rails_config', ref: 'merge-array-option'
 
 #provides  correct indefinite article 

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'haml-rails', '~> 0.4'
 # The specified commit is from a fork and allows to overwrite arrays.
 # It has been pull-requested:
 # https://github.com/railsconfig/rails_config/pull/99
-gem 'rails_config', github: 'eugenk/rails_config', ref: 'overwrite_arrays'
+gem 'rails_config', github: 'dtaniwaki/rails_config', ref: 'merge-array-option'
 
 #provides  correct indefinite article 
 gem 'indefinite_article', '~> 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,9 +13,9 @@ GIT
       rails (~> 3.2.21)
 
 GIT
-  remote: git://github.com/eugenk/rails_config.git
-  revision: d5dc9f2c8727be4ff389c89472fd27deba352abf
-  ref: overwrite_arrays
+  remote: git://github.com/dtaniwaki/rails_config.git
+  revision: e07c116d5591d31584215ac3bccc50321eef23f2
+  ref: merge-array-option
   specs:
     rails_config (0.5.0.beta1)
       activesupport (>= 3.0)
@@ -471,7 +471,6 @@ GEM
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
       rspec-mocks (~> 2.99.0)
-    rspec-support (3.3.0)
     ruby-graphviz (1.2.2)
     ruby-prof (0.15.8)
     rubydns (0.8.5)

--- a/config/application.rb
+++ b/config/application.rb
@@ -79,6 +79,8 @@ module Ontohub
                                                   "#{Rails.env}.local.rb")
       require local_environment_config if File.exists?(local_environment_config)
 
+      RailsConfig.overwrite_arrays = true
+
       Settings.add_source!(Rails.root.join('config', 'hets.yml').to_s)
       Settings.reload!
 


### PR DESCRIPTION
The previous rails_config version didn't properly overwrite arrays.
This version does overwrite them.