### PR TITLE
864 show warning if javascript is not activated

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,6 +18,9 @@
         .row.flash-messages
           = flash_messages
         .row.flash-messages
+          %noscript
+            .alert.alert-danger
+              JavaScript is deactivated in your browser. You might not be able to use all contents.
           .alert.alert-info
             Do you want to support the development of Ontohub by testing? Visit
             = link_to 'test.ontohub.org', 'http://test.ontohub.org'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -20,7 +20,7 @@
         .row.flash-messages
           %noscript
             .alert.alert-danger
-              JavaScript is deactivated in your browser. You might not be able to use all contents.
+              = I18n.t('info.javascript_warning')
           .alert.alert-info
             Do you want to support the development of Ontohub by testing? Visit
             = link_to 'test.ontohub.org', 'http://test.ontohub.org'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -267,3 +267,5 @@ en:
     labels:
       proof:
         axioms: Manual Axiom Selection
+  info:
+    javascript_warning: JavaScript is deactivated in your browser. Some features are only accessible with active JavaScript.

--- a/features/JavaScript.feature
+++ b/features/JavaScript.feature
@@ -1,0 +1,11 @@
+Feature: JavaScript
+
+@rack-test
+Scenario: Warning if JavaScript is deactivated
+  Given I visit the landing page with deactivated javascript
+  Then I should see a javascript-deactivated-warning
+
+@javascript
+Scenario: No warning if JavaScript is activated
+  Given I visit the landing page with activated javascript
+  Then I should see no javascript-deactivated-warning

--- a/features/step_definitions/javascript_steps.rb
+++ b/features/step_definitions/javascript_steps.rb
@@ -4,7 +4,7 @@ end
 
 Then(/^I should see a javascript\-deactivated\-warning$/) do
   page.should have_content("JavaScript is deactivated in your browser.
-    You might not be able to use all contents.")
+    Some features are only accessible with active JavaScript.")
 end
 
 Given(/^I visit the landing page with activated javascript$/) do
@@ -13,6 +13,6 @@ end
 
 Then(/^I should see no javascript\-deactivated\-warning$/) do
   page.should_not have_content("JavaScript is deactivated in your browser.
-    You might not be able to use all contents.")
+    Some features are only accessible with active JavaScript.")
 end
 

--- a/features/step_definitions/javascript_steps.rb
+++ b/features/step_definitions/javascript_steps.rb
@@ -1,0 +1,18 @@
+Given(/^I visit the landing page with deactivated javascript$/) do
+  visit root_path
+end
+
+Then(/^I should see a javascript\-deactivated\-warning$/) do
+  page.should have_content("JavaScript is deactivated in your browser.
+    You might not be able to use all contents.")
+end
+
+Given(/^I visit the landing page with activated javascript$/) do
+  visit root_path
+end
+
+Then(/^I should see no javascript\-deactivated\-warning$/) do
+  page.should_not have_content("JavaScript is deactivated in your browser.
+    You might not be able to use all contents.")
+end
+

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,7 +12,7 @@ require 'vcr'
 
 Capybara.current_driver = :poltergeist
 Capybara.javascript_driver = :poltergeist
-Capybara.default_wait_time = 5
+Capybara.default_max_wait_time = 5
 
 class Cucumber::Rails::World
   require Rails.root.join('spec', 'support', 'common_helper_methods.rb')

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -34,7 +34,7 @@ class Cucumber::Rails::World
     while page.evaluate_script("jQuery.active").to_i > 0
       counter += 1
       sleep(0.1)
-      if counter >= 10 * Capybara.default_wait_time
+      if counter >= 10 * Capybara.default_max_wait_time
         raise "AJAX request took longer than 5 seconds."
       end
     end


### PR DESCRIPTION
This should fix #864.
It also replaces a deprecated capybara config.