### PR TITLE
Styleguide fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -334,6 +334,10 @@ Style/MultilineTernaryOperator:
                  use if/unless instead.
   Enabled: true
 
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+  Enabled: true
+
 Style/NegatedIf:
   Description: >-
                  Favor unless over if for negative conditions

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -160,6 +160,7 @@ Style/Documentation:
 
 Style/DotPosition:
   Description: 'Checks the position of the dot in multi-line method calls.'
+  EnforcedStyle: trailing
   Enabled: true
 
 Style/DoubleNegation:

--- a/script/stylecheck
+++ b/script/stylecheck
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-rubocop --rails $@
+rubocop --display-cop-names --rails $@


### PR DESCRIPTION
This fixes some issues with Hound. There are additional (more fine grained) config keys for rubocop that are configured here.

This is stalled until I fix some more configuration mistakes when going through Hound's comments in the other pull requests.