### PR TITLE
1084 dont allow selection of private readable repository mode

### DIFF
--- a/app/assets/javascripts/repository/edit_remote.js.coffee
+++ b/app/assets/javascripts/repository/edit_remote.js.coffee
@@ -1,16 +1,21 @@
 $ ->
   if $('#repository_form').length > 0
-    mirror_option        = (o)     -> o.value.search(/_rw/) == -1
-    to_mirror_option     = (value) -> value.split("_")[0] + "_r"
-    to_non_mirror_option = (value) -> value
 
-    input_access_el    = $('#repository_form #repository_access')[0]
-    source_address_el  = $('#repository_form #repository_source_address')
-    options_all        = input_access_el.options
-    options_non_mirror = _.clone(options_all)
-    options_mirror     = _.filter(options_all, mirror_option)
+    to_mirror_option = (previous_option) ->
+      previous_option.split("_")[0] + "_r"
 
-    type_el = $($('#repository_form #remote_type')[0])
+    to_non_mirror_option = (previous_option) ->
+      if previous_option.split('_')[0] == 'public'
+        previous_option
+      else
+        'private_rw'
+
+    input_access_el    = $('#repository_access')[0]
+    source_address_el  = $('#repository_source_address')
+    options_non_mirror = _.clone($('#access_options_non_mirror')[0].options)
+    options_mirror     = _.clone($('#access_options_mirror')[0].options)
+
+    type_el = $($('#remote_type')[0])
 
     # If options are not set one by one, the select box wont change.
     set_options = (options, converter, last_value) ->

--- a/app/assets/javascripts/repository/edit_remote.js.coffee
+++ b/app/assets/javascripts/repository/edit_remote.js.coffee
@@ -34,20 +34,20 @@ $ ->
       else
         set_options(options_non_mirror, to_non_mirror_option, last_value)
 
-    is_mirror_selected = () ->
+    is_mirror_selected = ->
       remote_type_mirror_el.is(':checked')
 
-    is_source_address_set = () ->
+    is_source_address_set = ->
       source_address_el.val().trim().length > 0
 
     was_mirror_selected = is_mirror_selected()
 
     was_source_address_set = is_source_address_set()
 
-    reset_mirror_selected = () ->
+    reset_mirror_selected = ->
       was_mirror_selected = is_mirror_selected()
 
-    reset_was_source_address_set = () ->
+    reset_was_source_address_set = ->
       was_source_address_set = is_source_address_set()
 
     change_options = (event) ->

--- a/app/assets/javascripts/repository/edit_remote.js.coffee
+++ b/app/assets/javascripts/repository/edit_remote.js.coffee
@@ -12,6 +12,9 @@ $ ->
 
     input_access_el    = $('#repository_access')[0]
     source_address_el  = $('#repository_source_address')
+    remote_type_els    = $('input[name="repository[remote_type]"]')
+    remote_type_mirror_el = $('#repository_remote_type_mirror')
+
     options_non_mirror = _.clone($('#access_options_non_mirror')[0].options)
     options_mirror     = _.clone($('#access_options_mirror')[0].options)
 
@@ -31,20 +34,28 @@ $ ->
       else
         set_options(options_non_mirror, to_non_mirror_option, last_value)
 
+    is_mirror_selected = () ->
+      remote_type_mirror_el.is(':checked')
+
     is_source_address_set = () ->
       source_address_el.val().trim().length > 0
 
+    was_mirror_selected = is_mirror_selected()
+
     was_source_address_set = is_source_address_set()
+
+    reset_mirror_selected = () ->
+      was_mirror_selected = is_mirror_selected()
 
     reset_was_source_address_set = () ->
       was_source_address_set = is_source_address_set()
 
     change_options = (event) ->
-      if !was_source_address_set && is_source_address_set()
+      if !was_mirror_selected && is_mirror_selected()
         modify_access_list 'mirror'
-      else if was_source_address_set && !is_source_address_set()
+      else if was_mirror_selected && !is_mirror_selected()
         modify_access_list 'non_mirror'
