### PR TITLE
1542 detect timeout message of spass

### DIFF
--- a/lib/hets/prove/prove_evaluation_helper.rb
+++ b/lib/hets/prove/prove_evaluation_helper.rb
@@ -34,7 +34,7 @@ module Hets
 
       def find_proof_status_from_hash(proof_info)
         szs_parser = Hets::Prove::SZSParser.
-          new(proof_info[:prover], proof_info[:prover_output])
+          new(proof_info[:used_prover_identifier], proof_info[:prover_output])
         szs_name = szs_parser.call
         proof_status = ProofStatus.find_by_name(szs_name)
         proof_status ||= default_proof_status(proof_info)

--- a/lib/hets/prove/szs_parser.rb
+++ b/lib/hets/prove/szs_parser.rb
@@ -23,7 +23,12 @@ module Hets
       end
 
       def parse_status_darwin
-        regex_parse_status(/\n\nSZS status (\w+) for/)
+        status = regex_parse_status(/\n\nSZS status (\w+)/)
+        if status == 'Timeout'
+          'ResourceOut'
+        else
+          status
+        end
       end
 
       def parse_status_darwin_non_fd

--- a/lib/hets/prove/szs_parser.rb
+++ b/lib/hets/prove/szs_parser.rb
@@ -34,6 +34,14 @@ module Hets
         regex_parse_status(/\n# SZS status (\w+)/)
       end
 
+      def parse_status_spass
+        if match = generic_parse_status
+          match
+        elsif output.match(/^SPASS beiseite: Ran out of time.$/)
+          'ResourceOut'
+        end
+      end
+
       def regex_parse_status(regex)
         match = output.match(regex)
         match[1] if match

--- a/spec/fixtures/ontologies/prove/prover_output_generator.casl
+++ b/spec/fixtures/ontologies/prove/prover_output_generator.casl
@@ -1,0 +1,70 @@
+spec Group =
+  sort s
+  ops 0:s;
+      -__ :s->s;
+      __+__ :s*s->s, assoc
+  forall x,y:s
+  . x+(-x) = 0
+  . x+0=x %(leftunit)%
+  . 0+x=x %(rightunit)% %implied
+  . 0+0=0 %(zero_plus)% %implied
+end
+
+spec Theorem =
+  sort s
+  ops 0:s
+  forall x,y:s . x = x %implied
+end
+
+spec CounterSatisfiable =
+  sort s
+  ops 0:s;
+      1:s
+  forall x:s . x = 0
+  . not( 1 = 0 ) %implied
+end
+
+
+
+spec Category =
+  sort Bool, Arrow
+  op True : Bool
+
+  op __eEq__ : Arrow * Arrow -> Bool, comm
+  forall f, g : Arrow
+  . f eEq g = True => f eEq f = True
+  . f eEq g = True => f = g
+
+  op __comp__ : Arrow * Arrow -> Arrow, assoc
+  forall f, g : Arrow
+  . (f comp g) eEq (f comp g) = True => f eEq f = True /\ g eEq g = True
+
+  forall f, g, h : Arrow
+  . (f eEq f = True) /\ (g eEq g = True) /\ (h eEq h = True) =>
+    ( (f comp g) eEq (f comp g) = True /\
+      (g comp h) eEq (g comp h) = True => (f comp g comp h) eEq (f comp g comp h) = True )
+end
+
+spec ResourceOut =
+  Category then
+
+  pred CommSquare : Arrow * Arrow * Arrow * Arrow
+  %[ * - f ->  *  ]%
+  %[ g         g' ]%
+  %[ * - f'->  *  ]%
+  forall f, g, f', g' : Arrow
+  . (f eEq f = True) /\ (g eEq g = True) /\ (f' eEq f' = True) /\ (g' eEq g' = True) =>
+    ( CommSquare(f, g, f', g') <=> (f comp g') eEq (g comp f') = True ) %(CommSquareAx)%
+
+then %implies
+  %[Horizontal glueing of commutative squares]%
+
+  %[ * -f -> *  -h -> *   ]%
+  %[ g       g'       g'' ]%
+  %[ * -f'-> *  -h'-> *   ]%
+
+  forall f, g, f', g', h, h', g'' : Arrow
+  . (f eEq f = True) /\ (g eEq g = True) /\ (f' eEq f' = True) /\ (g' eEq g' = True) /\ (h eEq h = True) /\ (h' eEq h' = True) /\ (g'' eEq g'' = True) =>
+    ( CommSquare(f, g, f', g') /\ CommSquare(h, g', h', g'') =>
+      CommSquare(f comp h, g, f' comp h', g'') ) %(CommSquare-horizontal-glueing)% %implied
+end

--- a/spec/fixtures/prover_output/ResourceOut/SPASS
+++ b/spec/fixtures/prover_output/ResourceOut/SPASS
@@ -1,0 +1,375 @@
+
+--------------------------SPASS-START-----------------------------
+Input Problem:
+1[0:Inp] ||  -> arrow(skc15)*.
+2[0:Inp] ||  -> arrow(skc14)*.
+3[0:Inp] ||  -> arrow(skc13)*.
+4[0:Inp] ||  -> arrow(skc12)*.
+5[0:Inp] ||  -> arrow(skc11)*.
+6[0:Inp] ||  -> arrow(skc10)*.
+7[0:Inp] ||  -> arrow(skc9)*.
+8[0:Inp] ||  -> arrow(skc16)*.
+9[0:Inp] ||  -> bool(skc17)*.
+10[0:Inp] ||  -> bool(x_True)*.
+11[0:Inp] ||  -> equal(o__eEq__(skc15,skc15),x_True)**.
+12[0:Inp] ||  -> commSquare(skc15,skc14,skc13,skc12)*.
+13[0:Inp] ||  -> equal(o__eEq__(skc14,skc14),x_True)**.
+14[0:Inp] ||  -> equal(o__eEq__(skc13,skc13),x_True)**.
+15[0:Inp] ||  -> commSquare(skc11,skc12,skc10,skc9)*.
+16[0:Inp] ||  -> equal(o__eEq__(skc12,skc12),x_True)**.
+17[0:Inp] ||  -> equal(o__eEq__(skc11,skc11),x_True)**.
+18[0:Inp] ||  -> equal(o__eEq__(skc10,skc10),x_True)**.
+19[0:Inp] ||  -> equal(o__eEq__(skc9,skc9),x_True)**.
+20[0:Inp] || arrow(U) bool(U)* -> .
+21[0:Inp] || commSquare(U,V,W,X)* -> arrow(U).
+22[0:Inp] || commSquare(U,V,W,X)* -> arrow(V).
+23[0:Inp] || commSquare(U,V,W,X)* -> arrow(W).
+24[0:Inp] || commSquare(U,V,W,X)* -> arrow(X).
+25[0:Inp] || commSquare(o__comp__(skc15,skc11),skc14,o__comp__(skc13,skc10),skc9)* -> .
+26[0:Inp] || arrow(U) arrow(V) -> arrow(o__comp__(U,V))*.
+27[0:Inp] || arrow(U) arrow(V) -> bool(o__eEq__(U,V))*.
+28[0:Inp] || arrow(U) arrow(V) -> equal(o__eEq__(U,V),o__eEq__(V,U))*.
+29[0:Inp] || arrow(U) equal(o__eEq__(U,V),x_True)** arrow(V) -> equal(U,V).
+30[0:Inp] || arrow(U) equal(o__eEq__(U,V),x_True)** arrow(V) -> equal(o__eEq__(U,U),x_True)**.
+31[0:Inp] || arrow(U) arrow(V) arrow(W) -> equal(o__comp__(o__comp__(U,V),W),o__comp__(U,o__comp__(V,W)))**.
+32[0:Inp] || arrow(U) equal(o__eEq__(o__comp__(U,V),o__comp__(U,V)),x_True)** arrow(V) -> equal(o__eEq__(V,V),x_True).
+33[0:Inp] || arrow(U) equal(o__eEq__(o__comp__(U,V),o__comp__(U,V)),x_True)** arrow(V) -> equal(o__eEq__(U,U),x_True).
+34[0:Inp] || equal(o__eEq__(o__comp__(U,V),o__comp__(W,X)),x_True)** arrow(U) equal(o__eEq__(U,U),x_True)** equal(o__eEq__(W,W),x_True)** arrow(W) arrow(X) equal(o__eEq__(X,X),x_True)** equal(o__eEq__(V,V),x_True)** arrow(V) -> commSquare(U,W,X,V).
+35[0:Inp] || commSquare(U,V,W,X) arrow(U) equal(o__eEq__(U,U),x_True)** equal(o__eEq__(V,V),x_True)** arrow(V) arrow(W) equal(o__eEq__(W,W),x_True)** equal(o__eEq__(X,X),x_True)** arrow(X) -> equal(o__eEq__(o__comp__(U,X),o__comp__(V,W)),x_True)**.
+36[0:Inp] || arrow(U) equal(o__eEq__(U,U),x_True) equal(o__eEq__(o__comp__(U,V),o__comp__(U,V)),x_True) equal(o__eEq__(o__comp__(V,W),o__comp__(V,W)),x_True) equal(o__eEq__(V,V),x_True) arrow(V) arrow(W) equal(o__eEq__(W,W),x_True) -> equal(o__eEq__(o__comp__(o__comp__(U,V),W),o__comp__(o__comp__(U,V),W)),x_True)**.
+ This is a first-order Horn problem containing equality.
+ This is a problem that contains sort information.
+ All equations are many sorted.
+ The conjecture is ground.
+ Axiom clauses: 19 Conjecture clauses: 17
+ Inferences: IEmS=1 ISoR=1 IEqR=1 ISpR=1 ISpL=1 IORe=1 
+ Reductions: RFRew=1 RBRew=1 RFMRR=1 RBMRR=1 RObv=1 RUnC=1 RTaut=1 RSST=1 RSSi=1 RFSub=1 RBSub=1 RAED=1 RCon=1 
+ Extras    : Input Saturation, Dynamic Selection, No Splitting, Full Reduction,  Ratio: 5, FuncWeight: 1, VarWeight: 1
+ Precedence: o__eEq__ > o__comp__ > bool > arrow > commSquare > skc17 > skc16 > skc15 > skc14 > skc13 > skc12 > skc11 > skc10 > skc9 > skc8 > skc7 > skc6 > skc5 > skc4 > skc3 > skc2 > skc1 > skc0 > x_True
+ Ordering  : KBO
+Processed Problem:
+
+Worked Off Clauses:
+
+Usable Clauses:
+10[0:Inp] ||  -> bool(x_True)*.
+9[0:Inp] ||  -> bool(skc17)*.
+8[0:Inp] ||  -> arrow(skc16)*.
+7[0:Inp] ||  -> arrow(skc9)*.
+6[0:Inp] ||  -> arrow(skc10)*.
+5[0:Inp] ||  -> arrow(skc11)*.
+4[0:Inp] ||  -> arrow(skc12)*.
+3[0:Inp] ||  -> arrow(skc13)*.
+2[0:Inp] ||  -> arrow(skc14)*.
+1[0:Inp] ||  -> arrow(skc15)*.
+50[0:Res:7.0,20.0] bool(skc9) ||  -> .
+75[0:Res:6.0,20.0] bool(skc10) ||  -> .
+15[0:Inp] ||  -> commSquare(skc11,skc12,skc10,skc9)*.
+12[0:Inp] ||  -> commSquare(skc15,skc14,skc13,skc12)*.
+19[0:Inp] ||  -> equal(o__eEq__(skc9,skc9),x_True)**.
+18[0:Inp] ||  -> equal(o__eEq__(skc10,skc10),x_True)**.
+17[0:Inp] ||  -> equal(o__eEq__(skc11,skc11),x_True)**.
+16[0:Inp] ||  -> equal(o__eEq__(skc12,skc12),x_True)**.
+14[0:Inp] ||  -> equal(o__eEq__(skc13,skc13),x_True)**.
+13[0:Inp] ||  -> equal(o__eEq__(skc14,skc14),x_True)**.
+11[0:Inp] ||  -> equal(o__eEq__(skc15,skc15),x_True)**.
+20[0:Inp] bool(U) arrow(U) ||  -> .
+49[0:Res:7.0,27.0] arrow(U) ||  -> bool(o__eEq__(skc9,U))*.
+74[0:Res:6.0,27.0] arrow(U) ||  -> bool(o__eEq__(skc10,U))*.
+48[0:Res:7.0,26.0] arrow(U) ||  -> arrow(o__comp__(skc9,U))*.
+73[0:Res:6.0,26.0] arrow(U) ||  -> arrow(o__comp__(skc10,U))*.
+64[0:Res:7.0,27.1] arrow(U) ||  -> bool(o__eEq__(U,skc9))*.
+89[0:Res:6.0,27.1] arrow(U) ||  -> bool(o__eEq__(U,skc10))*.
+63[0:Res:7.0,26.1] arrow(U) ||  -> arrow(o__comp__(U,skc9))*.
+88[0:Res:6.0,26.1] arrow(U) ||  -> arrow(o__comp__(U,skc10))*.
+24[0:Inp] || commSquare(U,V,W,X)* -> arrow(X).
+23[0:Inp] || commSquare(U,V,W,X)* -> arrow(W).
+22[0:Inp] || commSquare(U,V,W,X)* -> arrow(V).
+21[0:Inp] || commSquare(U,V,W,X)* -> arrow(U).
+25[0:Inp] || commSquare(o__comp__(skc15,skc11),skc14,o__comp__(skc13,skc10),skc9)* -> .
+27[0:Inp] arrow(U) arrow(V) ||  -> bool(o__eEq__(V,U))*.
+26[0:Inp] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,U))*.
+47[0:Res:7.0,28.0] arrow(U) ||  -> equal(o__eEq__(skc9,U),o__eEq__(U,skc9))*.
+72[0:Res:6.0,28.0] arrow(U) ||  -> equal(o__eEq__(skc10,U),o__eEq__(U,skc10))*.
+46[0:Res:7.0,29.0] arrow(U) || equal(o__eEq__(skc9,U),x_True)** -> equal(skc9,U).
+71[0:Res:6.0,29.0] arrow(U) || equal(o__eEq__(skc10,U),x_True)** -> equal(skc10,U).
+61[0:Res:7.0,29.1] arrow(U) || equal(o__eEq__(U,skc9),x_True)** -> equal(U,skc9).
+86[0:Res:6.0,29.1] arrow(U) || equal(o__eEq__(U,skc10),x_True)** -> equal(U,skc10).
+28[0:Inp] arrow(U) arrow(V) ||  -> equal(o__eEq__(V,U),o__eEq__(U,V))*.
+60[0:Res:7.0,30.1] arrow(U) || equal(o__eEq__(U,skc9),x_True)** -> equal(o__eEq__(U,U),x_True)**.
+85[0:Res:6.0,30.1] arrow(U) || equal(o__eEq__(U,skc10),x_True)** -> equal(o__eEq__(U,U),x_True)**.
+29[0:Inp] arrow(U) arrow(V) || equal(o__eEq__(V,U),x_True)** -> equal(V,U).
+30[0:Inp] arrow(U) arrow(V) || equal(o__eEq__(V,U),x_True)** -> equal(o__eEq__(V,V),x_True)**.
+44[0:Res:7.0,31.0] arrow(U) arrow(V) ||  -> equal(o__comp__(o__comp__(skc9,V),U),o__comp__(skc9,o__comp__(V,U)))**.
+69[0:Res:6.0,31.0] arrow(U) arrow(V) ||  -> equal(o__comp__(o__comp__(skc10,V),U),o__comp__(skc10,o__comp__(V,U)))**.
+59[0:Res:7.0,31.1] arrow(U) arrow(V) ||  -> equal(o__comp__(o__comp__(V,skc9),U),o__comp__(V,o__comp__(skc9,U)))**.
+84[0:Res:6.0,31.1] arrow(U) arrow(V) ||  -> equal(o__comp__(o__comp__(V,skc10),U),o__comp__(V,o__comp__(skc10,U)))**.
+54[0:Res:7.0,31.2] arrow(U) arrow(V) ||  -> equal(o__comp__(o__comp__(V,U),skc9),o__comp__(V,o__comp__(U,skc9)))**.
+79[0:Res:6.0,31.2] arrow(U) arrow(V) ||  -> equal(o__comp__(o__comp__(V,U),skc10),o__comp__(V,o__comp__(U,skc10)))**.
+43[0:Res:7.0,32.0] arrow(U) || equal(o__eEq__(o__comp__(skc9,U),o__comp__(skc9,U)),x_True)** -> equal(o__eEq__(U,U),x_True).
+68[0:Res:6.0,32.0] arrow(U) || equal(o__eEq__(o__comp__(skc10,U),o__comp__(skc10,U)),x_True)** -> equal(o__eEq__(U,U),x_True).
+57[0:Res:7.0,33.1] arrow(U) || equal(o__eEq__(o__comp__(U,skc9),o__comp__(U,skc9)),x_True)** -> equal(o__eEq__(U,U),x_True).
+82[0:Res:6.0,33.1] arrow(U) || equal(o__eEq__(o__comp__(U,skc10),o__comp__(U,skc10)),x_True)** -> equal(o__eEq__(U,U),x_True).
+31[0:Inp] arrow(U) arrow(V) arrow(W) ||  -> equal(o__comp__(o__comp__(W,V),U),o__comp__(W,o__comp__(V,U)))**.
+32[0:Inp] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True)** -> equal(o__eEq__(U,U),x_True).
+33[0:Inp] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True)** -> equal(o__eEq__(V,V),x_True).
+37[0:MRR:35.0,35.1,35.2,35.3,21.1,22.1,23.1,24.1] || equal(o__eEq__(U,U),x_True)** equal(o__eEq__(V,V),x_True)** equal(o__eEq__(W,W),x_True)** equal(o__eEq__(X,X),x_True)** commSquare(X,U,W,V) -> equal(o__eEq__(o__comp__(X,V),o__comp__(U,W)),x_True)**.
+65[0:Res:6.0,39.0] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True) equal(o__eEq__(o__comp__(skc10,V),o__comp__(skc10,V)),x_True) -> equal(o__eEq__(o__comp__(skc10,o__comp__(V,U)),o__comp__(skc10,o__comp__(V,U))),x_True)**.
+40[0:Res:7.0,39.0] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True) equal(o__eEq__(o__comp__(skc9,V),o__comp__(skc9,V)),x_True) -> equal(o__eEq__(o__comp__(skc9,o__comp__(V,U)),o__comp__(skc9,o__comp__(V,U))),x_True)**.
+80[0:Res:6.0,39.1] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,skc10),o__comp__(V,skc10)),x_True) equal(o__eEq__(o__comp__(skc10,U),o__comp__(skc10,U)),x_True) -> equal(o__eEq__(o__comp__(V,o__comp__(skc10,U)),o__comp__(V,o__comp__(skc10,U))),x_True)**.
+55[0:Res:7.0,39.1] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,skc9),o__comp__(V,skc9)),x_True) equal(o__eEq__(o__comp__(skc9,U),o__comp__(skc9,U)),x_True) -> equal(o__eEq__(o__comp__(V,o__comp__(skc9,U)),o__comp__(V,o__comp__(skc9,U))),x_True)**.
+77[0:Res:6.0,39.2] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True) equal(o__eEq__(o__comp__(U,skc10),o__comp__(U,skc10)),x_True) -> equal(o__eEq__(o__comp__(V,o__comp__(U,skc10)),o__comp__(V,o__comp__(U,skc10))),x_True)**.
+52[0:Res:7.0,39.2] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True) equal(o__eEq__(o__comp__(U,skc9),o__comp__(U,skc9)),x_True) -> equal(o__eEq__(o__comp__(V,o__comp__(U,skc9)),o__comp__(V,o__comp__(U,skc9))),x_True)**.
+39[0:Obv:38.7] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(o__comp__(W,V),o__comp__(W,V)),x_True) equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True) -> equal(o__eEq__(o__comp__(W,o__comp__(V,U)),o__comp__(W,o__comp__(V,U))),x_True)**.
+97[0:Obv:96.4] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(W,W),x_True)** equal(o__eEq__(U,U),x_True)** equal(o__eEq__(V,V),x_True)** equal(o__eEq__(o__comp__(skc10,U),o__comp__(W,V)),x_True)** -> commSquare(skc10,W,V,U).
+105[0:Obv:104.4] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(W,W),x_True)** equal(o__eEq__(U,U),x_True)** equal(o__eEq__(V,V),x_True)** equal(o__eEq__(o__comp__(skc9,U),o__comp__(W,V)),x_True)** -> commSquare(skc9,W,V,U).
+91[0:Obv:90.7] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(U,U),x_True)** equal(o__eEq__(V,V),x_True)** equal(o__eEq__(W,W),x_True)** equal(o__eEq__(o__comp__(W,U),o__comp__(skc10,V)),x_True)** -> commSquare(W,skc10,V,U).
+99[0:Obv:98.7] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(U,U),x_True)** equal(o__eEq__(V,V),x_True)** equal(o__eEq__(W,W),x_True)** equal(o__eEq__(o__comp__(W,U),o__comp__(skc9,V)),x_True)** -> commSquare(W,skc9,V,U).
+93[0:Obv:92.5] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(V,V),x_True)** equal(o__eEq__(U,U),x_True)** equal(o__eEq__(W,W),x_True)** equal(o__eEq__(o__comp__(W,U),o__comp__(V,skc10)),x_True)** -> commSquare(W,V,skc10,U).
+101[0:Obv:100.5] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(V,V),x_True)** equal(o__eEq__(U,U),x_True)** equal(o__eEq__(W,W),x_True)** equal(o__eEq__(o__comp__(W,U),o__comp__(V,skc9)),x_True)** -> commSquare(W,V,skc9,U).
+95[0:Obv:94.6] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(V,V),x_True)** equal(o__eEq__(U,U),x_True)** equal(o__eEq__(W,W),x_True)** equal(o__eEq__(o__comp__(W,skc10),o__comp__(V,U)),x_True)** -> commSquare(W,V,U,skc10).
+103[0:Obv:102.6] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(V,V),x_True)** equal(o__eEq__(U,U),x_True)** equal(o__eEq__(W,W),x_True)** equal(o__eEq__(o__comp__(W,skc9),o__comp__(V,U)),x_True)** -> commSquare(W,V,U,skc9).
+34[0:Inp] arrow(U) arrow(V) arrow(W) arrow(X) || equal(o__eEq__(W,W),x_True)** equal(o__eEq__(U,U),x_True)** equal(o__eEq__(V,V),x_True)** equal(o__eEq__(X,X),x_True)** equal(o__eEq__(o__comp__(X,U),o__comp__(W,V)),x_True)** -> commSquare(X,W,V,U).
+	Given clause: 10[0:Inp] ||  -> bool(x_True)*.
+	Given clause: 9[0:Inp] ||  -> bool(skc17)*.
+	Given clause: 8[0:Inp] ||  -> arrow(skc16)*.
+	Given clause: 7[0:Inp] ||  -> arrow(skc9)*.
+	Given clause: 6[0:Inp] ||  -> arrow(skc10)*.
+	Given clause: 5[0:Inp] ||  -> arrow(skc11)*.
+	Given clause: 4[0:Inp] ||  -> arrow(skc12)*.
+	Given clause: 3[0:Inp] ||  -> arrow(skc13)*.
+	Given clause: 2[0:Inp] ||  -> arrow(skc14)*.
+	Given clause: 1[0:Inp] ||  -> arrow(skc15)*.
+	Given clause: 50[0:Res:7.0,20.0] bool(skc9) ||  -> .
+	Given clause: 75[0:Res:6.0,20.0] bool(skc10) ||  -> .
+	Given clause: 15[0:Inp] ||  -> commSquare(skc11,skc12,skc10,skc9)*.
+	Given clause: 12[0:Inp] ||  -> commSquare(skc15,skc14,skc13,skc12)*.
+	Given clause: 19[0:Inp] ||  -> equal(o__eEq__(skc9,skc9),x_True)**.
+	Given clause: 18[0:Inp] ||  -> equal(o__eEq__(skc10,skc10),x_True)**.
+	Given clause: 17[0:Inp] ||  -> equal(o__eEq__(skc11,skc11),x_True)**.
+	Given clause: 16[0:Inp] ||  -> equal(o__eEq__(skc12,skc12),x_True)**.
+	Given clause: 14[0:Inp] ||  -> equal(o__eEq__(skc13,skc13),x_True)**.
+	Given clause: 13[0:Inp] ||  -> equal(o__eEq__(skc14,skc14),x_True)**.
+	Given clause: 11[0:Inp] ||  -> equal(o__eEq__(skc15,skc15),x_True)**.
+	Given clause: 20[0:Inp] bool(U) arrow(U) ||  -> .
+	Given clause: 49[0:Res:7.0,27.0] arrow(U) ||  -> bool(o__eEq__(skc9,U))*.
+	Given clause: 74[0:Res:6.0,27.0] arrow(U) ||  -> bool(o__eEq__(skc10,U))*.
+	Given clause: 24[0:Inp] || commSquare(U,V,W,X)* -> arrow(X).
+	Given clause: 48[0:Res:7.0,26.0] arrow(U) ||  -> arrow(o__comp__(skc9,U))*.
+	Given clause: 73[0:Res:6.0,26.0] arrow(U) ||  -> arrow(o__comp__(skc10,U))*.
+	Given clause: 64[0:Res:7.0,27.1] arrow(U) ||  -> bool(o__eEq__(U,skc9))*.
+	Given clause: 89[0:Res:6.0,27.1] arrow(U) ||  -> bool(o__eEq__(U,skc10))*.
+	Given clause: 23[0:Inp] || commSquare(U,V,W,X)* -> arrow(W).
+	Given clause: 63[0:Res:7.0,26.1] arrow(U) ||  -> arrow(o__comp__(U,skc9))*.
+	Given clause: 88[0:Res:6.0,26.1] arrow(U) ||  -> arrow(o__comp__(U,skc10))*.
+	Given clause: 22[0:Inp] || commSquare(U,V,W,X)* -> arrow(V).
+	Given clause: 21[0:Inp] || commSquare(U,V,W,X)* -> arrow(U).
+	Given clause: 25[0:Inp] || commSquare(o__comp__(skc15,skc11),skc14,o__comp__(skc13,skc10),skc9)* -> .
+	Given clause: 47[0:Res:7.0,28.0] arrow(U) ||  -> equal(o__eEq__(skc9,U),o__eEq__(U,skc9))*.
+	Given clause: 72[0:Res:6.0,28.0] arrow(U) ||  -> equal(o__eEq__(skc10,U),o__eEq__(U,skc10))*.
+	Given clause: 27[0:Inp] arrow(U) arrow(V) ||  -> bool(o__eEq__(V,U))*.
+	Given clause: 26[0:Inp] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,U))*.
+	Given clause: 28[0:Inp] arrow(U) arrow(V) ||  -> equal(o__eEq__(V,U),o__eEq__(U,V))*.
+	Given clause: 46[0:Res:7.0,29.0] arrow(U) || equal(o__eEq__(skc9,U),x_True)** -> equal(skc9,U).
+	Given clause: 71[0:Res:6.0,29.0] arrow(U) || equal(o__eEq__(skc10,U),x_True)** -> equal(skc10,U).
+	Given clause: 61[0:Res:7.0,29.1] arrow(U) || equal(o__eEq__(U,skc9),x_True)** -> equal(U,skc9).
+	Given clause: 86[0:Res:6.0,29.1] arrow(U) || equal(o__eEq__(U,skc10),x_True)** -> equal(U,skc10).
+	Given clause: 29[0:Inp] arrow(U) arrow(V) || equal(o__eEq__(V,U),x_True)** -> equal(V,U).
+	Given clause: 60[0:Res:7.0,30.1] arrow(U) || equal(o__eEq__(U,skc9),x_True)**+ -> equal(o__eEq__(U,U),x_True)**.
+	Given clause: 85[0:Res:6.0,30.1] arrow(U) || equal(o__eEq__(U,skc10),x_True)**+ -> equal(o__eEq__(U,U),x_True)**.
+	Given clause: 322[0:Obv:318.0] arrow(U) || equal(o__eEq__(skc9,U),x_True)**+ -> equal(o__eEq__(U,U),x_True)**.
+	Given clause: 331[0:Obv:327.0] arrow(U) || equal(o__eEq__(skc10,U),x_True)**+ -> equal(o__eEq__(U,U),x_True)**.
+	Given clause: 30[0:Inp] arrow(U) arrow(V) || equal(o__eEq__(V,U),x_True)**+ -> equal(o__eEq__(V,V),x_True)**.
+	Given clause: 44[0:Res:7.0,31.0] arrow(U) arrow(V) ||  -> equal(o__comp__(o__comp__(skc9,V),U),o__comp__(skc9,o__comp__(V,U)))**.
+	Given clause: 383[0:SSi:381.2,381.0,48.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(U,skc9)))*.
+	Given clause: 384[0:SSi:382.2,382.0,48.0,6.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(U,skc10)))*.
+	Given clause: 388[0:SSi:387.2,387.0,48.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(U,skc9))))*.
+	Given clause: 31[0:Inp] arrow(U) arrow(V) arrow(W) ||  -> equal(o__comp__(o__comp__(W,V),U),o__comp__(W,o__comp__(V,U)))**.
+	Given clause: 390[0:SSi:389.2,389.0,48.0,6.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(U,skc10))))*.
+	Given clause: 386[0:SSi:385.2,48.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(U,V)))*.
+	Given clause: 403[0:SSi:399.3,399.0,26.0,6.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,o__comp__(U,skc10)))*.
+	Given clause: 404[0:SSi:396.3,396.0,26.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,o__comp__(U,skc9)))*.
+	Given clause: 32[0:Inp] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True)** -> equal(o__eEq__(U,U),x_True).
+	Given clause: 392[0:SSi:391.2,391.0,48.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(U,skc9)))))*.
+	Given clause: 416[0:SSi:414.2,414.0,48.0,6.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(U,skc10)))))*.
+	Given clause: 405[0:SSi:400.3,400.0,26.0,6.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(V,o__comp__(U,skc10))))*.
+	Given clause: 406[0:SSi:397.3,397.0,26.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(V,o__comp__(U,skc9))))*.
+	Given clause: 33[0:Inp] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True)** -> equal(o__eEq__(V,V),x_True).
+	Given clause: 421[0:SSi:420.1,48.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(U,V))))*.
+	Given clause: 428[0:SSi:424.2,424.0,48.0,6.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,o__comp__(skc9,o__comp__(U,skc10))))*.
+	Given clause: 434[0:SSi:430.2,430.0,48.0,7.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,o__comp__(skc9,o__comp__(U,skc9))))*.
+	Given clause: 452[0:SSi:450.2,450.0,48.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(U,skc9))))))*.
+	Given clause: 37[0:MRR:35.0,35.1,35.2,35.3,21.1,22.1,23.1,24.1] || equal(o__eEq__(U,U),x_True)**+ equal(o__eEq__(V,V),x_True)** equal(o__eEq__(W,W),x_True)** equal(o__eEq__(X,X),x_True)** commSquare(X,U,W,V) -> equal(o__eEq__(o__comp__(X,V),o__comp__(U,W)),x_True)**.
+	Given clause: 456[0:SSi:454.2,454.0,48.0,6.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(U,skc10))))))*.
+	Given clause: 408[0:SSi:407.3,26.2] arrow(U) arrow(V) arrow(W) ||  -> arrow(o__comp__(V,o__comp__(U,W)))*.
+	Given clause: 409[0:SSi:398.3,398.0,26.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(V,o__comp__(U,skc9)))))*.
+	Given clause: 417[0:SSi:415.3,415.0,26.0,6.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(V,o__comp__(U,skc10)))))*.
+	Given clause: 39[0:Obv:38.7] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(o__comp__(W,V),o__comp__(W,V)),x_True) equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True) -> equal(o__eEq__(o__comp__(W,o__comp__(V,U)),o__comp__(W,o__comp__(V,U))),x_True)**.
+	Given clause: 462[0:SSi:458.2,458.0,48.0,6.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(V,o__comp__(skc9,o__comp__(U,skc10)))))*.
+	Given clause: 468[0:SSi:464.2,464.0,48.0,7.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(V,o__comp__(skc9,o__comp__(U,skc9)))))*.
+	Given clause: 487[0:SSi:486.1,48.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(U,V)))))*.
+	Given clause: 494[0:SSi:490.2,490.0,48.0,6.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,o__comp__(skc9,o__comp__(skc9,o__comp__(U,skc10)))))*.
+	Given clause: 34[0:Inp] arrow(U) arrow(V) arrow(W) arrow(X) || equal(o__eEq__(W,W),x_True)** equal(o__eEq__(U,U),x_True)** equal(o__eEq__(V,V),x_True)** equal(o__eEq__(X,X),x_True)** equal(o__eEq__(o__comp__(X,U),o__comp__(W,V)),x_True)**+ -> commSquare(X,W,V,U).
+	Given clause: 500[0:SSi:496.2,496.0,48.0,7.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,o__comp__(skc9,o__comp__(skc9,o__comp__(U,skc9)))))*.
+	Given clause: 504[0:SSi:502.2,502.0,48.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(U,skc9)))))))*.
+	Given clause: 530[0:SSi:528.2,528.0,48.0,6.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(U,skc10)))))))*.
+	Given clause: 69[0:Res:6.0,31.0] arrow(U) arrow(V) ||  -> equal(o__comp__(o__comp__(skc10,V),U),o__comp__(skc10,o__comp__(V,U)))**.
+	Given clause: 59[0:Res:7.0,31.1] arrow(U) arrow(V) ||  -> equal(o__comp__(o__comp__(V,skc9),U),o__comp__(V,o__comp__(skc9,U)))**.
+	Given clause: 700[0:SSi:653.2,653.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(U,skc9)))*.
+	Given clause: 794[0:SSi:755.2,755.0,26.0,7.0,6.2] arrow(U) ||  -> arrow(o__comp__(U,o__comp__(skc9,skc10)))*.
+	Given clause: 701[0:SSi:654.2,654.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(U,skc9))))*.
+	Given clause: 795[0:SSi:756.2,756.0,26.0,7.0,6.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(U,o__comp__(skc9,skc10))))*.
+	Given clause: 84[0:Res:6.0,31.1] arrow(U) arrow(V) ||  -> equal(o__comp__(o__comp__(V,skc10),U),o__comp__(V,o__comp__(skc10,U)))**.
+	Given clause: 919[0:SSi:862.2,862.0,26.0,6.0,7.2] arrow(U) ||  -> arrow(o__comp__(U,o__comp__(skc10,skc9)))*.
+	Given clause: 836[0:SSi:832.2,832.0,48.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(U,skc9))))*.
+	Given clause: 837[0:SSi:834.2,834.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(U,skc9))))*.
+	Given clause: 838[0:SSi:835.2,835.0,26.0,7.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(U,o__comp__(skc9,skc9))))*.
+	Given clause: 54[0:Res:7.0,31.2] arrow(U) arrow(V) ||  -> equal(o__comp__(o__comp__(V,U),skc9),o__comp__(V,o__comp__(U,skc9)))**.
+	Given clause: 920[0:SSi:863.2,863.0,26.0,6.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(U,o__comp__(skc10,skc9))))*.
+	Given clause: 921[0:SSi:874.2,874.0,26.0,6.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(U,o__comp__(skc10,skc9))))*.
+	Given clause: 703[0:SSi:702.2,73.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(U,V)))*.
+	Given clause: 797[0:SSi:796.2,26.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(U,o__comp__(skc9,V)))*.
+	Given clause: 79[0:Res:6.0,31.2] arrow(U) arrow(V) ||  -> equal(o__comp__(o__comp__(V,U),skc10),o__comp__(V,o__comp__(U,skc10)))**.
+	Given clause: 923[0:SSi:922.2,26.0,6.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(U,o__comp__(skc10,V)))*.
+	Given clause: 704[0:SSi:655.2,655.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc10,o__comp__(U,skc9)))))*.
+	Given clause: 798[0:SSi:757.2,757.0,26.0,7.0,6.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(U,o__comp__(skc9,skc10)))))*.
+	Given clause: 848[0:SSi:847.2,847.0,26.0,7.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(U,o__comp__(skc9,skc9)))))*.
+	Given clause: 377[0:Obv:365.1] arrow(U) arrow(V) || equal(o__eEq__(U,V),x_True)**+ -> equal(o__eEq__(V,V),x_True)**.
+	Given clause: 849[0:SSi:846.2,846.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(skc10,o__comp__(U,skc9)))))*.
+	Given clause: 850[0:SSi:844.2,844.0,48.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(skc9,o__comp__(U,skc9)))))*.
+	Given clause: 924[0:SSi:875.2,875.0,26.0,6.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(U,o__comp__(skc10,skc9)))))*.
+	Given clause: 925[0:SSi:864.2,864.0,26.0,6.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(U,o__comp__(skc10,skc9)))))*.
+	Given clause: 43[0:Res:7.0,32.0] arrow(U) || equal(o__eEq__(o__comp__(skc9,U),o__comp__(skc9,U)),x_True)** -> equal(o__eEq__(U,U),x_True).
+	Given clause: 970[0:SSi:969.2,969.0,26.0,6.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(U,o__comp__(skc10,skc9)))))*.
+	Given clause: 971[0:SSi:968.2,968.0,26.0,7.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(U,o__comp__(skc9,skc9)))))*.
+	Given clause: 972[0:SSi:967.2,967.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(skc10,o__comp__(U,skc9)))))*.
+	Given clause: 973[0:SSi:965.2,965.0,48.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(skc9,o__comp__(U,skc9)))))*.
+	Given clause: 68[0:Res:6.0,32.0] arrow(U) || equal(o__eEq__(o__comp__(skc10,U),o__comp__(skc10,U)),x_True)** -> equal(o__eEq__(U,U),x_True).
+	Given clause: 980[0:SSi:979.2,979.0,26.0,6.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(U,o__comp__(skc10,skc9)))))*.
+	Given clause: 981[0:SSi:978.2,978.0,26.0,7.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(U,o__comp__(skc9,skc9)))))*.
+	Given clause: 982[0:SSi:977.2,977.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(skc10,o__comp__(U,skc9)))))*.
+	Given clause: 983[0:SSi:975.2,975.0,48.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(skc9,o__comp__(U,skc9)))))*.
+	Given clause: 57[0:Res:7.0,33.1] arrow(U) || equal(o__eEq__(o__comp__(U,skc9),o__comp__(U,skc9)),x_True)** -> equal(o__eEq__(U,U),x_True).
+	Given clause: 990[0:SSi:989.2,989.0,26.0,6.1,48.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(U,o__comp__(skc10,o__comp__(skc9,skc9)))))*.
+	Given clause: 991[0:SSi:988.2,988.0,26.0,7.1,48.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(U,o__comp__(skc9,o__comp__(skc9,skc9)))))*.
+	Given clause: 1055[0:SSi:1054.2,1054.0,26.0,6.1,73.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(U,o__comp__(skc10,o__comp__(skc10,skc9)))))*.
+	Given clause: 1056[0:SSi:1053.2,1053.0,26.0,7.1,73.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(U,o__comp__(skc9,o__comp__(skc10,skc9)))))*.
+	Given clause: 82[0:Res:6.0,33.1] arrow(U) || equal(o__eEq__(o__comp__(U,skc10),o__comp__(U,skc10)),x_True)** -> equal(o__eEq__(U,U),x_True).
+	Given clause: 706[0:SSi:705.1,73.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(U,V))))*.
+	Given clause: 707[0:SSi:662.2,662.0,73.0,7.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,o__comp__(skc10,o__comp__(U,skc9))))*.
+	Given clause: 800[0:SSi:799.1,26.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(U,o__comp__(skc9,V))))*.
+	Given clause: 801[0:SSi:764.2,764.0,26.0,7.0,6.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,o__comp__(U,o__comp__(skc9,skc10))))*.
+	Given clause: 413[0:SSi:412.4,26.2] arrow(U) arrow(V) arrow(W) arrow(X) ||  -> equal(o__comp__(o__comp__(V,o__comp__(U,X)),W),o__comp__(o__comp__(V,U),o__comp__(X,W)))**.
+	Given clause: 839[0:SSi:833.3,833.0,26.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(V,o__comp__(U,skc9))))*.
+	Given clause: 927[0:SSi:926.1,26.0,6.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(U,o__comp__(skc10,V))))*.
+	Given clause: 928[0:SSi:871.2,871.0,26.0,6.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,o__comp__(U,o__comp__(skc10,skc9))))*.
+	Given clause: 1065[0:SSi:1064.1,26.0,6.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(U,o__comp__(skc10,V))))*.
+	Given clause: 1623[0:Rew:1622.4,413.4] arrow(U) arrow(V) arrow(W) arrow(X) ||  -> equal(o__comp__(o__comp__(V,o__comp__(U,X)),W),o__comp__(V,o__comp__(U,o__comp__(X,W))))**.
+	Given clause: 1067[0:SSi:1066.1,26.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(U,o__comp__(skc9,V))))*.
+	Given clause: 1069[0:SSi:1068.1,73.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(U,V))))*.
+	Given clause: 1071[0:SSi:1070.1,48.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(U,V))))*.
+	Given clause: 708[0:SSi:656.2,656.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(skc10,o__comp__(U,skc9))))))*.
+	Given clause: 448[0:SSi:447.3,26.2] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(o__comp__(V,o__comp__(U,W)),o__comp__(V,o__comp__(U,W))),x_True)** -> equal(o__eEq__(W,W),x_True).
+	Given clause: 802[0:SSi:758.2,758.0,26.0,7.0,6.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(U,o__comp__(skc9,skc10))))))*.
+	Given clause: 929[0:SSi:865.2,865.0,26.0,6.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(U,o__comp__(skc10,skc9))))))*.
+	Given clause: 1143[0:SSi:1140.2,1140.0,26.0,6.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc10,o__comp__(U,o__comp__(skc10,skc9))))))*.
+	Given clause: 1144[0:SSi:1138.2,1138.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc10,o__comp__(skc10,o__comp__(U,skc9))))))*.
+	Given clause: 482[0:SSi:481.3,26.2] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(o__comp__(V,o__comp__(U,W)),o__comp__(V,o__comp__(U,W))),x_True)** -> equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True).
+	Given clause: 1155[0:SSi:1154.2,1154.0,26.0,6.1,48.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(U,o__comp__(skc10,o__comp__(skc9,skc9))))))*.
+	Given clause: 1156[0:SSi:1153.2,1153.0,26.0,7.1,48.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(U,o__comp__(skc9,o__comp__(skc9,skc9))))))*.
+	Given clause: 1157[0:SSi:1152.2,1152.0,73.0,48.1,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(skc10,o__comp__(U,o__comp__(skc9,skc9))))))*.
+	Given clause: 1158[0:SSi:1150.2,1150.0,48.0,48.1,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(skc9,o__comp__(U,o__comp__(skc9,skc9))))))*.
+	Given clause: 519[0:Obv:514.0] || equal(o__eEq__(U,U),x_True)**+ equal(o__eEq__(V,V),x_True)** equal(o__eEq__(W,W),x_True)** commSquare(W,skc15,V,U) -> equal(o__eEq__(o__comp__(W,U),o__comp__(skc15,V)),x_True)**.
+	Given clause: 1195[0:SSi:1192.2,1192.0,26.0,6.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(skc10,o__comp__(U,o__comp__(skc10,skc9))))))*.
+	Given clause: 1196[0:SSi:1190.2,1190.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(skc10,o__comp__(skc10,o__comp__(U,skc9))))))*.
+	Given clause: 1204[0:SSi:1201.2,1201.0,26.0,6.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(skc9,o__comp__(U,o__comp__(skc10,skc9))))))*.
+	Given clause: 1205[0:SSi:1199.2,1199.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(skc9,o__comp__(skc10,o__comp__(U,skc9))))))*.
+	Given clause: 520[0:Obv:513.0] || equal(o__eEq__(U,U),x_True)**+ equal(o__eEq__(V,V),x_True)** equal(o__eEq__(W,W),x_True)** commSquare(W,skc14,V,U) -> equal(o__eEq__(o__comp__(W,U),o__comp__(skc14,V)),x_True)**.
+	Given clause: 1211[0:SSi:1210.2,1210.0,26.0,6.1,73.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(U,o__comp__(skc10,o__comp__(skc10,skc9))))))*.
+	Given clause: 1212[0:SSi:1209.2,1209.0,26.0,7.1,73.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(U,o__comp__(skc9,o__comp__(skc10,skc9))))))*.
+	Given clause: 1229[0:SSi:1228.2,1228.0,26.0,6.1,73.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(U,o__comp__(skc10,o__comp__(skc10,skc9))))))*.
+	Given clause: 1230[0:SSi:1227.2,1227.0,26.0,7.1,73.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(U,o__comp__(skc9,o__comp__(skc10,skc9))))))*.
+	Given clause: 521[0:Obv:512.0] || equal(o__eEq__(U,U),x_True)**+ equal(o__eEq__(V,V),x_True)** equal(o__eEq__(W,W),x_True)** commSquare(W,skc13,V,U) -> equal(o__eEq__(o__comp__(W,U),o__comp__(skc13,V)),x_True)**.
+	Given clause: 1231[0:SSi:1226.2,1226.0,73.0,73.1,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(skc10,o__comp__(U,o__comp__(skc10,skc9))))))*.
+	Given clause: 1232[0:SSi:1224.2,1224.0,48.0,73.1,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(skc9,o__comp__(U,o__comp__(skc10,skc9))))))*.
+	Given clause: 1239[0:SSi:1238.2,1238.0,26.0,6.1,48.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(U,o__comp__(skc10,o__comp__(skc9,skc9))))))*.
+	Given clause: 1240[0:SSi:1237.2,1237.0,26.0,7.1,48.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(U,o__comp__(skc9,o__comp__(skc9,skc9))))))*.
+	Given clause: 522[0:Obv:511.0] || equal(o__eEq__(U,U),x_True)**+ equal(o__eEq__(V,V),x_True)** equal(o__eEq__(W,W),x_True)** commSquare(W,skc12,V,U) -> equal(o__eEq__(o__comp__(W,U),o__comp__(skc12,V)),x_True)**.
+	Given clause: 1241[0:SSi:1236.2,1236.0,73.0,48.1,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(skc10,o__comp__(U,o__comp__(skc9,skc9))))))*.
+	Given clause: 1242[0:SSi:1234.2,1234.0,48.0,48.1,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(skc9,o__comp__(U,o__comp__(skc9,skc9))))))*.
+	Given clause: 1251[0:SSi:1246.2,1246.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(skc10,o__comp__(skc10,o__comp__(U,skc9))))))*.
+	Given clause: 1259[0:SSi:1254.2,1254.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(skc9,o__comp__(skc10,o__comp__(U,skc9))))))*.
+	Given clause: 523[0:Obv:510.0] || equal(o__eEq__(U,U),x_True)**+ equal(o__eEq__(V,V),x_True)** equal(o__eEq__(W,W),x_True)** commSquare(W,skc11,V,U) -> equal(o__eEq__(o__comp__(W,U),o__comp__(skc11,V)),x_True)**.
+	Given clause: 1270[0:SSi:1269.2,1269.0,26.0,6.1,73.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(U,o__comp__(skc10,o__comp__(skc10,skc9))))))*.
+	Given clause: 1271[0:SSi:1268.2,1268.0,26.0,7.1,73.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(U,o__comp__(skc9,o__comp__(skc10,skc9))))))*.
+	Given clause: 1272[0:SSi:1267.2,1267.0,73.0,73.1,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(skc10,o__comp__(U,o__comp__(skc10,skc9))))))*.
+	Given clause: 1273[0:SSi:1265.2,1265.0,48.0,73.1,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(skc9,o__comp__(U,o__comp__(skc10,skc9))))))*.
+	Given clause: 524[0:Obv:508.0] || equal(o__eEq__(U,U),x_True)**+ equal(o__eEq__(V,V),x_True)** equal(o__eEq__(W,W),x_True)** commSquare(W,skc10,V,U) -> equal(o__eEq__(o__comp__(W,U),o__comp__(skc10,V)),x_True)**.
+	Given clause: 1280[0:SSi:1279.2,1279.0,26.0,6.1,48.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(U,o__comp__(skc10,o__comp__(skc9,skc9))))))*.
+	Given clause: 1281[0:SSi:1278.2,1278.0,26.0,7.1,48.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(U,o__comp__(skc9,o__comp__(skc9,skc9))))))*.
+	Given clause: 1282[0:SSi:1277.2,1277.0,73.0,48.1,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(skc10,o__comp__(U,o__comp__(skc9,skc9))))))*.
+	Given clause: 1283[0:SSi:1275.2,1275.0,48.0,48.1,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(skc9,o__comp__(U,o__comp__(skc9,skc9))))))*.
+	Given clause: 525[0:Obv:506.0] || equal(o__eEq__(U,U),x_True)**+ equal(o__eEq__(V,V),x_True)** equal(o__eEq__(W,W),x_True)** commSquare(W,skc9,V,U) -> equal(o__eEq__(o__comp__(W,U),o__comp__(skc9,V)),x_True)**.
+	Given clause: 1292[0:SSi:1287.2,1287.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(skc10,o__comp__(skc10,o__comp__(U,skc9))))))*.
+	Given clause: 1300[0:SSi:1295.2,1295.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(skc9,o__comp__(skc10,o__comp__(U,skc9))))))*.
+	Given clause: 710[0:SSi:709.1,73.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc10,o__comp__(U,V)))))*.
+	Given clause: 711[0:SSi:663.2,663.0,73.0,7.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(V,o__comp__(skc10,o__comp__(U,skc9)))))*.
+	Given clause: 634[0:SSi:633.2,26.2] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(o__comp__(W,V),o__comp__(W,V)),x_True) equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True) -> commSquare(W,W,o__comp__(V,U),o__comp__(V,U))*.
+	Given clause: 712[0:SSi:660.2,660.0,73.0,7.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,o__comp__(skc9,o__comp__(skc10,o__comp__(U,skc9)))))*.
+	Given clause: 804[0:SSi:803.1,26.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(U,o__comp__(skc9,V)))))*.
+	Given clause: 805[0:SSi:765.2,765.0,26.0,7.0,6.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(V,o__comp__(U,o__comp__(skc9,skc10)))))*.
+	Given clause: 806[0:SSi:762.2,762.0,26.0,7.0,6.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,o__comp__(skc9,o__comp__(U,o__comp__(skc9,skc10)))))*.
+	Given clause: 80[0:Res:6.0,39.1] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,skc10),o__comp__(V,skc10)),x_True) equal(o__eEq__(o__comp__(skc10,U),o__comp__(skc10,U)),x_True) -> equal(o__eEq__(o__comp__(V,o__comp__(skc10,U)),o__comp__(V,o__comp__(skc10,U))),x_True)**.
+	Given clause: 851[0:SSi:845.3,845.0,26.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(V,o__comp__(U,skc9)))))*.
+	Given clause: 931[0:SSi:930.1,26.0,6.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(U,o__comp__(skc10,V)))))*.
+	Given clause: 932[0:SSi:872.2,872.0,26.0,6.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(V,o__comp__(U,o__comp__(skc10,skc9)))))*.
+	Given clause: 933[0:SSi:869.2,869.0,26.0,6.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,o__comp__(skc9,o__comp__(U,o__comp__(skc10,skc9)))))*.
+	Given clause: 55[0:Res:7.0,39.1] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,skc9),o__comp__(V,skc9)),x_True) equal(o__eEq__(o__comp__(skc9,U),o__comp__(skc9,U)),x_True) -> equal(o__eEq__(o__comp__(V,o__comp__(skc9,U)),o__comp__(V,o__comp__(skc9,U))),x_True)**.
+	Given clause: 974[0:SSi:966.3,966.0,26.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(V,o__comp__(U,skc9)))))*.
+	Given clause: 984[0:SSi:976.3,976.0,26.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(V,o__comp__(U,skc9)))))*.
+	Given clause: 992[0:SSi:986.3,986.0,26.0,48.1,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(V,o__comp__(U,o__comp__(skc9,skc9)))))*.
+	Given clause: 1057[0:SSi:1051.3,1051.0,26.0,73.1,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(V,o__comp__(U,o__comp__(skc10,skc9)))))*.
+	Given clause: 65[0:Res:6.0,39.0] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True) equal(o__eEq__(o__comp__(skc10,V),o__comp__(skc10,V)),x_True) -> equal(o__eEq__(o__comp__(skc10,o__comp__(V,U)),o__comp__(skc10,o__comp__(V,U))),x_True)**.
+	Given clause: 1363[0:SSi:1362.1,26.0,6.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(U,o__comp__(skc10,V)))))*.
+	Given clause: 1365[0:SSi:1364.1,26.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(U,o__comp__(skc9,V)))))*.
+	Given clause: 1367[0:SSi:1366.1,73.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(skc10,o__comp__(U,V)))))*.
+	Given clause: 1369[0:SSi:1368.1,48.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc9,o__comp__(skc10,o__comp__(skc9,o__comp__(U,V)))))*.
+	Given clause: 40[0:Res:7.0,39.0] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True) equal(o__eEq__(o__comp__(skc9,V),o__comp__(skc9,V)),x_True) -> equal(o__eEq__(o__comp__(skc9,o__comp__(V,U)),o__comp__(skc9,o__comp__(V,U))),x_True)**.
+	Given clause: 1384[0:SSi:1376.2,1376.0,26.0,6.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,o__comp__(skc10,o__comp__(U,o__comp__(skc10,skc9)))))*.
+	Given clause: 1385[0:SSi:1374.2,1374.0,73.0,7.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(V,o__comp__(skc10,o__comp__(skc10,o__comp__(U,skc9)))))*.
+	Given clause: 1723[0:SSi:1714.2,1714.0,73.0,7.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(V,o__comp__(skc10,o__comp__(U,skc9)))))*.
+	Given clause: 1938[0:SSi:1935.3,1935.2,6.2,26.0] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(V,o__comp__(U,skc10)))))*.
+	Given clause: 77[0:Res:6.0,39.2] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True) equal(o__eEq__(o__comp__(U,skc10),o__comp__(U,skc10)),x_True) -> equal(o__eEq__(o__comp__(V,o__comp__(U,skc10)),o__comp__(V,o__comp__(U,skc10))),x_True)**.
+	Given clause: 1940[0:SSi:1939.1,26.0,6.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(U,o__comp__(skc10,V)))))*.
+	Given clause: 1942[0:SSi:1941.1,26.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(U,o__comp__(skc9,V)))))*.
+	Given clause: 1944[0:SSi:1943.1,73.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(skc10,o__comp__(U,V)))))*.
+	Given clause: 1946[0:SSi:1945.1,48.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(skc10,o__comp__(skc9,o__comp__(U,V)))))*.
+	Given clause: 52[0:Res:7.0,39.2] arrow(U) arrow(V) || equal(o__eEq__(o__comp__(V,U),o__comp__(V,U)),x_True) equal(o__eEq__(o__comp__(U,skc9),o__comp__(U,skc9)),x_True) -> equal(o__eEq__(o__comp__(V,o__comp__(U,skc9)),o__comp__(V,o__comp__(U,skc9))),x_True)**.
+	Given clause: 1960[0:SSi:1959.1,26.0,6.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(U,o__comp__(skc10,V)))))*.
+	Given clause: 1962[0:SSi:1961.1,26.0,7.2] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(U,o__comp__(skc9,V)))))*.
+	Given clause: 1964[0:SSi:1963.1,73.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(skc10,o__comp__(U,V)))))*.
+	Given clause: 1966[0:SSi:1965.1,48.1] arrow(U) arrow(V) ||  -> arrow(o__comp__(skc10,o__comp__(skc9,o__comp__(skc9,o__comp__(U,V)))))*.
+	Given clause: 97[0:Obv:96.4] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(W,W),x_True)** equal(o__eEq__(U,U),x_True)** equal(o__eEq__(V,V),x_True)** equal(o__eEq__(o__comp__(skc10,U),o__comp__(W,V)),x_True)**+ -> commSquare(skc10,W,V,U).
+	Given clause: 715[0:SSi:657.2,657.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(skc10,o__comp__(U,skc9)))))))*.
+	Given clause: 809[0:SSi:759.2,759.0,26.0,7.0,6.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(U,o__comp__(skc9,skc10)))))))*.
+	Given clause: 936[0:SSi:866.2,866.0,26.0,6.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(U,o__comp__(skc10,skc9)))))))*.
+	Given clause: 1979[0:SSi:1975.2,1975.0,26.0,6.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(skc10,o__comp__(U,o__comp__(skc10,skc9)))))))*.
+	Given clause: 105[0:Obv:104.4] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(W,W),x_True)** equal(o__eEq__(U,U),x_True)** equal(o__eEq__(V,V),x_True)** equal(o__eEq__(o__comp__(skc9,U),o__comp__(W,V)),x_True)**+ -> commSquare(skc9,W,V,U).
+	Given clause: 1980[0:SSi:1973.2,1973.0,73.0,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc9,o__comp__(skc10,o__comp__(skc10,o__comp__(U,skc9)))))))*.
+	Given clause: 2053[0:SSi:2051.2,2051.0,26.0,6.1,73.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc10,o__comp__(U,o__comp__(skc10,o__comp__(skc10,skc9)))))))*.
+	Given clause: 2054[0:SSi:2050.2,2050.0,26.0,7.1,73.0,7.2] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc10,o__comp__(U,o__comp__(skc9,o__comp__(skc10,skc9)))))))*.
+	Given clause: 2055[0:SSi:2049.2,2049.0,73.0,73.1,7.1] arrow(U) ||  -> arrow(o__comp__(skc9,o__comp__(skc9,o__comp__(skc10,o__comp__(skc10,o__comp__(U,o__comp__(skc10,skc9)))))))*.
+	Given clause: 91[0:Obv:90.7] arrow(U) arrow(V) arrow(W) || equal(o__eEq__(U,U),x_True)** equal(o__eEq__(V,V),x_True)** equal(o__eEq__(W,W),x_True)** equal(o__eEq__(o__comp__(W,U),o__comp__(skc10,V)),x_True)**+ -> commSquare(W,skc10,V,U).
+SPASS V 3.7 
+SPASS beiseite: Ran out of time.
+Problem: Read from stdin. 
+SPASS derived 2209 clauses, backtracked 0 clauses, performed 0 splits and kept 899 clauses.
+SPASS allocated 60229 KBytes.
+SPASS spent	0:00:01.01 on the problem.
+		0:00:00.01 for the input.
+		0:00:00.01 for the FLOTTER CNF translation.
+		0:00:00.04 for inferences.
+		0:00:00.00 for the backtracking.
+		0:00:00.93 for the reduction.
+
+--------------------------SPASS-STOP------------------------------

