### PR TITLE
1491 error when displaying sentences

### DIFF
--- a/app/controllers/axioms_controller.rb
+++ b/app/controllers/axioms_controller.rb
@@ -27,9 +27,9 @@ class AxiomsController < InheritedResources::Base
           else
             parent.translated_axioms
           end
-        Kaminari.paginate_array(axioms).page(params[:page])
+        Kaminari.paginate_array(axioms).page(params[:page]).per(params[:per_page])
       else
-        Kaminari.paginate_array(parent.axioms.original).page(params[:page])
+        Kaminari.paginate_array(parent.axioms.original).page(params[:page]).per(params[:per_page])
       end
   end
 

--- a/app/controllers/axioms_controller.rb
+++ b/app/controllers/axioms_controller.rb
@@ -2,7 +2,6 @@
 # Lists axioms of an ontology
 #
 class AxiomsController < InheritedResources::Base
-
   belongs_to :ontology
 
   actions :index
@@ -27,9 +26,11 @@ class AxiomsController < InheritedResources::Base
           else
             parent.translated_axioms
           end
-        Kaminari.paginate_array(axioms).page(params[:page]).per(params[:per_page])
+        Kaminari.paginate_array(axioms).page(params[:page]).
+          per(params[:per_page])
       else
-        Kaminari.paginate_array(parent.axioms.original).page(params[:page]).per(params[:per_page])
+        Kaminari.paginate_array(parent.axioms.original).page(params[:page]).
+          per(params[:per_page])
       end
   end
 

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -31,8 +31,7 @@ module PaginationHelper
       query_string_parts << ['per_page', per_page]
     end
 
-    query_string_parts.map! { |p| p.join('=') }
-    query_string = query_string_parts.join('&')
+    query_string = query_string_parts.map { |p| p.join('=') }.join('&')
 
     [request.env['REQUEST_PATH'], query_string].compact.join('?')
   end
@@ -42,15 +41,13 @@ module PaginationHelper
   # This method extracts the page number and page size from the generated url.
   def params_from_kaminari_url(kaminari_url)
     page =
-      if match = kaminari_url.match(/[\?&]page=(\d+)/)
+      if (match = kaminari_url.match(/[\?&]page=(\d+)/)) ? match[1] : 1
         match[1]
-      else
-        1
       end
     per_page =
       if match = kaminari_url.match(/[\?&]per_page=(\d+)/)
         match[1]
       end
-    [page, per_page]
+    [page || 1, per_page]
   end
 end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,10 +1,10 @@
 module PaginationHelper
 
-  def pagination(collection=nil, &block)
+  def pagination(collection=nil, **options, &block)
     # call the collection-method if no collection is given
     collection ||= send :collection
 
-    pages = paginate(collection)
+    pages = paginate(collection, **options)
 
     html = ''
     html << pages

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,5 +1,4 @@
 module PaginationHelper
-
   def pagination(collection = nil, **options, &block)
     # call the collection-method if no collection is given
     collection ||= send :collection
@@ -23,15 +22,8 @@ module PaginationHelper
       split(/;|&/).
       map { |p| p.split('=') }
 
-    query_string_parts.reject! { |p| p.first == 'page' } if page
-    query_string_parts.reject! { |p| p.first == 'per_page' } if per_page
-
-    query_string_parts << ['page', page] if page
-    if per_page && per_page != :default
-      query_string_parts << ['per_page', per_page]
-    end
-
-    query_string = query_string_parts.map { |p| p.join('=') }.join('&')
+    query_string_parts = replace_page_params(query_string_parts, page, per_page)
+    query_string = build_query_string(query_string_parts)
 
     [request.env['REQUEST_PATH'], query_string].compact.join('?')
   end
@@ -49,5 +41,24 @@ module PaginationHelper
         match[1]
       end
     [page || 1, per_page]
+  end
+
+  private
+
+  def replace_page_params(page, per_page)
+    query_string_parts.reject! { |p| p.first == 'page' } if page
+    query_string_parts.reject! { |p| p.first == 'per_page' } if per_page
+
+    query_string_parts << ['page', page] if page
+    if per_page && per_page != :default
+      query_string_parts << ['per_page', per_page]
+    end
+
+    query_string_parts
+  end
+
+  def build_query_string(query_string_parts)
+    query_string = query_string_parts.map { |p| p.join('=') }.join('&')
+    query_string if query_string.present?
   end
 end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,6 +1,6 @@
 module PaginationHelper
 
