### PR TITLE
1445 run multiple hets instances

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem 'rdf', '~> 1.1.9'
 gem 'rdf-rdfxml', '~> 1.1.3'
 gem 'rdf-n3', '~> 1.1.2'
 
+gem 'redis-semaphore', '~> 0.2.4'
+
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -441,6 +441,8 @@ GEM
     redis (3.2.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
+    redis-semaphore (0.2.4)
+      redis
     ref (1.0.5)
     responders (1.0.0)
       railties (>= 3.2, < 5)
@@ -639,6 +641,7 @@ DEPENDENCIES
   rdf-n3 (~> 1.1.2)
   rdf-rdfxml (~> 1.1.3)
   redcarpet (~> 3.3.2)
+  redis-semaphore (~> 0.2.4)
   rest-client (~> 1.8.0)
   rspec-activemodel-mocks (~> 1.0.1)
   rspec-its (~> 1.0.1)

--- a/app/controllers/filetypes_controller.rb
+++ b/app/controllers/filetypes_controller.rb
@@ -9,8 +9,9 @@ class FiletypesController < ApplicationController
   protected
 
   def filetype
-    @filetype ||= Hets::FiletypeCaller.new(HetsInstance.choose!).
-      call(params[:iri])
+    HetsInstance.with_instance! do |hets_instance|
+      @filetype ||= Hets::FiletypeCaller.new(hets_instance).call(params[:iri])
+    end
   end
 
   def filetype_json

--- a/app/models/hets_instance.rb
+++ b/app/models/hets_instance.rb
@@ -19,10 +19,16 @@ has a minimal Hets version of #{Hets.minimal_version_string}
     end
   end
 
-  attr_accessible :name, :uri
+  STATES = %w(free force-free busy)
+
+  attr_accessible :name, :uri, :state, :queue_size
 
   before_save :set_up_state
+  before_save :set_state_updated_at
   after_create :start_update_clock
+
+  validate :state, inclusion: {in: STATES}
+  validate :queue_size, numericality: {greater_than_or_equal_to: 0}
 
   scope :active_instances, -> do
     where(up: true).where('version >= ?', Hets.minimal_version_string)
@@ -70,6 +76,10 @@ has a minimal Hets version of #{Hets.minimal_version_string}
   def set_up_state!
     set_up_state
     save!
+  end
+
+  def set_state_updated_at
+    self.state_updated_at = Time.now if state_changed?
   end
 
   def start_update_clock

--- a/app/models/hets_instance.rb
+++ b/app/models/hets_instance.rb
@@ -21,6 +21,7 @@ has a minimal Hets version of #{Hets.minimal_version_string}
 
   STATES = %w(free force-free busy)
   MUTEX_KEY = :choose_hets_instance
+  FORCE_FREE_WAITING_PERIOD = 60.seconds
 
   attr_accessible :name, :uri, :state, :queue_size
 
@@ -94,6 +95,7 @@ has a minimal Hets version of #{Hets.minimal_version_string}
 
   def set_busy!
     self.state = 'busy'
+    HetsInstanceForceFreeWorker.perform_in(FORCE_FREE_WAITING_PERIOD, id)
     save!
   end
 

--- a/config/god/app.rb
+++ b/config/god/app.rb
@@ -12,7 +12,7 @@ God.pid_file_directory = File.join(RAILS_ROOT, 'tmp/pids/')
 SidekiqWorkers.configure do
   if ENV['RAILS_ENV']=='production'
     # one worker per core
-    Settings.hets.instances_count.times.each do
+    Settings.hets.instance_urls.size.times.each do
       watch 'hets', 1
     end
 
@@ -30,5 +30,7 @@ SidekiqWorkers.configure do
 end
 
 HetsWorkers.configure do
-  watch
+  Settings.hets.instance_urls.each do |hets_url|
+    watch(URI(hets_url).port)
+  end
 end

--- a/config/god/hets_workers.rb
+++ b/config/god/hets_workers.rb
@@ -5,10 +5,11 @@ class HetsWorkers < Watcher
     'hets'
   end
 
-  def start_cmd
+  def start_cmd(port)
     load_hets_settings
-    hets_opts = ' ' << hets_server_options.join(' ')
-    "exec nice #{hets_executable} -X" << hets_opts
+    options = hets_server_options.dup
+    options << "--listen=#{port}" if port
+    "exec nice #{hets_executable} --server #{options.join(' ')}"
   end
 
   def pid_file

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -86,9 +86,11 @@ hets:
   # This is the path to the hets executable we use in `rake hets:*` and for the
   # process manager in production mode (god)
   executable_path: /usr/bin/hets
-  # The number of hets instances to run in parallel in production mode.
-  # Minimum: 1, Maximum: number of processors
-  instances_count: 1
+  # The URLs to the hets instances without trailing slash.
+  # The number of instances is not allowed to be greater than the number of
+  # hardware processor cores.
+  instance_urls:
+    - http://localhost:8000
   # The time between update-checks of registered hets-instances in minutes
   time_between_updates: 360
 

--- a/db/migrate/20150807083608_add_hets_instance_load_balancing_attributes.rb
+++ b/db/migrate/20150807083608_add_hets_instance_load_balancing_attributes.rb
@@ -1,0 +1,9 @@
+class AddHetsInstanceLoadBalancingAttributes < ActiveRecord::Migration
+  def change
+    add_column :hets_instances, :state, :string
+    add_column :hets_instances, :state_updated_at, :datetime
+    add_column :hets_instances, :queue_size, :integer
+
+    add_index :hets_instances, :state
+  end
+end

--- a/db/seeds/001-hets.rb
+++ b/db/seeds/001-hets.rb
@@ -1,3 +1,7 @@
-Sidekiq::Testing.disable! do
+if Rails.env.production?
   RakeHelper::Hets.create_instances
+else
+  Sidekiq::Testing.disable! do
+    RakeHelper::Hets.create_instances
+  end
 end

--- a/db/seeds/001-hets.rb
+++ b/db/seeds/001-hets.rb
@@ -1,5 +1,5 @@
 Sidekiq::Testing.disable! do
   %w(localhost:8000).each do |uri|
-    HetsInstance.create(name: uri, uri: "http://#{uri}")
+    HetsInstance.create(name: uri, uri: "http://#{uri}", state: 'free', queue_size: 0)
   end
 end

--- a/db/seeds/001-hets.rb
+++ b/db/seeds/001-hets.rb
@@ -1,5 +1,3 @@
 Sidekiq::Testing.disable! do
-  %w(localhost:8000).each do |uri|
-    HetsInstance.create(name: uri, uri: "http://#{uri}", state: 'free', queue_size: 0)
-  end
+  RakeHelper::Hets.create_instances
 end

--- a/db/seeds/020-logicgraph.rb
+++ b/db/seeds/020-logicgraph.rb
@@ -1,2 +1,2 @@
 # Initially import logics.
-RakeHelper.import_logicgraph
+RakeHelper::LogicGraph.import

--- a/db/seeds/020-logicgraph.rb
+++ b/db/seeds/020-logicgraph.rb
@@ -1,2 +1,2 @@
 # Initially import logics.
-Rake::Task['import:logicgraph'].invoke
+RakeHelper.import_logicgraph

--- a/db/seeds/030-proof_statuses.rb
+++ b/db/seeds/030-proof_statuses.rb
@@ -1,2 +1,2 @@
 # Create ProofStatuses from SZS ontology.
-Rake::Task['generate:proof_statuses'].invoke
+RakeHelper::Generate.proof_statuses

--- a/db/seeds/080-metadata.rb
+++ b/db/seeds/080-metadata.rb
@@ -1,2 +1,2 @@
 # Create metadata objects (FormalityLevel, LicenseModel, OntologyType, Task).
-Rake::Task['generate:metadata'].invoke
+RakeHelper::Generate.metadata

--- a/db/seeds/090-categories.rb
+++ b/db/seeds/090-categories.rb
@@ -1,2 +1,2 @@
 # Create categories from Domain_Fields_Core ontology.
-Rake::Task['generate:categories'].invoke
+RakeHelper::Generate.categories

--- a/lib/hets.rb
+++ b/lib/hets.rb
@@ -22,25 +22,32 @@ module Hets
 
   def self.parse_via_api(resource, hets_options, structure_only: false)
     mode = structure_only ? :fast_run : :default
-    parse_caller = Hets::ParseCaller.new(HetsInstance.choose!, hets_options)
-    parse_caller.call(qualified_loc_id_for(resource), with_mode: mode)
+    HetsInstance.with_instance! do |hets_instance|
+      parse_caller = Hets::ParseCaller.new(hets_instance, hets_options)
+      parse_caller.call(qualified_loc_id_for(resource), with_mode: mode)
+    end
   end
 
   def self.prove_via_api(resource, prove_options)
-    prove_caller = Hets::ProveCaller.new(HetsInstance.choose!, prove_options)
-    prove_caller.call(qualified_loc_id_for(resource))
+    HetsInstance.with_instance! do |hets_instance|
+      prove_caller = Hets::ProveCaller.new(hets_instance, prove_options)
+      prove_caller.call(qualified_loc_id_for(resource))
+    end
   end
 
   def self.provers_via_api(resource, provers_options)
-    provers_caller = Hets::ProversCaller.new(HetsInstance.choose!, provers_options)
-    provers_caller.call(qualified_loc_id_for(resource))
+    HetsInstance.with_instance! do |hets_instance|
+      provers_caller = Hets::ProversCaller.new(hets_instance, provers_options)
+      provers_caller.call(qualified_loc_id_for(resource))
+    end
   end
 
   def self.filetype(resource)
     iri = qualified_loc_id_for(resource)
-    filetype_caller = Hets::FiletypeCaller.new(HetsInstance.choose!)
-
-    response_iri, filetype = filetype_caller.call(iri).split(': ')
+    HetsInstance.with_instance! do |hets_instance|
+      filetype_caller = Hets::FiletypeCaller.new(hets_instance)
+      response_iri, filetype = filetype_caller.call(iri).split(': ')
+    end
     if response_iri == iri
       Mime::Type.lookup(filetype)
     else

--- a/lib/hets_instance_force_free_worker.rb
+++ b/lib/hets_instance_force_free_worker.rb
@@ -1,0 +1,10 @@
+class HetsInstanceForceFreeWorker < BaseWorker
+  sidekiq_options queue: 'default'
+
+  def perform(hets_instance_id)
+    Semaphore.exclusively(HetsInstance::MUTEX_KEY) do
+      hets_instance = HetsInstance.find(hets_instance_id)
+      hets_instance.set_force_free!
+    end
+  end
+end

--- a/lib/rake_helper.rb
+++ b/lib/rake_helper.rb
@@ -1,0 +1,26 @@
+module RakeHelper
+  def self.import_logicgraph(email = nil)
+    def save(user, symbol)
+      symbol.user = user if symbol.has_attribute? "user_id"
+      begin
+        symbol.save!
+      rescue ActiveRecord::RecordInvalid => e
+        puts "Validation-Error: #{e.record} (#{e.message})"
+      end
+    end
+
+    user = User.find_all_by_admin(true).first
+    user = User.find_by_email! email unless nil.nil?
+
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        system("#{Settings.hets.executable_path} -G")
+        LogicgraphParser.parse(File.open(File.join(dir, 'LogicGraph.xml')),
+          logic:          Proc.new{ |h| save(user, h) },
+          language:       Proc.new{ |h| save(user, h) },
+          logic_mapping:  Proc.new{ |h| save(user, h) },
+          support:        Proc.new{ |h| save(user, h) })
+        end
+    end
+  end
+end

--- a/lib/rake_helper.rb
+++ b/lib/rake_helper.rb
@@ -1,6 +1,24 @@
 module RakeHelper
-  def self.import_logicgraph(email = nil)
-    def save(user, symbol)
+  module LogicGraph
+    def self.import(email = nil)
+      user = User.find_all_by_admin(true).first
+      user = User.find_by_email! email unless email.nil?
+
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          system("#{Settings.hets.executable_path} -G")
+          LogicgraphParser.parse(File.open(File.join(dir, 'LogicGraph.xml')),
+                                 logic:          Proc.new{ |h| save(user, h) },
+                                 language:       Proc.new{ |h| save(user, h) },
+                                 logic_mapping:  Proc.new{ |h| save(user, h) },
+                                 support:        Proc.new{ |h| save(user, h) })
+        end
+      end
+    end
+
+    protected
+
+    def self.save(user, symbol)
       symbol.user = user if symbol.has_attribute? "user_id"
       begin
         symbol.save!
@@ -8,19 +26,97 @@ module RakeHelper
         puts "Validation-Error: #{e.record} (#{e.message})"
       end
     end
+  end
 
-    user = User.find_all_by_admin(true).first
-    user = User.find_by_email! email unless nil.nil?
+  module Generate
+    def self.categories
+      ontology = meta_repository.ontologies.
+        where("name ilike '%Domain Fields Core'").first
+      if ontology
+        ontology.create_categories
+      else
+        ontology = download_from_ontohub_meta(
+          'Domain_Fields_Core.owl', 'categories.owl')
+      end
+      ontology.create_categories
+    end
 
-    Dir.mktmpdir do |dir|
-      Dir.chdir(dir) do
-        system("#{Settings.hets.executable_path} -G")
-        LogicgraphParser.parse(File.open(File.join(dir, 'LogicGraph.xml')),
-          logic:          Proc.new{ |h| save(user, h) },
-          language:       Proc.new{ |h| save(user, h) },
-          logic_mapping:  Proc.new{ |h| save(user, h) },
-          support:        Proc.new{ |h| save(user, h) })
+    def self.proof_statuses
+      meta_repository
+      download_from_ontohub_meta('proof_statuses.owl', 'proof_statuses.owl')
+      ProofStatus.refresh_statuses
+    end
+
+    def self.owl_ontology_class_hierarchies
+      # clean up
+      SymbolGroup.destroy_all
+      # generating new
+      logics = Logic.where(name: ["OWL2", "OWL"])
+      ontologies = Ontology.where(logic_id: logics)
+      ontologies.each do |ontology|
+        begin
+          TarjanTree.for(ontology)
+        rescue ActiveRecord::RecordNotFound => e
+          puts "Could not create symbol tree for: #{ontology.name} (#{ontology.id}) caused #{e}"
         end
+      end
+    end
+
+    def self.class_hierachy_for_specific_ontology
+      ontology = Ontology.find!(args.ontology_id)
+      #cleaning up to prevent duplicated symbol_groups
+      ontology.symbol_groups.destroy_all
+      #generating new
+      begin
+        TarjanTree.for(ontology)
+      rescue ActiveRecord::RecordNotFound => e
+        puts "Could not create entity tree for: #{ontology.name} (#{ontology.id}) caused #{e}"
+      end
+    end
+
+    def self.metadata
+      Settings.formality_levels.each { |t| update_or_create_by_name(FormalityLevel, t.to_h) }
+      Settings.license_models.each { |t| update_or_create_by_name(LicenseModel, t.to_h) }
+      Settings.ontology_types.each { |t| update_or_create_by_name(OntologyType, t.to_h) }
+      Settings.tasks.each { |t| update_or_create_by_name(Task, t.to_h) }
+    end
+
+    protected
+
+    def self.update_or_create_by_name(klass, h)
+      x = klass.find_by_name(h[:name])
+      if x.nil?
+        x = klass.create!(h)
+      else
+        x.update_attributes!(h)
+      end
+      x
+    end
+
+    def self.meta_repository
+      Repository.where(name: 'meta').
+        first_or_create!(description: 'Meta ontologies for Ontohub')
+    end
+
+    def self.download_from_ontohub_meta(source_file, target_file)
+      meta_repository
+      user = User.where(admin: true).first
+      filepath = "#{Rails.root}/spec/fixtures/seeds/#{target_file}"
+      basename = File.basename(filepath)
+      if ENV['DOWNLOAD_FIXTURES']
+        source_url =
+          "https://ontohub.org/repositories/meta/master/download/#{source_file}"
+        temp_file = Tempfile.new([target_file, File.extname(target_file)]).path
+        if system("wget -O #{temp_file} #{source_url}")
+          filepath = temp_file
+        else
+          puts 'No connection to ontohub.org. Using local file for the current task.'
+        end
+      end
+      version = meta_repository.
+        save_file(filepath, basename, "Add #{basename}.", user, do_not_parse: true)
+      version.parse
+      version.ontology
     end
   end
 end

--- a/lib/rake_helper.rb
+++ b/lib/rake_helper.rb
@@ -119,4 +119,20 @@ module RakeHelper
       version.ontology
     end
   end
+
+  module Hets
+    def self.recreate_instances
+      HetsInstance.all.each(&:destroy)
+      create_instances
+    end
+
+    def self.create_instances
+      Settings.hets.instance_urls.each do |hets_url|
+        uri = URI(hets_url)
+        name = uri.host
+        name += ":#{uri.port}" if uri.port
+        HetsInstance.create(name: name, uri: uri.to_s, state: 'free', queue_size: 0)
+      end
+    end
+  end
 end

--- a/lib/semaphore.rb
+++ b/lib/semaphore.rb
@@ -1,0 +1,20 @@
+# The Semaphore class allows to lock resources. The processes are blocked, i.e.
+# not polling, when they wait for a lock to be opened.
+# They are executed in order they arrive at the lock.
+#
+# It is based on Redis::Semaphore and can be extended to allow multiple
+# processes to enter the critical path.
+# Currently, only a mutex is implemented in this abstraction.
+class Semaphore
+  def self.exclusively(lock_key, &block)
+    Redis::Semaphore.new(lock_key,
+                         redis: redis,
+                         expiration: 120).lock { yield }
+  end
+
+  protected
+
+  def self.redis
+    Sidekiq.redis { |connection| connection }.redis
+  end
+end

--- a/lib/settings_validation_wrapper.rb
+++ b/lib/settings_validation_wrapper.rb
@@ -58,6 +58,7 @@ class SettingsValidationWrapper
                 yml__git__push_priority__changed_files_per_commit
                 yml__git__fallbacks__committer_name
                 yml__git__fallbacks__committer_email
+                yml__hets__instance_urls
                 yml__allowed_iri_schemes
                 yml__external_repository_name
                 yml__formality_levels
@@ -74,8 +75,7 @@ class SettingsValidationWrapper
 
                 initializers__fqdn)
 