--- a/spec/fixtures/prover_output/ResourceOut/darwin
+++ b/spec/fixtures/prover_output/ResourceOut/darwin
@@ -1,0 +1,38 @@
+Darwin 1.4.4
+
+Finite Domain: setting initial domain size to 1.
+Finite Domain: using non-ground splitting in preprocessing.
+
+Parsing /var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp ...
+Calling /usr/local/bin/eprover for clausification ...
+
+
+
+Proving  ...
+
+
+Statistics:
+Close                                   :      445
+Assert                                  :    20474
+Split                                   :      451
+Resolve                                 :    36693
+Subsume                                 :     6359
+Compact                                 :        0
+Productivity Filtered                   :        0
+Assert Candidates                       :    64223
+Split Candidates                        :    30456
+Jumps                                   :        0
+Debug                                   :        0
+Global Debug                            :        0
+Global Debug2                           :        0
+Maximum Context Size                    :      272
+Incomplete Branches                     :        0
+Restarts                                :        3
+Bound                                   :        4
+Lemmas                                  :      433
+
+CPU  Time (s)                           :      1.0
+Memory    (MB)                          :        4
+
+SZS status Timeout
+SZS status User for /var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp

--- a/spec/fixtures/prover_output/ResourceOut/darwin-non-fd
+++ b/spec/fixtures/prover_output/ResourceOut/darwin-non-fd
@@ -1,0 +1,37 @@
+Darwin 1.4.4
+
+
+Parsing /var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp ...
+Calling /usr/local/bin/eprover for clausification ...
+
+
+Horn problem: ignoring negative assert candidates.
+
+Proving  ...
+
+
+Statistics:
+Close                                   :        0
+Assert                                  :      481
+Split                                   :        0
+Resolve                                 :        0
+Subsume                                 :       42
+Compact                                 :        0
+Productivity Filtered                   :        0
+Assert Candidates                       :    17783
+Split Candidates                        :        0
+Jumps                                   :        0
+Debug                                   :        0
+Global Debug                            :        0
+Global Debug2                           :        0
+Maximum Context Size                    :      227
+Incomplete Branches                     :        1
+Restarts                                :        1
+Bound                                   :        3
+Lemmas                                  :        0
+
+CPU  Time (s)                           :      1.0
+Memory    (MB)                          :       11
+
+SZS status Timeout
+SZS status User for /var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp

