### PR TITLE
Fix proving HTTP timeout

### DIFF
--- a/lib/hets/prove_caller.rb
+++ b/lib/hets/prove_caller.rb
@@ -23,8 +23,8 @@ module Hets
     end
 
     def timeout
-      timeout = hets_options.options['timeout']
-      30.seconds + 2 * timeout.to_i if timeout
+      # The HTTP timeout must be as long as Hets maximally takes.
+      HetsInstance::FORCE_FREE_WAITING_PERIOD
     end
   end
 end


### PR DESCRIPTION
The timeout for the prover is not the same as for the HTTP session.

The HTTP session can take much longer than the actual proof because Hets analyses the ontology
again for proving.