### PR TITLE
mapping_spec quick fix

### DIFF
--- a/spec/fixtures/ontologies/dol/reference.dol
+++ b/spec/fixtures/ontologies/dol/reference.dol
@@ -1,10 +1,10 @@
 %prefix(
-   path: <https://ontohub.org/fois-ontology-competition/FormalCAD/>
+   path: <https://github.com/ontohub/ontohub/raw/staging/spec/fixtures/ontologies/owl/>
     )%
 
-logic OWL 
+logic OWL
 
-ontology Features = 
+ontology Features =
  path:features.owl
 end
 


### PR DESCRIPTION
The `mapping_spec` depends on ontohub being available. However, with the current server/TLS problems, we need to remove this dependency. Unfortunately, we need an external source (i.e. not on the same ontohub instance that is tested) for the imported fixture file in order for it to be placed in the `ExternalRepository`.

I couldn't find a clean way to do this without depending on a network connection. So instead of depending on Ontohub, we now depend on Github.