### PR TITLE
1528 find the reason for the empty named queue

### DIFF
--- a/lib/worker.rb
+++ b/lib/worker.rb
@@ -3,6 +3,7 @@ require 'sidekiq/worker'
 # Worker for Sidekiq
 class Worker < BaseWorker
   sidekiq_options queue: 'hets'
+  sidekiq_options backtrace: true
 
   # Because of the JSON-Parsing the hash which contains
   # the try_count will contain the try_count key
@@ -40,14 +41,6 @@ class Worker < BaseWorker
       self.class.perform_async(*@args, try_count: @try_count+1)
     end
   end
-
-  # This method definition is required by sidekiq
-  def self.get_sidekiq_options
-    {
-      'backtrace' => true
-    }
-  end
-
 end
 
 class SequentialWorker < Worker

--- a/lib/worker.rb
+++ b/lib/worker.rb
@@ -3,6 +3,7 @@ require 'sidekiq/worker'
 # Worker for Sidekiq
 class Worker < BaseWorker
   sidekiq_options queue: 'hets'
+  sidekiq_options retry: 3
   sidekiq_options backtrace: true
 
   # Because of the JSON-Parsing the hash which contains


### PR DESCRIPTION
This shall fix #1528.

The error was caused by a method that "overwrites" the sidekiq options. I tested it on ontohub.org by async-parsing the ontology versions mentioned in #1528. I am certain that it fixes the issue.

Additionally, I defined the retry-count for failures *that are not caused by concurrently* parsing different ontologies. The concurrency balancing remains unchanged.