### PR TITLE
Fix error header codes.

### DIFF
--- a/lib/hets/hets_error_process.rb
+++ b/lib/hets/hets_error_process.rb
@@ -1,6 +1,6 @@
 module Hets
   class HetsErrorProcess
-    HETS_ERROR_CODES = %w(400, 422, 500)
+    HETS_ERROR_CODES = %w(400 422 500)
     HETS_ERROR_MESSAGE_REGEXP = /\A[*]{3}\s*Error:\s*/
 
     attr_reader :error, :response


### PR DESCRIPTION
I missed a detail in a review: There were commas in the magic string which don't belong there.