-  def pagination(collection=nil, **options, &block)
+  def pagination(collection = nil, **options, &block)
     # call the collection-method if no collection is given
     collection ||= send :collection
 
@@ -27,7 +27,9 @@ module PaginationHelper
     query_string_parts.reject! { |p| p.first == 'per_page' } if per_page
 
     query_string_parts << ['page', page] if page
-    query_string_parts << ['per_page', per_page] if per_page && per_page != :default
+    if per_page && per_page != :default
+      query_string_parts << ['per_page', per_page]
+    end
 
     query_string_parts.map! { |p| p.join('=') }
     query_string = query_string_parts.join('&')
@@ -48,8 +50,6 @@ module PaginationHelper
     per_page =
       if match = kaminari_url.match(/[\?&]per_page=(\d+)/)
         match[1]
-      else
-        nil
       end
     [page, per_page]
   end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -13,4 +13,44 @@ module PaginationHelper
     html.html_safe
   end
 
+  # Kaminari generates a URL from the params hash. The URL is, however, not
+  # compatible to loc/ids.
+  # This method builds the loc/id compatible link to the page.
+  def build_link_from_request(kaminari_url)
+    page, per_page = params_from_kaminari_url(kaminari_url)
+
+    query_string_parts = request.env['QUERY_STRING'].
+      split(/;|&/).
+      map { |p| p.split('=') }
+
+    query_string_parts.reject! { |p| p.first == 'page' } if page
+    query_string_parts.reject! { |p| p.first == 'per_page' } if per_page
+
+    query_string_parts << ['page', page] if page
+    query_string_parts << ['per_page', per_page] if per_page && per_page != :default
+
+    query_string_parts.map! { |p| p.join('=') }
+    query_string = query_string_parts.join('&')
+
+    [request.env['REQUEST_PATH'], query_string].compact.join('?')
+  end
+
+  # Kaminari generates a URL from the params hash. The URL is, however, not
+  # compatible to loc/ids.
+  # This method extracts the page number and page size from the generated url.
+  def params_from_kaminari_url(kaminari_url)
+    page =
+      if match = kaminari_url.match(/[\?&]page=(\d+)/)
+        match[1]
+      else
+        1
+      end
+    per_page =
+      if match = kaminari_url.match(/[\?&]per_page=(\d+)/)
+        match[1]
+      else
+        nil
+      end
+    [page, per_page]
+  end
 end

--- a/app/views/axioms/index.html.haml
+++ b/app/views/axioms/index.html.haml
@@ -14,7 +14,7 @@
     = link_to "Click here #{t('.to_display_all_axioms')}", locid_for(parent, :axioms, all: true)
 
 
-= pagination do
+= pagination(build_links_from_request: true) do
   %table.axioms
     %thead
       %tr

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,8 +1,8 @@
 - unless current_page.first?
   %li.first
     - if current_page.instance_variable_get(:@options)[:build_links_from_request]
-      - # use request url for page creation
+      -# use request url for page creation
       = link_to_unless current_page.first?, raw(t 'views.pagination.first'), build_link_from_request(url), :remote => remote
     - else
-      - # use default kaminari behavior
+      -# use default kaminari behavior
       = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,3 +1,8 @@
 - unless current_page.first?
   %li.first
-    = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote
+    - if current_page.instance_variable_get(:@options)[:build_links_from_request]
+      - # use request url for page creation
+      = link_to_unless current_page.first?, raw(t 'views.pagination.first'), build_link_from_request(url), :remote => remote
+    - else
+      - # use default kaminari behavior
+      = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,3 +1,8 @@
 - unless current_page.last?
-  %li.last.next/
-  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote}
+  %li.last.next
+    - if current_page.instance_variable_get(:@options)[:build_links_from_request]
+      - # use request url for page creation
+      = link_to_unless current_page.last?, raw(t 'views.pagination.last'), build_link_from_request(url), {:remote => remote}
+    - else
+      - # use default kaminari behavior
+      = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote}

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,8 +1,8 @@
 - unless current_page.last?
   %li.last.next
     - if current_page.instance_variable_get(:@options)[:build_links_from_request]
-      - # use request url for page creation
+      -# use request url for page creation
       = link_to_unless current_page.last?, raw(t 'views.pagination.last'), build_link_from_request(url), {:remote => remote}
     - else
