### PR TITLE
1251 fix ontology delete

### DIFF
--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -77,8 +77,9 @@ class OntologiesController < InheritedResources::Base
       resource.destroy_with_parent(current_user)
       destroy!
     else
-      flash[:error] = "Can't delete #{Settings.OMS.with_indefinite_article}
-      that (contains a child that) is imported by another one."
+      flash[:error] = t('ontology.delete_error',
+                        oms_with_article: Settings.OMS.with_indefinite_article,
+                        oms: Settings.OMS)
       redirect_to resource_chain
     end
   end

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -73,13 +73,13 @@ class OntologiesController < InheritedResources::Base
   end
 
   def destroy
-    if resource.is_imported?
-      flash[:error] = "Can't delete #{Settings.OMS.with_indefinite_article}
-      that is imported by another one."
-      redirect_to resource_chain
-    else
+    if resource.can_be_deleted?
       resource.destroy_with_parent(current_user)
       destroy!
+    else
+      flash[:error] = "Can't delete #{Settings.OMS.with_indefinite_article}
+      that (contains a child that) is imported by another one."
+      redirect_to resource_chain
     end
   end
 

--- a/app/models/ontology.rb
+++ b/app/models/ontology.rb
@@ -110,7 +110,7 @@ class Ontology < ActiveRecord::Base
   end
 
   def can_be_deleted_alone?
-    !is_imported?
+    !is_imported_from_other_file?
   end
 
   def can_be_deleted_with_whole_repository?

--- a/app/models/ontology.rb
+++ b/app/models/ontology.rb
@@ -110,12 +110,12 @@ class Ontology < ActiveRecord::Base
   end
 
   def can_be_deleted_alone?
-    !is_imported_from_other_file? &&
+    !source_mappings_from_other_files.any? &&
       children.all?(&:can_be_deleted_alone?)
   end
 
   def can_be_deleted_with_whole_repository?
-    !is_imported_from_other_repository?
+    !source_mappings_from_other_repositories.any?
   end
 
   def contains_logic_translations?

--- a/app/models/ontology.rb
+++ b/app/models/ontology.rb
@@ -110,7 +110,8 @@ class Ontology < ActiveRecord::Base
   end
 
   def can_be_deleted_alone?
-    !is_imported_from_other_file?
+    !is_imported_from_other_file? &&
+      children.all?(&:can_be_deleted_alone?)
   end
 
   def can_be_deleted_with_whole_repository?

--- a/app/models/ontology/import_mappings.rb
+++ b/app/models/ontology/import_mappings.rb
@@ -11,6 +11,10 @@ class Ontology
         import_mappings_from_other_repositories.present?
       end
 
+      def is_imported_from_other_file?
+        import_mappings_from_other_files.present?
+      end
+
       def mapping_targets
         source_mappings.map(&:target)
       end
@@ -29,6 +33,12 @@ class Ontology
 
       def import_mappings
         Mapping.where(source_id: id, kind: 'import')
+      end
+
+      def import_mappings_from_other_files
+        import_mappings.reject do |l|
+          l.target.repository == repository && l.target.path == path
+        end
       end
 
       def import_mappings_from_other_repositories

--- a/app/models/ontology/import_mappings.rb
+++ b/app/models/ontology/import_mappings.rb
@@ -30,18 +30,14 @@ class Ontology
 
       protected
 
-      def import_mappings
-        Mapping.where(source_id: id)
-      end
-
       def import_mappings_from_other_files
-        import_mappings.reject do |l|
+        source_mappings.reject do |l|
           l.target.repository == repository && l.target.path == path
         end
       end
 
       def import_mappings_from_other_repositories
-        import_mappings.select { |l| l.target.repository != repository }
+        source_mappings.select { |l| l.target.repository != repository }
       end
     end
   end

--- a/app/models/ontology/import_mappings.rb
+++ b/app/models/ontology/import_mappings.rb
@@ -6,10 +6,6 @@ class Ontology
     extend ActiveSupport::Concern
 
     included do
-      def is_imported?
-        import_mappings.present?
-      end
-
       def is_imported_from_other_repository?
         import_mappings_from_other_repositories.present?
       end

--- a/app/models/ontology/import_mappings.rb
+++ b/app/models/ontology/import_mappings.rb
@@ -1,4 +1,7 @@
 class Ontology
+  # An ontology being imported into is in this context not only a Mapping with
+  # kind 'import' but any kind of mapping. Otherwise the target ontology's view,
+  # alignment, etc. is invalid.
   module ImportMappings
     extend ActiveSupport::Concern
 
@@ -32,7 +35,7 @@ class Ontology
       protected
 
       def import_mappings
-        Mapping.where(source_id: id, kind: 'import')
+        Mapping.where(source_id: id)
       end
 
       def import_mappings_from_other_files

--- a/app/models/ontology/import_mappings.rb
+++ b/app/models/ontology/import_mappings.rb
@@ -6,14 +6,6 @@ class Ontology
     extend ActiveSupport::Concern
 
     included do