--- a/spec/fixtures/prover_output/ResourceOut/eprover
+++ b/spec/fixtures/prover_output/ResourceOut/eprover
@@ -1,0 +1,33 @@
+# Parsed axioms                        : 15
+# SZS output end Derivation.
+fof(c_0_136, axiom, (?[X5]:arrow(X5)), c_0_14).
+fof(c_0_134, axiom, (bool(x_True)), c_0_109).
+fof(c_0_109, axiom, (bool(x_True)), c_0_13).
+fof(c_0_108, axiom, (?[X5]:bool(X5)), c_0_12).
+fof(c_0_107, axiom, (![X1]:![X2]:((arrow(X1)&arrow(X2))=>bool(o__eEq__(X1,X2)))), c_0_11).
+fof(c_0_87, axiom, (![X6]:![X7]:![X12]:(((arrow(X6)&arrow(X7))&arrow(X12))=>(((o__eEq__(X6,X6)=x_True&o__eEq__(X7,X7)=x_True)&o__eEq__(X12,X12)=x_True)=>((o__eEq__(o__comp__(X6,X7),o__comp__(X6,X7))=x_True&o__eEq__(o__comp__(X7,X12),o__comp__(X7,X12))=x_True)=>o__eEq__(o__comp__(o__comp__(X6,X7),X12),o__comp__(o__comp__(X6,X7),X12))=x_True)))), c_0_9).
+fof(c_0_70, axiom, (![X6]:![X7]:((arrow(X6)&arrow(X7))=>(o__eEq__(o__comp__(X6,X7),o__comp__(X6,X7))=x_True=>(o__eEq__(X6,X6)=x_True&o__eEq__(X7,X7)=x_True)))), c_0_8).
+fof(c_0_68, axiom, (![X10]:![X5]:((arrow(X10)&arrow(X5))=>o__eEq__(X10,X5)=o__eEq__(X5,X10))), c_0_7).
+fof(c_0_67, axiom, (![X6]:![X7]:((arrow(X6)&arrow(X7))=>(o__eEq__(X6,X7)=x_True=>o__eEq__(X6,X6)=x_True))), c_0_6).
+fof(c_0_58, axiom, (![X10]:![X5]:![X11]:(((arrow(X10)&arrow(X5))&arrow(X11))=>o__comp__(o__comp__(X10,X5),X11)=o__comp__(X10,o__comp__(X5,X11)))), c_0_5).
+fof(c_0_50, axiom, (![X1]:![X2]:((arrow(X1)&arrow(X2))=>arrow(o__comp__(X1,X2)))), c_0_4).
+fof(c_0_38, axiom, (![X6]:![X7]:((arrow(X6)&arrow(X7))=>(o__eEq__(X6,X7)=x_True=>X6=X7))), c_0_3).
+fof(c_0_16, axiom, (![X6]:![X7]:![X8]:![X9]:((((arrow(X6)&arrow(X7))&arrow(X8))&arrow(X9))=>((((o__eEq__(X6,X6)=x_True&o__eEq__(X7,X7)=x_True)&o__eEq__(X8,X8)=x_True)&o__eEq__(X9,X9)=x_True)=>(commSquare(X6,X7,X8,X9)<=>o__eEq__(o__comp__(X6,X9),o__comp__(X7,X8))=x_True)))), c_0_1).
+fof(c_0_15, axiom, (![X13]:![X3]:![X4]:![X14]:(commSquare(X13,X3,X4,X14)=>(((arrow(X13)&arrow(X3))&arrow(X4))&arrow(X14)))), c_0_0).
+fof(c_0_14, axiom, (?[X5]:arrow(X5)), file('/var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp', ga_non_empty_sort_arrow)).
+fof(c_0_13, axiom, (bool(x_True)), file('/var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp', declaration2)).
+fof(c_0_12, axiom, (?[X5]:bool(X5)), file('/var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp', ga_non_empty_sort_bool)).
+fof(c_0_11, axiom, (![X1]:![X2]:((arrow(X1)&arrow(X2))=>bool(o__eEq__(X1,X2)))), file('/var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp', declaration1)).
+fof(c_0_10, axiom, (![X3]:![X4]:((arrow(X3)&bool(X4))=>~(X3=X4))), file('/var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp', disjoint_sorts_arrow_bool)).
+fof(c_0_9, axiom, (![X6]:![X7]:![X12]:(((arrow(X6)&arrow(X7))&arrow(X12))=>(((o__eEq__(X6,X6)=x_True&o__eEq__(X7,X7)=x_True)&o__eEq__(X12,X12)=x_True)=>((o__eEq__(o__comp__(X6,X7),o__comp__(X6,X7))=x_True&o__eEq__(o__comp__(X7,X12),o__comp__(X7,X12))=x_True)=>o__eEq__(o__comp__(o__comp__(X6,X7),X12),o__comp__(o__comp__(X6,X7),X12))=x_True)))), file('/var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp', ax6)).
+fof(c_0_8, axiom, (![X6]:![X7]:((arrow(X6)&arrow(X7))=>(o__eEq__(o__comp__(X6,X7),o__comp__(X6,X7))=x_True=>(o__eEq__(X6,X6)=x_True&o__eEq__(X7,X7)=x_True)))), file('/var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp', ax5)).
+fof(c_0_7, axiom, (![X10]:![X5]:((arrow(X10)&arrow(X5))=>o__eEq__(X10,X5)=o__eEq__(X5,X10))), file('/var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp', ga_comm___eEq__)).
+fof(c_0_6, axiom, (![X6]:![X7]:((arrow(X6)&arrow(X7))=>(o__eEq__(X6,X7)=x_True=>o__eEq__(X6,X6)=x_True))), file('/var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp', ax2)).
+fof(c_0_5, axiom, (![X10]:![X5]:![X11]:(((arrow(X10)&arrow(X5))&arrow(X11))=>o__comp__(o__comp__(X10,X5),X11)=o__comp__(X10,o__comp__(X5,X11)))), file('/var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp', ga_assoc___comp__)).
+fof(c_0_4, axiom, (![X1]:![X2]:((arrow(X1)&arrow(X2))=>arrow(o__comp__(X1,X2)))), file('/var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp', declaration0)).
+fof(c_0_3, axiom, (![X6]:![X7]:((arrow(X6)&arrow(X7))=>(o__eEq__(X6,X7)=x_True=>X6=X7))), file('/var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp', ax3)).
+fof(c_0_1, axiom, (![X6]:![X7]:![X8]:![X9]:((((arrow(X6)&arrow(X7))&arrow(X8))&arrow(X9))=>((((o__eEq__(X6,X6)=x_True&o__eEq__(X7,X7)=x_True)&o__eEq__(X8,X8)=x_True)&o__eEq__(X9,X9)=x_True)=>(commSquare(X6,X7,X8,X9)<=>o__eEq__(o__comp__(X6,X9),o__comp__(X7,X8))=x_True)))), file('/var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp', commSquareAx)).
+fof(c_0_0, axiom, (![X13]:![X3]:![X4]:![X14]:(commSquare(X13,X3,X4,X14)=>(((arrow(X13)&arrow(X3))&arrow(X4))&arrow(X14)))), file('/var/folders/h0/h5fs6h4n4wg1qpj05yd205dc0000gn/T/_commSquareMinushorizontalMinusglueing69766.tptp', arg_restriction_commSquare)).
+# SZS output start Derivation.
+# SZS status ResourceOut
+# Scanning for AC axioms

