### PR TITLE
Fix symbol parsing and code style

### DIFF
--- a/app/models/ontology/associations_and_attributes.rb
+++ b/app/models/ontology/associations_and_attributes.rb
@@ -16,6 +16,11 @@ module Ontology::AssociationsAndAttributes
       class_name: 'Mapping', foreign_key: 'target_id', dependent: :destroy
     has_many :tools
 
+    has_many :symbols,
+      autosave: false,
+      class_name: 'OntologyMember::Symbol',
+      extend:   Ontology::Symbols::Methods
+
     has_many :sentences,
       autosave: false,
       extend: Ontology::Sentences::Methods

--- a/app/models/ontology/sentences.rb
+++ b/app/models/ontology/sentences.rb
@@ -149,15 +149,15 @@ class Ontology
       private
 
       def set_theorem_attributes(theorem, hash)
-          theorem.provable = hash['status'] == 'open'
-          if hash['status'] == 'proven'
-            status_id = ProofStatus::DEFAULT_PROVEN_STATUS
-            theorem.state = 'done'
-          else
-            status_id = ProofStatus::DEFAULT_OPEN_STATUS
-            theorem.state = 'not_started_yet'
-          end
-          theorem.proof_status = ProofStatus.find(status_id)
+        theorem.provable = hash['status'] == 'open'
+        if hash['status'] == 'proven'
+          status_id = ProofStatus::DEFAULT_PROVEN_STATUS
+          theorem.state = 'done'
+        else
+          status_id = ProofStatus::DEFAULT_OPEN_STATUS
+          theorem.state = 'not_started_yet'
+        end
+        theorem.proof_status = ProofStatus.find(status_id)
       end
 
     end

--- a/app/models/ontology/symbols.rb
+++ b/app/models/ontology/symbols.rb
@@ -2,13 +2,6 @@ class Ontology
   module Symbols
     extend ActiveSupport::Concern
 
-    included do
-      has_many :symbols,
-        autosave: false,
-        class_name: 'OntologyMember::Symbol',
-        extend:   Methods
-    end
-
     module Methods
       def update_or_create_from_hash(hash, timestamp = Time.now)
         raise ArgumentError, 'No hash given.' unless hash.is_a? Hash

--- a/app/models/ontology/symbols.rb
+++ b/app/models/ontology/symbols.rb
@@ -58,7 +58,9 @@ class Ontology
           e.range = e.range.split(':', 2).last
         end
 
+        e.ontology.symbols << e if e.id.nil?
         e.save!
+        e
       end
     end
 


### PR DESCRIPTION
This fixes three little issues:
* **During** parsing, `ontology.symbols` was empty, even if there are symbols. This made parsing callbacks that depend on this association fail.
* The method `update_or_create_from_hash` is supposed to return the symbol, but it returned a boolean.
* Code style: Indentation and the place of the association definition were wrong.

I add no test because this only affects the parsing code. I would need to intercept the parsing and then test internals (which is bad style). The effect will be tested implicitly by #1600.