### PR TITLE
Deletes whitespace to fix test.

### DIFF
--- a/app/models/key/fingerprint.rb
+++ b/app/models/key/fingerprint.rb
@@ -30,7 +30,7 @@ module Key::Fingerprint
       self.fingerprint = match.gsub(":","")
     end
   rescue Subprocess::Error => e
-    errors[:key] << e.output.split("\n").last.split(" ",2).last
+    errors[:key] << e.output.split("\n").last.split(" ",2).last.strip
   end
 
 end


### PR DESCRIPTION
This should fix

```
Failure/Error: it{ subject.errors[:key].should == ["is not a public key file."] }
       expected: ["is not a public key file."]
            got: ["is not a public key file.\r"] (using ==)
     # ./spec/models/key_spec.rb:34:in `block (4 levels) in <top (required)>'
```