### PR TITLE
Add hound configs

### DIFF
--- a/.coffeescript-style.json
+++ b/.coffeescript-style.json
@@ -1,0 +1,98 @@
+{
+  "arrow_spacing": {
+    "level": "error"
+  },
+  "camel_case_classes": {
+    "level": "error"
+  },
+  "coffeescript_error": {
+    "level": "error"
+  },
+  "colon_assignment_spacing": {
+    "level": "error",
+    "spacing": {
+      "left": 0,
+      "right": 1
+    }
+  },
+  "cyclomatic_complexity": {
+    "level": "ignore",
+    "value": 10
+  },
+  "duplicate_key": {
+    "level": "error"
+  },
+  "empty_constructor_needs_parens": {
+    "level": "ignore"
+  },
+  "indentation": {
+    "level": "error",
+    "value": 2
+  },
+  "line_endings": {
+    "level": "ignore",
+    "value": "unix"
+  },
+  "max_line_length": {
+    "level": "error",
+    "value": 80
+  },
+  "missing_fat_arrows": {
+    "level": "ignore"
+  },
+  "newlines_after_classes": {
+    "level": "error",
+    "value": 1
+  },
+  "no_backticks": {
+    "level": "ignore"
+  },
+  "no_debugger": {
+    "level": "error"
+  },
+  "no_empty_functions": {
+    "level": "error"
+  },
+  "no_empty_param_list": {
+    "level": "error"
+  },
+  "no_implicit_braces": {
+    "level": "ignore"
+  },
+  "no_implicit_parens": {
+    "level": "ignore"
+  },
+  "no_interpolation_in_single_quotes": {
+    "level": "error"
+  },
+  "no_plusplus": {
+    "level": "ignore"
+  },
+  "no_stand_alone_at": {
+    "level": "error"
+  },
+  "no_tabs": {
+    "level": "error"
+  },
+  "no_throwing_strings": {
+    "level": "error"
+  },
+  "no_trailing_semicolons": {
+    "level": "error"
+  },
+  "no_trailing_whitespace": {
+    "level": "error"
+  },
+  "no_unnecessary_double_quotes": {
+    "level": "ignore"
+  },
+  "no_unnecessary_fat_arrows": {
+    "level": "error"
+  },
+  "non_empty_constructor_needs_parens": {
+    "level": "ignore"
+  },
+  "space_operators": {
+    "level": "ignore"
+  }
+}

--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -1,0 +1,70 @@
+# Whether to ignore frontmatter at the beginning of HAML documents for
+# frameworks such as Jekyll/Middleman
+skip_frontmatter: false
+
+linters:
+  AltText:
+    enabled: false
+
+  ClassAttributeWithStaticValue:
+    enabled: true
+
+  ClassesBeforeIds:
+    enabled: true
+
+  ConsecutiveComments:
+    enabled: true
+
+  ConsecutiveSilentScripts:
+    enabled: true
+    max_consecutive: 2
+
+  EmptyScript:
+    enabled: true
+
+  HtmlAttributes:
+    enabled: true
+
+  ImplicitDiv:
+    enabled: true
+
+  LeadingCommentSpace:
+    enabled: true
+
+  LineLength:
+    enabled: true
+    max: 80
+
+  MultilinePipe:
+    enabled: true
+
+  MultilineScript:
+    enabled: true
+
+  ObjectReferenceAttributes:
+    enabled: true
+
+  RuboCop:
+    enabled: false
+
+  RubyComments:
+    enabled: true
+
+  SpaceBeforeScript:
+    enabled: true
+
+  SpaceInsideHashAttributes:
+    enabled: true
+    style: space
+
+  TagName:
+    enabled: true
+
+  TrailingWhitespace:
+    enabled: true
+
+  UnnecessaryInterpolation:
+    enabled: true
+
+  UnnecessaryStringOutput:
+    enabled: true

--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -32,7 +32,7 @@ linters:
     enabled: true
 
   LineLength:
-    enabled: true
+    enabled: false
     max: 80
 
   MultilinePipe:

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,17 @@
 ShowCopNames: true
 
-inherit_from: .rubocop.yml
+ruby:
+  enabled: true
+  config_file: .rubocop.yml
+
+haml:
+  enabled: true
+  config_file: .haml-lint.yml
+
+coffeescript:
+  enabled: true
+  config_file: .coffeescript-style.json
+
+javascript:
+  enabled: true
+  config_file: .javascript-style.json

--- a/.javascript-style.json
+++ b/.javascript-style.json
@@ -1,0 +1,33 @@
+{
+  "asi": false,
+  "bitwise": true,
+  "browser": true,
+  "camelcase": true,
+  "curly": true,
+  "forin": true,
+  "immed": true,
+  "latedef": "nofunc",
+  "maxlen": 80,
+  "newcap": true,
+  "noarg": true,
+  "noempty": true,
+  "nonew": true,
+  "predef": [
+    "$",
+    "jQuery",
+
+    "jasmine",
+    "beforeEach",
+    "describe",
+    "expect",
+    "it",
+
+    "angular",
+    "inject",
+    "module"
+  ],
+  "quotmark": true,
+  "trailing": true,
+  "undef": true,
+  "unused": true
+}


### PR DESCRIPTION
This adds default and activates config files for the different linters that Hound uses.

The only change to the default configs that I made is to remove the limit of the line length for HAML.