### PR TITLE
1477 announcement on test ontohub org

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,6 +17,11 @@
       .container
         .row.flash-messages
           = flash_messages
+        .row.flash-messages
+          .alert.alert-info
+            Do you want to test Ontohub? Visit the
+            = link_to 'Ontohub Wiki', 'http://wiki.ontohub.org/index.php/How_to_test_Ontohub'
+            for more information
         .row
           - if cover_visible?
             = render partial: '/shared/cover'


### PR DESCRIPTION
This second and last part should fix #1477.

In #1488 is a flash message which leads to test.ontohub.org. This one is on test.ontohub.org.
This flash message should only be pushed to test.ontohub.org, it leads to the [wiki entry](http://wiki.ontohub.org/index.php/How_to_test_Ontohub)