--- a/spec/lib/hets/szs_parser_spec.rb
+++ b/spec/lib/hets/szs_parser_spec.rb
@@ -1,13 +1,19 @@
 require 'spec_helper'
 
 describe Hets::Prove::SZSParser do
-  %w(Theorem CounterSatisfiable).each do |szs_status|
+  %w(Theorem CounterSatisfiable ResourceOut).each do |szs_status|
     %w(SPASS).each do |prover|
       context "#{prover} on #{szs_status}" do
         let(:output) { File.read(prover_output_fixture(szs_status, prover)) }
 
-        it "returns nil" do
-          expect(Hets::Prove::SZSParser.new(prover, output).call).to be(nil)
+        if szs_status == 'ResourceOut'
+          it "returns ResourceOut" do
+            expect(Hets::Prove::SZSParser.new(prover, output).call).to eq('ResourceOut')
+          end
+        else
+          it "returns nil" do
+            expect(Hets::Prove::SZSParser.new(prover, output).call).to be(nil)
+          end
         end
       end
     end

--- a/spec/support/fixtures_generation/prover_output_generator.rb
+++ b/spec/support/fixtures_generation/prover_output_generator.rb
@@ -2,7 +2,7 @@ require_relative 'direct_hets_generator.rb'
 
 module FixturesGeneration
   class ProverOutputGenerator < DirectHetsGenerator
-    NODES = %w(CounterSatisfiable Theorem)
+    NODES = %w(CounterSatisfiable Theorem ResourceOut)
     PROVERS = %w(SPASS darwin darwin-non-fd eprover)
     protected
 
@@ -22,7 +22,7 @@ module FixturesGeneration
     end
 
     def files
-      %w(spec/fixtures/ontologies/prove/Simple_Implications.casl)
+      %w(spec/fixtures/ontologies/prove/prover_output_generator.casl)
     end
 
     def subdir


### PR DESCRIPTION
This shall fix #1542.

It also transforms the status Timeout to ResourceOut for uniformity among the provers.

---


This branch is based on **fix_sine_spec** (#1543) **instead of staging** because the tests are not green otherwise.