### PR TITLE
Sleep instead of waiting actively.

### DIFF
--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -17,6 +17,6 @@ namespace :elasticsearch do
     end
     Elasticsearch::Extensions::Test::Cluster.start timeout: timeout
 
-    loop {}
+    sleep
   end
 end


### PR DESCRIPTION
One CPU core was always at 100% because of waiting actively for an interrupt. With this change, the process is simply asleep forever.