-  PRESENCE_IN_PRODUCTION = %i(yml__hets__executable_path
-                              yml__hets__instances_count)
+  PRESENCE_IN_PRODUCTION = %i(yml__hets__executable_path)
 
   BOOLEAN = %i(yml__exception_notifier__enabled
                yml__display_head_commit
@@ -87,8 +87,7 @@ class SettingsValidationWrapper
 
                initializers__consider_all_requests_local)
 
-  FIXNUM = %i(yml__hets__instances_count
-              yml__action_mailer__smtp_settings__port
+  FIXNUM = %i(yml__action_mailer__smtp_settings__port
               yml__allow_unconfirmed_access_for_days
               yml__git__push_priority__commits
               yml__git__push_priority__changed_files_per_commit
@@ -120,6 +119,7 @@ class SettingsValidationWrapper
              yml__ontology_types
              yml__tasks
 
+             yml__hets__instance_urls
              yml__hets__cmd_line_options
              yml__hets__server_options)
 
@@ -193,13 +193,15 @@ class SettingsValidationWrapper
 
   validates :yml__hets__executable_path, executable: true, if: :in_production?
   if NPROC_AVAILABLE
-    validates :yml__hets__instances_count,
-              numericality: {greater_than: 0,
-                             less_than_or_equal_to: `nproc`.to_i},
+    validates :yml__hets__instance_urls,
+              length: {minimum: 1,
+                       maximum: `nproc`.to_i},
+              elements_are_uris: true,
               if: :in_production?
   else
-    validates :yml__hets__instances_count,
-              numericality: {greater_than: 0},
+    validates :yml__hets__instance_urls,
+              length: {minimum: 1},
+              elements_are_uris: true,
               if: :in_production?
   end
 

--- a/lib/settings_validation_wrapper/validators.rb
+++ b/lib/settings_validation_wrapper/validators.rb
@@ -34,6 +34,30 @@ module SettingsValidationWrapper::Validators
     end
   end
 
+  class ElementsAreUrisValidator < ActiveModel::EachValidator
+    def validate_each(record, attribute, value)
+      bad_uris = []
+      if value.is_a?(Array)
+        value.each do |elem|
+          if elem.is_a?(String)
+            begin
+              URI(elem)
+            rescue URI::InvalidURIError
+              bad_uris << elem
+            end
+          else
+            bad_uris << elem
+          end
+        end
+      end
+      unless bad_uris.empty?
+        record.errors.add(attribute,
+                          "all elements must be valid URIs.\n"\
+                          "The following are not:\n#{bad_uris.join("\n")}")
+      end
+    end
+  end
+
   class ElementsAreEmailValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
       unless value.is_a?(Array) && value.all? { |elem| elem.match(/@/) }

--- a/lib/settings_validator.rb
+++ b/lib/settings_validator.rb
@@ -67,7 +67,7 @@ class SettingsValidator
       message =
         "#{message} (see the comments in the config/settings.yml at this key)"
     end
-    "  #{message}"
+    indent_message(message, 2)
   end
 
   def format_initializer_error(key_portions)
@@ -89,5 +89,9 @@ class SettingsValidator
       object = SettingsValidationWrapper.base(category.to_s)
       SettingsValidationWrapper.get_value(object, key_portions)
     end
+  end
+
+  def indent_message(message, indentation)
+    message.split("\n").map { |line| "#{' ' * indentation}#{line}"}.join("\n")
   end
 end

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -1,95 +1,26 @@
-def update_or_create_by_name(klass, h)
-  x = klass.find_by_name(h[:name])
-  if x.nil?
-    x = klass.create!(h)
-  else
-    x.update_attributes!(h)
-  end
-  x
-end
-
-def meta_repository
-  Repository.where(name: 'meta').
-    first_or_create!(description: 'Meta ontologies for Ontohub')
-end
-
-def download_from_ontohub_meta(source_file, target_file)
-  meta_repository
-  user = User.where(admin: true).first
-  filepath = "#{Rails.root}/spec/fixtures/seeds/#{target_file}"
-  basename = File.basename(filepath)
-  if ENV['DOWNLOAD_FIXTURES']
-    source_url =
-      "https://ontohub.org/repositories/meta/master/download/#{source_file}"
-    temp_file = Tempfile.new([target_file, File.extname(target_file)]).path
-    if system("wget -O #{temp_file} #{source_url}")
-      filepath = temp_file
-    else
-      puts 'No connection to ontohub.org. Using local file for the current task.'
-    end
-  end
-  version = meta_repository.
-    save_file(filepath, basename, "Add #{basename}.", user, do_not_parse: true)
-  version.parse
-  version.ontology
-end
-
 namespace :generate do
   desc 'Import the categories for the ontologies'
   task :categories => :environment do
-    ontology = meta_repository.ontologies.
-      where("name ilike '%Domain Fields Core'").first
-    if ontology
-      ontology.create_categories
-    else
-      ontology = download_from_ontohub_meta(
-        'Domain_Fields_Core.owl', 'categories.owl')
-    end
-    ontology.create_categories
+    RakeHelper::Generate.categories
   end
 
   desc 'Import the proof statuses for theorems'
   task :proof_statuses => :environment do
-    meta_repository
-    download_from_ontohub_meta('proof_statuses.owl', 'proof_statuses.owl')
-    ProofStatus.refresh_statuses
+    RakeHelper::Generate.proof_statuses
   end
 
   desc 'Generate symbol trees for ALL OWL ontologies'
   task :owl_ontology_class_hierarchies => :environment do
-    #cleaning up
-    SymbolGroup.destroy_all
-    #generating new
-    logics = Logic.where(name: ["OWL2", "OWL"])
-    ontologies = Ontology.where(logic_id: logics)
-    ontologies.each do |ontology|
-      begin
-        TarjanTree.for(ontology)
-      rescue ActiveRecord::RecordNotFound => e
-        puts "Could not create symbol tree for: #{ontology.name} (#{ontology.id}) caused #{e}"
-      end
-    end
+    RakeHelper::Generate.owl_ontology_class_hierarchies
   end
-  
-  desc 'Generate symbol tree for one specific OWL ontologies'
 
+  desc 'Generate symbol tree for one specific OWL ontologies'
   task :class_hierachy_for_specific_ontology, [:ontology_id] => :environment do |t,args|
-    ontology = Ontology.find!(args.ontology_id)
-    #cleaning up to prevent duplicated symbol_groups
-    ontology.symbol_groups.destroy_all
-    #generating new
-    begin
-      TarjanTree.for(ontology)
-    rescue ActiveRecord::RecordNotFound => e
-      puts "Could not create entity tree for: #{ontology.name} (#{ontology.id}) caused #{e}"
-    end
+    RakeHelper::Generate.owl_ontology_class_hierarchies
   end
 
   desc 'Import the values for metadata'
   task :metadata => :environment do
-    Settings.formality_levels.each { |t| update_or_create_by_name(FormalityLevel, t.to_h) }
-    Settings.license_models.each { |t| update_or_create_by_name(LicenseModel, t.to_h) }
-    Settings.ontology_types.each { |t| update_or_create_by_name(OntologyType, t.to_h) }
-    Settings.tasks.each { |t| update_or_create_by_name(Task, t.to_h) }
+    RakeHelper::Generate.metadata
   end
 end

--- a/lib/tasks/hets.rake
+++ b/lib/tasks/hets.rake
@@ -4,7 +4,10 @@ namespace :hets do
 
   desc "Create Hets Instance if neccessary"
   task :generate_first_instance => :environment do
-    HetsInstance.first_or_create(name: 'localhost:8000', uri: 'http://localhost:8000')
+    HetsInstance.first_or_create(name: 'localhost:8000',
+                                 uri: 'http://localhost:8000',
+                                 state: 'free',
+                                 queue_size: 0)
   end
 
   desc 'Recreate Hets Instances from config'

--- a/lib/tasks/hets.rake
+++ b/lib/tasks/hets.rake
@@ -12,13 +12,7 @@ namespace :hets do
 
   desc 'Recreate Hets Instances from config'
   task :recreate_hets_instances => :environment do
-    HetsInstance.all.each(&:destroy)
-    Settings.hets.instance_urls.each do |hets_url|
-      uri = URI(hets_url)
-      name = uri.host
-      name += ":#{uri.port}" if uri.port
-      HetsInstance.create(name: name, uri: uri.to_s, state: 'free', queue_size: 0)
-    end
+    RakeHelper::Hets.recreate_instances
   end
 
   desc 'Start a hets server'

--- a/lib/tasks/hets.rake
+++ b/lib/tasks/hets.rake
@@ -7,6 +7,16 @@ namespace :hets do
     HetsInstance.first_or_create(name: 'localhost:8000', uri: 'http://localhost:8000')
   end
 
+  desc 'Recreate Hets Instances from config'
+  task :recreate_hets_instances => :environment do
+    HetsInstance.all.each(&:destroy)
+    Settings.hets.instance_urls.each do |hets_url|
+      uri = URI(hets_url)
+      name = uri.host
+      name += ":#{uri.port}" if uri.port
+      HetsInstance.create(name: name, uri: uri.to_s, state: 'free', queue_size: 0)
+    end
+  end
 
   desc 'Start a hets server'
   task :start do

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -41,28 +41,7 @@ namespace :import do
 
   desc 'Import logic graph.'
   task :logicgraph => :environment do
-    def save(symbol)
-      symbol.user = @user if symbol.has_attribute? "user_id"
-      begin
-        symbol.save!
-      rescue ActiveRecord::RecordInvalid => e
-        puts "Validation-Error: #{e.record} (#{e.message})"
-      end
-    end
-
-    @user = User.find_all_by_admin(true).first
-    @user = User.find_by_email! ENV['EMAIL'] unless ENV['EMAIL'].nil?
-
-    Dir.mktmpdir do |dir|
-      Dir.chdir(dir) do
-        system("#{Settings.hets.executable_path} -G")
-        LogicgraphParser.parse(File.open(File.join(dir, 'LogicGraph.xml')),
-          logic:          Proc.new{ |h| save(h) },
-          language:       Proc.new{ |h| save(h) },
-          logic_mapping:  Proc.new{ |h| save(h) },
-          support:        Proc.new{ |h| save(h) })
-        end
-    end
+    RakeHelper.import_logicgraph(ENV['EMAIL'])
   end
 
   desc 'Import keywords starting with P.'

--- a/spec/factories/hets_instance_factory_factory.rb
+++ b/spec/factories/hets_instance_factory_factory.rb
@@ -11,6 +11,8 @@ FactoryGirl.define do
   factory :hets_instance, aliases: [:local_hets_instance] do
     name { FactoryGirl.generate :hets_instance_name }
     uri { 'http://localhost:8000' }
+    state { 'free' }
+    queue_size { 0 }
   end
 
 end

--- a/spec/factories/hets_instance_factory_factory.rb
+++ b/spec/factories/hets_instance_factory_factory.rb
@@ -4,13 +4,17 @@ FactoryGirl.define do
     "gopher://host/ontology/#{n}"
   end
 
+  sequence :hets_uri do |n|
+    "http://localhost:#{8000 + (n % 1000)}"
+  end
+
   sequence :hets_instance_name do |n|
     "hets_instance-#{n}"
   end
 
   factory :hets_instance, aliases: [:local_hets_instance] do
     name { FactoryGirl.generate :hets_instance_name }
-    uri { 'http://localhost:8000' }
+    uri { FactoryGirl.generate :hets_uri }
     state { 'free' }
     queue_size { 0 }
   end

--- a/spec/hets_helper.rb
+++ b/spec/hets_helper.rb
@@ -23,7 +23,8 @@ def hets_prove_matcher(request1, request2)
 
   match1[:end] == match2[:end] &&
   inner_match1[:ontology] == inner_match2[:ontology] &&
-  %i(scheme host port query fragment).all? { |m| uri1.send(m) == uri2.send(m)}
+  # We don't check for the port because the HetsInstances factory varies it.
+  %i(scheme host query fragment).all? { |m| uri1.send(m) == uri2.send(m)}
 end
 
 def hets_vcr_file(subdir, ontology_fixture)
@@ -81,7 +82,7 @@ end
 def setup_hets
   let(:hets_instance) { create_local_hets_instance }
   before do
-    stub_request(:get, 'http://localhost:8000/version').
+    stub_request(:get, %r{http://localhost:8\d{3}/version}).
       to_return(body: Hets.minimal_version_string)
     hets_instance
   end
@@ -90,7 +91,7 @@ end
 
 def stub_hets_for(ontology_fixture,
                   command: 'dg', with: nil, with_version: nil, method: :get)
-  stub_request(:get, 'http://localhost:8000/version').
+  stub_request(:get, %r{http://localhost:8\d{3}/version}).
     to_return(body: Hets.minimal_version_string)
   stub_request(method, hets_uri(command, with, with_version)).
     to_return(body: hets_out_body(command, ontology_fixture))

--- a/spec/hets_helper.rb
+++ b/spec/hets_helper.rb
@@ -85,6 +85,7 @@ def setup_hets
       to_return(body: Hets.minimal_version_string)
     hets_instance
   end
+  after { hets_instance.finish_work! }
 end
 
 def stub_hets_for(ontology_fixture,

--- a/spec/lib/hets_instance_foce_free_worker_spec.rb
+++ b/spec/lib/hets_instance_foce_free_worker_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe HetsInstanceForceFreeWorker do
+  before do
+    stub_request(:get, %r{http://localhost:8\d{3}/version}).
+      to_return(status: 500, body: "", headers: {})
+  end
+
+  context 'on a free instance' do
+    let!(:hets_instance) { create :hets_instance, state: 'free' }
+    before do
+      Sidekiq::Testing.inline! do
+        HetsInstanceForceFreeWorker.new.perform(hets_instance.id)
+      end
+    end
+
+    it 'is a no-op' do
+      expect(hets_instance.reload.state).to eq('free')
+    end
+  end
+
+  context 'on a force-free instance' do
+    let!(:hets_instance) { create :hets_instance, state: 'force-free' }
+    before do
+      Sidekiq::Testing.inline! do
+        HetsInstanceForceFreeWorker.new.perform(hets_instance.id)
+      end
+    end
+
+    it 'is a no-op' do
+      expect(hets_instance.reload.state).to eq('force-free')
+    end
+  end
+
+  context 'on a busy instance' do
+    let!(:hets_instance) { create :hets_instance, state: 'busy' }
+    before do
+      Sidekiq::Testing.inline! do
+        HetsInstanceForceFreeWorker.new.perform(hets_instance.id)
+      end
+    end
+
+    it 'change the state' do
+      expect(hets_instance.reload.state).to eq('force-free')
+    end
+  end
+end

--- a/spec/models/hets_instance_spec.rb
+++ b/spec/models/hets_instance_spec.rb
@@ -8,7 +8,7 @@ describe HetsInstance do
   context 'when registering a hets instance' do
     context 'wrt. to update-jobs' do
       before do
-        stub_request(:get, "http://localhost:8000/version").
+        stub_request(:get, %r{http://localhost:8\d{3}/version}).
           to_return(status: 200,
                     body: "v#{general_version}, #{specific_version}",
                     headers: {})
@@ -38,7 +38,7 @@ describe HetsInstance do
       let(:hets_instance) { create_local_hets_instance }
 
       before do
-        stub_request(:get, "http://localhost:8000/version").
+        stub_request(:get, %r{http://localhost:8\d{3}/version}).
           to_return(status: 500, body: "", headers: {})
         hets_instance
       end
@@ -51,7 +51,7 @@ describe HetsInstance do
 
     context 'and there is an acceptable hets instance' do
       before do
-        stub_request(:get, "http://localhost:8000/version").
+        stub_request(:get, %r{http://localhost:8\d{3}/version}).
           to_return(status: 200,
                     body: "v#{general_version}, #{specific_version}",
                     headers: {})
@@ -377,7 +377,7 @@ describe HetsInstance do
   context 'when creating a hets instance' do
     context 'and it has a reachable uri' do
       before do
-        stub_request(:get, "http://localhost:8000/version").
+        stub_request(:get, %r{http://localhost:8\d{3}/version}).
           to_return(status: 200,
                     body: "v#{general_version}, #{specific_version}",
                     headers: {})
@@ -403,7 +403,7 @@ describe HetsInstance do
 
     context 'and it has a non-reachable uri' do
       before do
-        stub_request(:get, "http://localhost:8000/version").
+        stub_request(:get, %r{http://localhost:8\d{3}/version}).
           to_return(status: 500, body: "", headers: {})
       end
 

--- a/spec/models/hets_instance_spec.rb
+++ b/spec/models/hets_instance_spec.rb
@@ -62,6 +62,265 @@ describe HetsInstance do
         expect(HetsInstance.choose!).to eq(hets_instance)
       end
     end
+
+    context 'load balancing' do
+      before do
+        stub_request(:get, %r{http://localhost:8\d{3}/version}).
+          to_return({status: 200,
+                     body: "v#{general_version}, #{specific_version}",
+                     headers: {}})
+      end
+
+      context 'free, force-free and busy are available' do
+        let!(:free) { create :hets_instance, state: 'free' }
+        let!(:force_free) { create :hets_instance, state: 'force-free' }
+        let!(:busy) { create :hets_instance, state: 'busy' }
+
+        it 'choose! chose the free instance' do
+          expect(HetsInstance.choose!.uri).to eq(free.uri)
+        end
+
+        it 'with_instance! returns the result of its block' do
+          expect(HetsInstance.with_instance! { |_i| :result }).to be(:result)
+        end
+
+        it 'with_instance! chose the free instance' do
+          chosen = nil
+          HetsInstance.with_instance! { |instance| chosen = instance }
+          expect(chosen.uri).to eq(free.uri)
+        end
+
+        it 'choose! marks it as busy' do
+          instance = HetsInstance.choose!
+          expect(instance.state).to eq('busy')
+        end
+
+        it 'choose! does not increase the queue size' do
+          instance = HetsInstance.choose!
+          expect(instance.queue_size).to eq(0)
+        end
+
+        it 'with_instance! does not increase the queue size during the work' do
+          HetsInstance.with_instance! do |instance|
+            expect(instance.queue_size).to eq(0)
+          end
+        end
+
+        it 'with_instance! does not increase the queue size after the work' do
+          chosen = nil
+          HetsInstance.with_instance! { |instance| chosen = instance }
+          expect(chosen.queue_size).to eq(0)
+        end
+
+        it 'finish_work! marks it as free' do
+          instance = HetsInstance.choose!
+          instance.finish_work!
+          expect(instance.state).to eq('free')
+        end
+
+        it 'finish_work! does not decrease the queue size' do
+          instance = HetsInstance.choose!
+          instance.finish_work!
+          expect(instance.queue_size).to eq(0)
+        end
+
+        it 'with_instance! marks it as busy during the work' do
+          HetsInstance.with_instance! do |instance|
+            expect(instance.state).to eq('busy')
+          end
+        end
+
+        it 'with_instance! marks it as free after the work' do
+          chosen = nil
+          HetsInstance.with_instance! { |instance| chosen = instance }
+          expect(chosen.state).to eq('free')
+        end
+      end
+
+      context 'force-free and busy are available' do
+        let!(:force_free0) { create :hets_instance, state: 'force-free', queue_size: 0 }
+        let!(:force_free1) { create :hets_instance, state: 'force-free', queue_size: 1 }
+        let!(:busy) { create :hets_instance, state: 'busy' }
+
+        it 'choose! chose the force-free instance with queue size 0' do
+          expect(HetsInstance.choose!.uri).to eq(force_free0.uri)
+        end
+
+        it 'with_instance! chose the force-free instance with queue size 0' do
+          chosen = nil
+          HetsInstance.with_instance! { |instance| chosen = instance }
+          expect(chosen.uri).to eq(force_free0.uri)
+        end
+
+        it 'choose! marks it as busy' do
+          instance = HetsInstance.choose!
+          expect(instance.state).to eq('busy')
+        end
+
+        it 'choose! increases the queue size' do
+          instance = HetsInstance.choose!
+          expect(instance.queue_size).to eq(1)
+        end
+
+        it 'with_instance! increases the queue size during the work' do
+          HetsInstance.with_instance! do |instance|
+            expect(instance.queue_size).to eq(1)
+          end
+        end
+
+        it 'with_instance! does not increase the queue size after the work' do
+          chosen = nil
+          HetsInstance.with_instance! { |instance| chosen = instance }
+          expect(chosen.queue_size).to eq(0)
+        end
+
+        it 'finish_work! marks it as free' do
+          instance = HetsInstance.choose!
+          instance.finish_work!
+          expect(instance.state).to eq('free')
+        end
+
+        it 'finish_work! decreases the queue size' do
+          instance = HetsInstance.choose!
+          instance.finish_work!
+          expect(instance.queue_size).to eq(0)
+        end
+
+        it 'with_instance! marks it as busy during the work' do
+          HetsInstance.with_instance! do |instance|
+            expect(instance.state).to eq('busy')
+          end
+        end
+
+        it 'with_instance! marks it as free after the work' do
+          chosen = nil
+          HetsInstance.with_instance! { |instance| chosen = instance }
+          expect(chosen.state).to eq('free')
+        end
+      end
+
+      context 'only busy are available' do
+        let!(:busy0) { create :hets_instance, state: 'busy', queue_size: 0 }
+        let!(:busy1) { create :hets_instance, state: 'busy', queue_size: 1 }
+
+        it 'choose! chose the busy instance with queue size 0' do
+          expect(HetsInstance.choose!.uri).to eq(busy0.uri)
+        end
+
+        it 'with_instance! chose the busy instance with queue size 0' do
+          chosen = nil
+          HetsInstance.with_instance! { |instance| chosen = instance }
+          expect(chosen.uri).to eq(busy0.uri)
+        end
+
+        it 'choose! marks it as busy' do
+          instance = HetsInstance.choose!
+          expect(instance.state).to eq('busy')
+        end
+
+        it 'choose! increases the queue size' do
+          instance = HetsInstance.choose!
+          expect(instance.queue_size).to eq(1)
+        end
+
+        it 'with_instance! increases the queue size during the work' do
+          HetsInstance.with_instance! do |instance|
+            expect(instance.queue_size).to eq(1)
+          end
+        end
+
+        it 'with_instance! does not increase the queue size after the work' do
+          chosen = nil
+          HetsInstance.with_instance! { |instance| chosen = instance }
+          expect(chosen.queue_size).to eq(0)
+        end
+
+        it 'finish_work! marks it as free' do
+          instance = HetsInstance.choose!
+          instance.finish_work!
+          expect(instance.state).to eq('free')
+        end
+
+        it 'finish_work! decreases the queue size' do
+          instance = HetsInstance.choose!
+          instance.finish_work!
+          expect(instance.queue_size).to eq(0)
+        end
+
+        it 'with_instance! marks it as busy during the work' do
+          HetsInstance.with_instance! do |instance|
+            expect(instance.state).to eq('busy')
+          end
+        end
+
+        it 'with_instance! marks it as free after the work' do
+          chosen = nil
+          HetsInstance.with_instance! { |instance| chosen = instance }
+          expect(chosen.state).to eq('free')
+        end
+      end
+
+      context 'only very busy are available' do
+        let!(:busy0) { create :hets_instance, state: 'busy', queue_size: 1 }
+        let!(:busy1) { create :hets_instance, state: 'busy', queue_size: 2 }
+
+        it 'choose! chose the busy instance with queue size 0' do
+          expect(HetsInstance.choose!.uri).to eq(busy0.uri)
+        end
+
+        it 'with_instance! chose the busy instance with queue size 0' do
+          chosen = nil
+          HetsInstance.with_instance! { |instance| chosen = instance }
+          expect(chosen.uri).to eq(busy0.uri)
+        end
+
+        it 'choose! marks it as busy' do
+          instance = HetsInstance.choose!
+          expect(instance.state).to eq('busy')
+        end
+
+        it 'choose! increases the queue size' do
+          instance = HetsInstance.choose!
+          expect(instance.queue_size).to eq(2)
+        end
+
+        it 'with_instance! increases the queue size during the work' do
+          HetsInstance.with_instance! do |instance|
+            expect(instance.queue_size).to eq(2)
+          end
+        end
+
+        it 'with_instance! does not increase the queue size after the work' do
+          chosen = nil
+          HetsInstance.with_instance! { |instance| chosen = instance }
+          expect(chosen.queue_size).to eq(1)
+        end
+
+        it 'finish_work! still marks it as busy' do
+          instance = HetsInstance.choose!
+          instance.finish_work!
+          expect(instance.state).to eq('busy')
+        end
+
+        it 'finish_work! decreases the queue size' do
+          instance = HetsInstance.choose!
+          instance.finish_work!
+          expect(instance.queue_size).to eq(1)
+        end
+
+        it 'with_instance! marks it as busy during the work' do
+          HetsInstance.with_instance! do |instance|
+            expect(instance.state).to eq('busy')
+          end
+        end
+
+        it 'with_instance! still marks it as free after the work' do
+          chosen = nil
+          HetsInstance.with_instance! { |instance| chosen = instance }
+          expect(chosen.state).to eq('busy')
+        end
+      end
+    end
   end
 
   context 'when creating a hets instance' do

--- a/spec/models/ontology_version_spec.rb
+++ b/spec/models/ontology_version_spec.rb
@@ -90,9 +90,10 @@ describe OntologyVersion do
       end
 
       it 'have sent a request with url-catalog' do
+        hets_instance = HetsInstance.choose!
         expect(WebMock).
           to have_requested(:get,
-            /http:\/\/localhost:8000\/dg\/.*\?.*url-catalog=#{url_maps.join(',')}.*/)
+            /#{hets_instance.uri}\/dg\/.*\?.*url-catalog=#{url_maps.join(',')}.*/)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,10 @@ def generate_cassette_name
   "specs/#{current_file_path}/#{current_full_description}"
 end
 
+def stub_hets_instance_force_free_worker
+  allow(HetsInstanceForceFreeWorker).to receive(:perform_in)
+end
+
 # Recording HTTP Requests
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/fixtures/vcr'
@@ -98,6 +102,8 @@ RSpec.configure do |config|
       example.metadata[:example_group][:full_description]
     config.current_description = example.description
     config.current_file_path = example.file_path
+
+    stub_hets_instance_force_free_worker
   end
 
   config.after(:each) do


### PR DESCRIPTION
This shall fix #1445.

This also adds a new rake task `hets: recreate_hets_instances` to create the `HetsIntance`s from the configuration in the database.

To check if really multiple Hets instances are used, I suggest to prove all theorems of an ontology (e.g. v__T) and prove it with several provers. Then, check the `state_updated_at` attributes of the `HetsInstance`s.