-      def is_imported_from_other_repository?
-        import_mappings_from_other_repositories.present?
-      end
-
-      def is_imported_from_other_file?
-        import_mappings_from_other_files.present?
-      end
-
       def mapping_targets
         source_mappings.map(&:target)
       end
@@ -28,15 +20,13 @@ class Ontology
         Ontology.where(id: ontology_ids)
       end
 
-      protected
-
-      def import_mappings_from_other_files
+      def source_mappings_from_other_files
         source_mappings.reject do |l|
           l.target.repository == repository && l.target.path == path
         end
       end
 
-      def import_mappings_from_other_repositories
+      def source_mappings_from_other_repositories
         source_mappings.select { |l| l.target.repository != repository }
       end
     end

--- a/app/views/ontologies/_menu.html.haml
+++ b/app/views/ontologies/_menu.html.haml
@@ -18,7 +18,7 @@
         - if resource.can_be_deleted?
           = modal_button(t('ontology.delete'), btn_class: 'btn-default')
         - else
-          .btn.btn-default.tooltip-btn{ disabled: true, data: { toggle: "tooltip", :'original-title' => t('ontology.delete_error', oms: Settings.OMS), container: 'body' } }
+          .btn.btn-default.tooltip-btn{ disabled: true, data: { toggle: "tooltip", :'original-title' => t('ontology.delete_error', oms_with_article: Settings.OMS.with_indefinite_article, oms: Settings.OMS), container: 'body' } }
             %span.allow-tooltips
               Delete
       - if Settings.format_selection

--- a/app/views/ontologies/_menu.html.haml
+++ b/app/views/ontologies/_menu.html.haml
@@ -29,4 +29,4 @@
           %ul.dropdown-menu{role: 'menu'}
             - %w(xml json).each do |f|
               %li= link_to f.upcase, format: f
-= modal_body("header_text", t('ontology.delete_confirm.text', name: resource, parent_text: resource.parent.present? ? t('ontology.delete_confirm.parent') : '', children_text: resource.children.present? ? t('ontology.delete_confirm.children') : '', path: resource.path), resource_chain, t('ontology.delete'))
+= modal_body(t('ontology.delete_confirm.header_text', oms: Settings.OMS), t('ontology.delete_confirm.text', name: resource, parent_text: resource.parent.present? ? t('ontology.delete_confirm.parent') : '', children_text: resource.children.present? ? t('ontology.delete_confirm.children') : '', path: resource.path), resource_chain, t('ontology.delete'))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,7 +87,7 @@ en:
       info: The defining file %{path} of this %{oms} was deleted. However, you can check the
       last_file_version: last version of that file
     delete: Delete
-    delete_error: Can't delete an %{oms} that's imported by another one.
+    delete_error: Can't delete %{oms_with_article} that (contains a child that) is imported by another %{oms}.
     delete_confirm:
       header_text: Are you sure about deleting the %{oms}?
       text: "Really delete the ontology %{name}?\n\nThe %{parent_text}%{children_text}defining file %{path} will be deleted as well."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,7 @@ en:
     delete: Delete
     delete_error: Can't delete an %{oms} that's imported by another one.
     delete_confirm:
+      header_text: Are you sure about deleting the %{oms}?
       text: "Really delete the ontology %{name}?\n\nThe %{parent_text}%{children_text}defining file %{path} will be deleted as well."
       parent: 'parent ontology including its children and the '
       children: 'subontologies and the '

--- a/spec/factories/ontology_factory.rb
+++ b/spec/factories/ontology_factory.rb
@@ -118,6 +118,21 @@ FactoryGirl.define do
         end
       end
 
