### PR TITLE
Add flash message to announce test ontohub org.

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,6 +17,11 @@
       .container
         .row.flash-messages
           = flash_messages
+        .row.flash-messages
+          .alert.alert-info
+            Do you want to test Ontohub? Visit
+            = link_to 'test.ontohub.org', 'http://test.ontohub.org'
+            for more information
         .row
           - if cover_visible?
             = render partial: '/shared/cover'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -19,7 +19,7 @@
           = flash_messages
         .row.flash-messages
           .alert.alert-info
-            Do you want to test Ontohub? Visit
+            Do you want to support the development of Ontohub by testing? Visit
             = link_to 'test.ontohub.org', 'http://test.ontohub.org'
             for more information
         .row


### PR DESCRIPTION
This first part should fix #1477 partially.

It adds a flash message on ontohub.org which leads to test.ontohub.org.
On test.ontohub.org is another flash message, which is in another PR because the two flash messages need to be pushed on different maschines (ontohub.org and test.ontohub.org)

You can find the wiki entry [here](http://wiki.ontohub.org/index.php/How_to_test_Ontohub)