-      - # use default kaminari behavior
+      -# use default kaminari behavior
       = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote}

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,8 +1,8 @@
 - unless current_page.last?
   %li.next_page
     - if current_page.instance_variable_get(:@options)[:build_links_from_request]
-      - # use request url for page creation
+      -# use request url for page creation
       = link_to_unless current_page.last?, raw(t 'views.pagination.next'), build_link_from_request(url), :rel => 'next', :remote => remote
     - else
-      - # use default kaminari behavior
+      -# use default kaminari behavior
       = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,3 +1,8 @@
 - unless current_page.last?
   %li.next_page
-    = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote
+    - if current_page.instance_variable_get(:@options)[:build_links_from_request]
+      - # use request url for page creation
+      = link_to_unless current_page.last?, raw(t 'views.pagination.next'), build_link_from_request(url), :rel => 'next', :remote => remote
+    - else
+      - # use default kaminari behavior
+      = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -1,2 +1,7 @@
 %li{ :class => page.current? ? 'active' : nil }
-  = link_to page, url, :remote => remote, :rel => (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
+  - if current_page.instance_variable_get(:@options)[:build_links_from_request]
+    - # use request url for page creation
+    = link_to page, build_link_from_request(url), :remote => remote, :rel => (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
+  - else
+    - # use default kaminari behavior
+    = link_to page, url, :remote => remote, :rel => (page.next? ? 'next' : (page.prev? ? 'prev' : nil))

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -1,7 +1,7 @@
 %li{ :class => page.current? ? 'active' : nil }
   - if current_page.instance_variable_get(:@options)[:build_links_from_request]
-    - # use request url for page creation
+    -# use request url for page creation
     = link_to page, build_link_from_request(url), :remote => remote, :rel => (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
   - else
-    - # use default kaminari behavior
+    -# use default kaminari behavior
     = link_to page, url, :remote => remote, :rel => (page.next? ? 'next' : (page.prev? ? 'prev' : nil))

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -20,7 +20,7 @@
       = last_page_tag unless current_page.last? || exclude.include?(:last)
     - unless exclude.include?(:per_page)
       %form.row
-        %label
+        %label.col-md-3
           .col-md-6
             %select{name: 'per_page', class: 'form-control'}
               - [25, 50, 100, 500].each do |num|

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,8 +1,8 @@
 - unless current_page.first?
   %li.prev
     - if current_page.instance_variable_get(:@options)[:build_links_from_request]
-      - # use request url for page creation
+      -# use request url for page creation
       = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), build_link_from_request(url), :rel => 'prev', :remote => remote
     - else
-      - # use default kaminari behavior
+      -# use default kaminari behavior
       = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,3 +1,8 @@
 - unless current_page.first?
   %li.prev
-    = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote
+    - if current_page.instance_variable_get(:@options)[:build_links_from_request]
+      - # use request url for page creation
+      = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), build_link_from_request(url), :rel => 'prev', :remote => remote
+    - else
+      - # use default kaminari behavior
+      = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote

--- a/app/views/ontologies/show.html.haml
+++ b/app/views/ontologies/show.html.haml
@@ -1,4 +1,0 @@
-= ontology_nav @ontology, :symbols
-
-= pagination do
-  = render :partial => 'symbols/index'

--- a/app/views/symbols/index.html.haml
+++ b/app/views/symbols/index.html.haml
@@ -3,7 +3,7 @@
 = ontology_nav parent, :symbols
 
 - unless parent.owl?
-  = pagination do
+  = pagination(build_links_from_request: true) do
     - unless collection.blank?
       = render partial: 'list'
     - else
@@ -25,7 +25,7 @@
           = render partial: 'treeview'
 
   .symbols-detail
-    = pagination do
+    = pagination(build_links_from_request: true) do
       - unless collection.blank?
         = render partial: 'list'
       - else

--- a/app/views/theorems/index.html.haml
+++ b/app/views/theorems/index.html.haml
@@ -5,7 +5,7 @@
 - if can?(:write, parent.repository) && @ontology.theorems.provable.any?
   = link_to t('theorems.index.prove'), [*resource_chain, :proofs, :new], class: 'btn btn-primary'
 
-= pagination do
+= pagination(build_links_from_request: true) do
   %table.sentences
     %thead
       %tr


### PR DESCRIPTION
This shall fix #1491.

Pagination of objects that have a loc/id must be done with the custom kaminari-option `build_links_from_request: true`. This switches from the default kaminari-generated page-URLs to URLs based on the current request-URL.