### PR TITLE
Reduce scheduled timeout workers

### DIFF
--- a/lib/ontology_batch_parse_worker.rb
+++ b/lib/ontology_batch_parse_worker.rb
@@ -22,7 +22,7 @@ class OntologyBatchParseWorker < BaseWorker
     return if versions.empty?
 
     version_id, opts = versions.head
-    TimeoutWorker.start_timeout_clock(version_id)
+    timeout_job_id = TimeoutWorker.start_timeout_clock(version_id)
 
     version = OntologyVersion.find(version_id)
 
@@ -31,6 +31,7 @@ class OntologyBatchParseWorker < BaseWorker
     end
 
     version.parse
+    Sidekiq::Status.unschedule(timeout_job_id)
   rescue ConcurrencyBalancer::AlreadyProcessingError
     done = handle_concurrency_issue
   ensure

--- a/lib/ontology_batch_parse_worker.rb
+++ b/lib/ontology_batch_parse_worker.rb
@@ -31,10 +31,10 @@ class OntologyBatchParseWorker < BaseWorker
     end
 
     version.parse
-    Sidekiq::Status.unschedule(timeout_job_id)
   rescue ConcurrencyBalancer::AlreadyProcessingError
     done = handle_concurrency_issue
   ensure
+    Sidekiq::Status.unschedule(timeout_job_id) if timeout_job_id
     self.class.perform_async_with_priority(@queue,
       versions.tail, try_count: try_count) unless versions.tail.empty? || done
   end

--- a/lib/timeout_worker.rb
+++ b/lib/timeout_worker.rb
@@ -2,8 +2,6 @@ class TimeoutWorker < BaseWorker
   class Error < ::StandardError; end
   class TimeOutNotSetError < Error; end
 
-  RESCHEDULE_TIME = 30 # minutes
-
   sidekiq_options queue: 'default'
 
   def self.start_timeout_clock(ontology_version_id, hours_offset=nil)

--- a/lib/worker.rb
+++ b/lib/worker.rb
@@ -24,12 +24,13 @@ class Worker < BaseWorker
         timeout_job_id = TimeoutWorker.start_timeout_clock(id)
       end
       klass.unscoped.find(id).send method, *args
-      Sidekiq::Status.unschedule(timeout_job_id) if timeout_job_id
     else
       raise ArgumentError, "unsupported type: #{type}"
     end
   rescue ConcurrencyBalancer::AlreadyProcessingError
     handle_concurrency_issue
+  ensure
+    Sidekiq::Status.unschedule(timeout_job_id) if timeout_job_id
   end
 
   def handle_concurrency_issue


### PR DESCRIPTION
The timeout is only needed to cancel parsing jobs that take longer than
the configured amount of time.
Once the job is done, the TimeoutWorker job can be unscheduled.

This is very similar to #1524 and can't be tested for the same reasons.

This also removes an unused constant.