### PR TITLE
Delete categories from view in search response.

### DIFF
--- a/app/views/shared/_ontology_search_response.html.haml
+++ b/app/views/shared/_ontology_search_response.html.haml
@@ -6,6 +6,3 @@
         = response.file_extension
       .repository= fancy_link(response.repository)
       .content= response.description if response.description.present?
-      .categories
-        - response.categories.each do |category|
-          = link_to category, category

--- a/features/OntologySearch.feature
+++ b/features/OntologySearch.feature
@@ -120,3 +120,8 @@ Scenario: I want to search for a not existing ontology in a repository
   And I should not see ontologies from other repositories
   When I type in a ontology name I'm searching for which is not existing
   Then I should not see the ontology
+
+Scenario: I want to search for a ontology with a category
+  Given there is an ontology with a category
+  When I open the ontologies overview page
+  Then I should see all ontologies with a category

--- a/features/step_definitions/ontology_search_steps.rb
+++ b/features/step_definitions/ontology_search_steps.rb
@@ -207,3 +207,13 @@ Then(/^I should not see the ontology$/) do
     page.should_not have_content('OntologyThree')
   end
 end
+
+Given(/^there is an ontology with a category$/) do
+  @ont_with_cat = FactoryGirl.create :ontology
+  @cat = FactoryGirl.create :category
+  @ont_with_cat.categories << @cat
+end
+
+Then(/^I should see all ontologies with a category$/) do
+  page.should have_content(@ont_with_cat.name)
+end


### PR DESCRIPTION
We missed something in #1513. The search is broken if there's an ontology with a category.