+      trait :with_children do
+        after(:build) do |ontology|
+          ontology.children << FactoryGirl.build(:ontology,
+            parent: ontology,
+            repository: ontology.repository,
+            basepath: ontology.basepath,
+            file_extension: ontology.file_extension)
+          ontology.children << FactoryGirl.build(:ontology,
+            parent: ontology,
+            repository: ontology.repository,
+            basepath: ontology.basepath,
+            file_extension: ontology.file_extension)
+        end
+      end
+
       trait :with_versioned_children do
         after(:build) do |ontology|
           version = ontology.versions.build({

--- a/spec/factories/ontology_factory.rb
+++ b/spec/factories/ontology_factory.rb
@@ -119,17 +119,17 @@ FactoryGirl.define do
       end
 
       trait :with_children do
-        after(:build) do |ontology|
-          ontology.children << FactoryGirl.build(:ontology,
-            parent: ontology,
-            repository: ontology.repository,
-            basepath: ontology.basepath,
-            file_extension: ontology.file_extension)
-          ontology.children << FactoryGirl.build(:ontology,
-            parent: ontology,
-            repository: ontology.repository,
-            basepath: ontology.basepath,
-            file_extension: ontology.file_extension)
+        after(:build) do |built_ontology|
+          built_ontology.children << FactoryGirl.build(:ontology,
+            parent: built_ontology,
+            repository: built_ontology.repository,
+            basepath: built_ontology.basepath,
+            file_extension: built_ontology.file_extension)
+          built_ontology.children << FactoryGirl.build(:ontology,
+            parent: built_ontology,
+            repository: built_ontology.repository,
+            basepath: built_ontology.basepath,
+            file_extension: built_ontology.file_extension)
         end
       end
 

--- a/spec/models/ontology_spec.rb
+++ b/spec/models/ontology_spec.rb
@@ -167,6 +167,16 @@ describe Ontology do
         end
       end
 
+      context 'with sibling imported by an onology in a different repository' do
+        let(:importing) { create :ontology }
+        before { create :import_mapping, target: importing, source: sibling_ontology }
+
+        it 'should not be allowed' do
+          expect { ontology.destroy_with_parent(user) }.
+            to raise_error(Ontology::DeleteError)
+        end
+      end
+
       context 'imported by an onology in the same repository but another file' do
         let(:importing) { create :ontology, repository: ontology.repository }
         before { create :import_mapping, target: importing, source: ontology }

--- a/spec/models/ontology_spec.rb
+++ b/spec/models/ontology_spec.rb
@@ -98,7 +98,7 @@ describe Ontology do
     end
 
     context 'a single ontology in a distributed ontology' do
-      let(:distributed_ontology) { create :linked_distributed_ontology }
+      let(:distributed_ontology) { create :distributed_ontology, :with_children }
       let(:ontology) { distributed_ontology.children.first }
 
       before do
@@ -125,7 +125,7 @@ describe Ontology do
     end
 
     context 'a distributed ontology' do
-      let (:ontology) { create :linked_distributed_ontology }
+      let (:ontology) { create :distributed_ontology, :with_children }
 
       before do
         stub = ->(_u, _t, _m, &block) { block.call('0'*40) }
@@ -147,7 +147,7 @@ describe Ontology do
       end
     end
 
-    context 'an imported ontology' do
+    context 'an imported ontology (meaning any kind of mapping)' do
       let(:parent_ontology) { create :distributed_ontology, :with_children }
       let(:ontology) { parent_ontology.children.first }
       let(:sibling_ontology) { parent_ontology.children.last }
@@ -159,7 +159,7 @@ describe Ontology do
 
       context 'imported by an onology in a different repository' do
         let(:importing) { create :ontology }
-        before { create :import_mapping, target: importing, source: ontology }
+        before { create :mapping, target: importing, source: ontology }
 
         it 'should not be allowed' do
           expect { ontology.destroy_with_parent(user) }.
@@ -169,7 +169,7 @@ describe Ontology do
 
       context 'with sibling imported by an onology in a different repository' do
         let(:importing) { create :ontology }
-        before { create :import_mapping, target: importing, source: sibling_ontology }
+        before { create :mapping, target: importing, source: sibling_ontology }
 
         it 'should not be allowed' do
           expect { ontology.destroy_with_parent(user) }.
@@ -179,7 +179,7 @@ describe Ontology do
 
       context 'imported by an onology in the same repository but another file' do
         let(:importing) { create :ontology, repository: ontology.repository }
-        before { create :import_mapping, target: importing, source: ontology }
+        before { create :mapping, target: importing, source: ontology }
 
         it 'should not be allowed' do
           expect { ontology.destroy_with_parent(user) }.
@@ -189,7 +189,7 @@ describe Ontology do
 
       context 'imported by an onology in the same file' do
         let(:importing) { sibling_ontology }
-        before { create :import_mapping, target: importing, source: ontology }
+        before { create :mapping, target: importing, source: ontology }
 
         it 'should be allowed' do
           expect { ontology.destroy_with_parent(user) }.to_not raise_error

--- a/spec/models/ontology_spec.rb
+++ b/spec/models/ontology_spec.rb
@@ -98,7 +98,9 @@ describe Ontology do
     end
 
     context 'a single ontology in a distributed ontology' do
-      let(:distributed_ontology) { create :distributed_ontology, :with_children }
+      let(:distributed_ontology) do
+        create :distributed_ontology, :with_children
+      end
       let(:ontology) { distributed_ontology.children.first }
 
       before do
@@ -125,7 +127,7 @@ describe Ontology do
     end
 
     context 'a distributed ontology' do
-      let (:ontology) { create :distributed_ontology, :with_children }
+      let(:ontology) { create :distributed_ontology, :with_children }
 
       before do
         stub = ->(_u, _t, _m, &block) { block.call('0'*40) }


### PR DESCRIPTION
This shall fix #1251.

--

~~The branch of this pull request is **not based on staging**, but on the one of #1556 (`167-creating_a_new_ontology_version_needs_to_be_propagated`). Revieweing that one first may be easier.~~

~~The first commit of this branch is~~
~~c299dbe Allow to delete an ontology if it is only imported from the same file.~~