### PR TITLE
1523 hetsinstanceworkers perform too often

### DIFF
--- a/app/models/hets_instance.rb
+++ b/app/models/hets_instance.rb
@@ -95,6 +95,7 @@ has a minimal Hets version of #{Hets.minimal_version_string}
 
   def finish_work!
     reload
+    Sidekiq::Status.unschedule(@force_free_job_id)
     self.queue_size -= 1 if queue_size > 0
     if queue_size > 0
       set_busy!
@@ -118,7 +119,8 @@ has a minimal Hets version of #{Hets.minimal_version_string}
 
   def set_busy!
     self.state = 'busy'
-    HetsInstanceForceFreeWorker.perform_in(FORCE_FREE_WAITING_PERIOD, id)
+    @force_free_job_id =
+      HetsInstanceForceFreeWorker.perform_in(FORCE_FREE_WAITING_PERIOD, id)
     save!
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 require 'sidekiq/web' if defined? Sidekiq
+require 'sidekiq-status/web' if defined? Sidekiq::Status
 require Rails.root.join('lib', 'router_constraints.rb')
 
 Specroutes.define(Ontohub::Application.routes) do


### PR DESCRIPTION
This shall fix #1523. Unfortunately, it is not possible to test Sidekiq's **scheduling**.

It seems to work though:
1. Run the seeds
2. Open the http://localhost:3000/admin/sidekiq/scheduled in one tab and http://ontohub.dev/default/partial_order//v__T//antisymmetric///proof_attempts in another tab
3. Create a ProofAttempt for `antisymmetric`.
4. As soon as the proof is finished, check back at the sidekiq/scheduled tab. There should be no additional scheduled jobs.