### PR TITLE
1450 ontohub slow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ gem 'rails', '~> 3.2.22'
 gem 'rack-protection', '~> 1.5.3'
 gem 'secure_headers', '~> 2.2.3'
 
+gem 'rack-mini-profiler', require: false
+
 gem 'pry-rails', '~> 0.3.2'
 
 gem 'pg', '~> 0.18.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,6 +344,8 @@ GEM
     rack (1.4.7)
     rack-cache (1.2)
       rack (>= 0.4)
+    rack-mini-profiler (0.9.7)
+      rack (>= 1.1.3)
     rack-protection (1.5.3)
       rack
     rack-ssl (1.3.4)
@@ -591,6 +593,7 @@ DEPENDENCIES
   pry-rails (~> 0.3.2)
   puma
   quiet_assets (~> 1.1.0)
+  rack-mini-profiler
   rack-protection (~> 1.5.3)
   rails (~> 3.2.22)
   rails-erd (~> 1.4.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,11 @@
 class ApplicationController < ActionController::Base
 
+  before_filter do
+    if current_user && current_user.is_admin?
+      Rack::MiniProfiler.authorize_request
+    end
+  end
+
   protect_from_forgery
   ensure_security_headers
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
 
   before_filter do
-    if current_user && current_user.is_admin?
+    if current_user && current_user.admin
       Rack::MiniProfiler.authorize_request
     end
   end

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,0 +1,6 @@
+if ['development', 'production'].include?(Rails.env)
+  require 'rack-mini-profiler'
+
+  # initialization is skipped so trigger it
+  Rack::MiniProfilerRails.initialize!(Rails.application)
+end

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,4 +1,4 @@
-if ['development', 'production'].include?(Rails.env)
+if ['development', 'production', 'test'].include?(Rails.env)
   require 'rack-mini-profiler'
 
   # initialization is skipped so trigger it


### PR DESCRIPTION
This should introduce the rack-mini-profiler gem in development and production
In Production-Mode only an admin can see the miniprofiler and in development it is for every transaction.
this should help to find the weak points in ontohub to make it faster