-      else if !was_source_address_set && !is_source_address_set()
+      else if !was_mirror_selected && !is_mirror_selected()
         modify_access_list 'non_mirror'
 
     change_type_display = (event) ->
@@ -60,7 +71,9 @@ $ ->
     change_options()
     change_type_display()
 
-    source_address_el.on('input', change_options)
     source_address_el.on('input', change_type_display)
     source_address_el.on('input', reset_was_source_address_set)
+    _.each(remote_type_els, (el) ->
+      $(el).on('click', change_options)
+    )
   return

--- a/app/assets/javascripts/repository/edit_remote.js.coffee
+++ b/app/assets/javascripts/repository/edit_remote.js.coffee
@@ -34,28 +34,28 @@ $ ->
       else
         set_options(options_non_mirror, to_non_mirror_option, last_value)
 
+    is_mirror_active = ->
+      is_mirror_selected() && is_source_address_set()
+
     is_mirror_selected = ->
       remote_type_mirror_el.is(':checked')
 
     is_source_address_set = ->
       source_address_el.val().trim().length > 0
 
-    was_mirror_selected = is_mirror_selected()
+    was_mirror_active = is_mirror_selected()
 
     was_source_address_set = is_source_address_set()
-
-    reset_mirror_selected = ->
-      was_mirror_selected = is_mirror_selected()
 
     reset_was_source_address_set = ->
       was_source_address_set = is_source_address_set()
 
     change_options = (event) ->
-      if !was_mirror_selected && is_mirror_selected()
+      if !was_mirror_active && is_mirror_active()
         modify_access_list 'mirror'
-      else if was_mirror_selected && !is_mirror_selected()
+      else if was_mirror_active && !is_mirror_active()
         modify_access_list 'non_mirror'
-      else if !was_mirror_selected && !is_mirror_selected()
+      else if !was_mirror_active && !is_mirror_active()
         modify_access_list 'non_mirror'
 
     change_type_display = (event) ->
@@ -73,6 +73,7 @@ $ ->
 
     source_address_el.on('input', change_type_display)
     source_address_el.on('input', reset_was_source_address_set)
+    source_address_el.on('input', change_options)
     _.each(remote_type_els, (el) ->
       $(el).on('click', change_options)
     )

--- a/app/helpers/repositories_helper.rb
+++ b/app/helpers/repositories_helper.rb
@@ -34,13 +34,11 @@ module RepositoriesHelper
   end
 
   def access_options
-    t('repository.access.options').select do |k,v|
-      if @repository.mirror?
-        k.to_s.split('_')[1] == 'r'
-      else
-        true
-      end
-    end.invert
+    t('repository.access.options').invert
+  end
+
+  def access_options_mirror
+    t('repository.access.options_mirror').invert
   end
 
   def repository_modal_body

--- a/app/models/repository/access.rb
+++ b/app/models/repository/access.rb
@@ -1,7 +1,8 @@
 module Repository::Access
   extend ActiveSupport::Concern
 
-  OPTIONS = %w[public_r public_rw private_r private_rw]
+  OPTIONS = %w[public_r public_rw private_rw]
+  OPTIONS_MIRROR = %w[public_r private_r]
   DEFAULT_OPTION = OPTIONS[0]
 
   def self.as_read_only(access)

--- a/app/models/repository/access.rb
+++ b/app/models/repository/access.rb
@@ -1,8 +1,8 @@
 module Repository::Access
   extend ActiveSupport::Concern
 
-  OPTIONS = %w[public_r public_rw private_rw]
-  OPTIONS_MIRROR = %w[public_r private_r]
+  OPTIONS = %w(public_r public_rw private_rw)
+  OPTIONS_MIRROR = %w(public_r private_r)
   DEFAULT_OPTION = OPTIONS[0]
 
   def self.as_read_only(access)

