### PR TITLE
Extract SequentialOntologyBatchParseWorker into a separate file.

### DIFF
--- a/lib/ontology_batch_parse_worker.rb
+++ b/lib/ontology_batch_parse_worker.rb
@@ -48,24 +48,4 @@ class OntologyBatchParseWorker < BaseWorker
     end
     true
   end
-
-end
-
-class SequentialOntologyBatchParseWorker < OntologyBatchParseWorker
-  sidekiq_options queue: 'sequential'
-
-  def perform(*args, try_count: 1)
-    establish_arguments(args, try_count: try_count)
-    ConcurrencyBalancer.sequential_lock do
-      execute_perform(try_count, args.first)
-    end
-  rescue ConcurrencyBalancer::AlreadyLockedError
-    handle_concurrency_issue
-  end
-
-  def handle_concurrency_issue
-    SequentialOntologyBatchParseWorker.
-      perform_async(*@args, try_count: @try_count + 1)
-  end
-
 end

--- a/lib/sequential_ontology_batch_parse_worker.rb
+++ b/lib/sequential_ontology_batch_parse_worker.rb
@@ -1,0 +1,17 @@
+class SequentialOntologyBatchParseWorker < OntologyBatchParseWorker
+  sidekiq_options queue: 'sequential'
+
+  def perform(*args, try_count: 1)
+    establish_arguments(args, try_count: try_count)
+    ConcurrencyBalancer.sequential_lock do
+      execute_perform(try_count, args.first)
+    end
+  rescue ConcurrencyBalancer::AlreadyLockedError
+    handle_concurrency_issue
+  end
+
+  def handle_concurrency_issue
+    SequentialOntologyBatchParseWorker.
+      perform_async(*@args, try_count: @try_count + 1)
+  end
+end


### PR DESCRIPTION
This shall fix #1005. It is deployed on develop.ontohub.org. You can test it by executing
```
ontology_version_id = 19426
Sidekiq::Client.push("retry"=>false, "queue"=>"sequential", "class"=>"SequentialOntologyBatchParseWorker", "args"=>[[[ontology_version_id, {"fast_parse"=>true}]]])
```
in the Rails console on develop.ontohub.org and following the log of the sidekiq sequential queue:
```
tail -f ~ontohub/webapp/log/sidekiq-sequential.log
```

There will be an error (UriFetcher::Errors::UnfollowableResponseError: can't follow the response, and response not useable) because of an issue with Hets (#1559). The code, however, is executed and calls Hets which means that it found the class `SequentialOntologyBatchParseWorker`.