### PR TITLE
Fix proving timeout

### DIFF
--- a/app/fake_records/proof.rb
+++ b/app/fake_records/proof.rb
@@ -22,10 +22,7 @@ class Proof < FakeRecord
     end
   end
 
-  TIMEOUT_RANGE = [5.seconds, 10.seconds, 30.seconds,
-                   1.minutes, 5.minutes, 10.minutes, 30.minutes,
-                   1.hours, 6.hours,
-                   1.days, 2.days, 7.days]
+  TIMEOUT_RANGE = [5.seconds, 10.seconds, 15.seconds, 30.seconds, 45.seconds]
 
   # flags
   attr_reader :prove_asynchronously

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -163,7 +163,7 @@ en:
         select_none: Select none
       timeout:
         label: Timeout
-        hint: The timeout will be split evenly across the proof obligations.
+        hint: The timeout will be used for each proof obligation individually.
         default: Default (10 seconds)
         day: day
         hour: hour


### PR DESCRIPTION
This fixes two little issues:

1. Hets closes the connection after 60 seconds. We shouldn't allow timeouts this long. This is supposed to be reverted as soon as we can have an open connection for as long as the job takes.
2. Since the proving pipeline refactoring the timeout is no longer split across the proof obligations. The hint needed to be adjusted accordingly.