--- a/app/models/repository/importing.rb
+++ b/app/models/repository/importing.rb
@@ -30,6 +30,10 @@ module Repository::Importing
     remote_type == 'fork'
   end
 
+  def remote?
+    REMOTE_TYPES.include?(remote_type)
+  end
+
   def convert_to_local!
     self.remote_type = 'fork'
     save!

--- a/app/models/repository/validations.rb
+++ b/app/models/repository/validations.rb
@@ -24,19 +24,14 @@ module Repository::Validations
     validates :remote_type, presence: true, if: :source_address?
     validates_with RemoteTypeValidator
 
-    validates_with RemoteAccessValidator
     validates :access,
       presence: true,
-      inclusion: {in: Repository::Access::OPTIONS}
-  end
-
-  class RemoteAccessValidator < ActiveModel::Validator
-    def validate(record)
-      if record.mirror? && (record.private_rw? || record.public_rw?)
-        record.errors[:access] =
-          'Error! Write access is not allowed for a mirrored repositry.'
-      end
-    end
+      inclusion: {in: Repository::Access::OPTIONS},
+      unless: :mirror?
+    validates :access,
+      presence: true,
+      inclusion: {in: Repository::Access::OPTIONS_MIRROR},
+      if: :mirror?
   end
 
   class UnreservedValidator < ActiveModel::Validator

--- a/app/models/repository/validations.rb
+++ b/app/models/repository/validations.rb
@@ -113,9 +113,10 @@ module Repository::Validations
 
   class SourceTypeValidator < ActiveModel::Validator
     def validate(record)
-      if record.mirror? && !record.source_type.present?
+      if record.remote? && !record.source_type.present?
         record.errors[:source_address] = 'not a valid remote repository '\
-          "or not accessible (types supported: #{SOURCE_TYPES.join(', ')})"
+          'or not accessible '\
+          "(types supported: #{Repository::SOURCE_TYPES.join(', ')})"
         record.errors[:source_type] = 'not present'
       end
     end

--- a/app/views/repositories/_form.html.haml
+++ b/app/views/repositories/_form.html.haml
@@ -1,10 +1,6 @@
 = simple_form_for resource, html: {class: 'form-horizontal', id: 'repository_form' } do |f|
   = f.input :name, input_html: { class: 'input-xlarge' }, required: true, disabled: resource.persisted?, as: :string
   = f.input :description, input_html: { rows: 8 }
-  = f.input :access, collection: resource.mirror? ? access_options_mirror : access_options, include_blank: false, hint: access_change_hint
-  .access-options.hide
-    = select_tag :access_options_non_mirror, options_for_select(access_options)
-    = select_tag :access_options_mirror, options_for_select(access_options_mirror)
 
   - if resource.new_record?
     = f.input :source_address, as: :url
@@ -18,5 +14,10 @@
       .col-lg-10
         = check_box_tag :un_mirror
         = t 'repository.un_mirror.text'
+
+  = f.input :access, collection: resource.mirror? ? access_options_mirror : access_options, include_blank: false, hint: access_change_hint
+  .access-options.hide
+    = select_tag :access_options_non_mirror, options_for_select(access_options)
+    = select_tag :access_options_mirror, options_for_select(access_options_mirror)
 
   = f.button :wrapped

--- a/app/views/repositories/_form.html.haml
+++ b/app/views/repositories/_form.html.haml
@@ -1,7 +1,10 @@
 = simple_form_for resource, html: {class: 'form-horizontal', id: 'repository_form' } do |f|
   = f.input :name, input_html: { class: 'input-xlarge' }, required: true, disabled: resource.persisted?, as: :string
   = f.input :description, input_html: { rows: 8 }
-  = f.input :access, collection: access_options, include_blank: false, hint: access_change_hint
+  = f.input :access, collection: resource.mirror? ? access_options_mirror : access_options, include_blank: false, hint: access_change_hint
+  .access-options.hide
+    = select_tag :access_options_non_mirror, options_for_select(access_options)
+    = select_tag :access_options_mirror, options_for_select(access_options_mirror)
 
   - if resource.new_record?
     = f.input :source_address, as: :url

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,10 +63,12 @@ en:
     access:
       change_hint: 'Caution! When setting the repository public, all reader permissions are removed.'
       options:
-        private_r: Privately readable, not writable at all
         private_rw: Privately readable, privately writable
         public_r: Publicly readable, privately writable
         public_rw: Publicly readable, publicly writable
+      options_mirror:
+        private_r: Privately readable, not writable at all
+        public_r: Publicly readable, not writable at all
     remote_type:
       text: A mirror will be synchronized periodically. A fork is just a one-time copy.
     un_mirror:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,7 +70,9 @@ en:
         private_r: Privately readable, not writable at all
         public_r: Publicly readable, not writable at all
     remote_type:
-      text: A mirror will be synchronized periodically. A fork is just a one-time copy.
+      text:
+        Changing this value may change the access as well.
+        A mirror will be synchronized periodically. A fork is just a one-time copy.
     un_mirror:
       label: Un-mirror
       text: If you un-mirror this repository, it won't get synchronized with the remote reposoitory any more. There is no possibility to synchronize it ever again.

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -172,10 +172,10 @@ describe Ability do
     end
   end
 
-  context 'Private read-only Repository' do
-    let(:editor){ create :user } # editor
-    let(:reader){ create :user } # reader
-    let(:item){   create(:repository, access: 'private_r', user: owner) }
+  context 'Private Repository' do
+    let(:editor) { create :user } # editor
+    let(:reader) { create :user } # reader
+    let(:item) { create(:repository, access: 'private_rw', user: owner) }
 
     before do
       create(:permission, subject: editor, role: 'editor', item: item)
@@ -192,29 +192,39 @@ describe Ability do
       end
     end
 
-    context 'reader, editor, owner' do
+    context 'reader' do
       it 'not be allowed: to write' do
-        [reader, editor, owner].each do |role|
-          Ability.new(role, nil).should_not be_able_to(:write, item)
+        expect(Ability.new(reader, nil)).to_not be_able_to(:write, item)
+      end
+
+      it 'be allowed: to read' do
+        expect(Ability.new(reader, nil)).to be_able_to(:show, item)
+      end
+    end
+
+    context 'editor, owner' do
+      it 'be allowed: to write' do
+        [editor, owner].each do |role|
+          expect(Ability.new(role, nil)).to be_able_to(:write, item)
         end
       end
 
       it 'be allowed: to read' do
-        [reader, editor, owner].each do |role|
-          Ability.new(role, nil).should be_able_to(:show, item)
+        [editor, owner].each do |role|
+          expect(Ability.new(role, nil)).to be_able_to(:show, item)
         end
       end
     end
 
     context 'update:' do
-      it 'reader, editor should be allowed' do
+      it 'reader, editor should not be allowed' do
         [reader, editor].each do |role|
-          Ability.new(role, nil).should_not be_able_to(:update, item)
+          expect(Ability.new(role, nil)).to_not be_able_to(:update, item)
         end
       end
 
-      it 'owner should not be allowed' do
-        Ability.new(owner, nil).should be_able_to(:update, item)
+      it 'owner should be allowed' do
+        expect(Ability.new(owner, nil)).to be_able_to(:update, item)
       end
     end
   end

--- a/spec/models/repository/access_spec.rb
+++ b/spec/models/repository/access_spec.rb
@@ -7,8 +7,6 @@ describe 'Repository Access' do
       access: 'public_r' }
     let!(:repository_pub_rw)  { create :repository, user: user,
       access: 'public_rw' }
-    let!(:repository_priv_r)  { create :repository, user: user,
-      access: 'private_r' }
     let!(:repository_priv_rw) { create :repository, user: user,
       access: 'private_rw' }
 


### PR DESCRIPTION
This shall fix #1084. By splitting the access options into two hashes, we can disable `private_rw` for non-mirrors.