### PR TITLE
1602 add a sidekiq queue for migrations

### DIFF
--- a/config/processes/app.eye
+++ b/config/processes/app.eye
@@ -21,7 +21,9 @@ Eye.application :ontohub do
   FileUtils.mkdir_p(env['PID_DIR'])
 
   group :sidekiq do
-    sidekiq_process self, :"sidekiq-hets", 'hets', hets_queue_thread_count
+    # Use a second queue for migration jobs which is checked less frequently.
+    sidekiq_process self, :"sidekiq-hets", ['hets,5', 'hets-migration,1'],
+                    hets_queue_thread_count
 
     # one worker for hets load balancing
     sidekiq_process self, :'sidekiq-hets-load-balancing', 'hets_load_balancing', 1


### PR DESCRIPTION
This shall fix #1602.

It also makes a few more changes to the sidekiq queues:
The number of worker processes is reduced drastically to reduce memory consumption. Each worker process loads the entire application into memory, just like the rails server.
* Instead of having one worker for each hets instance, we now have a single worker for all hets tasks with as many threads as there are hets instances
* The three queues for hets tasks `priority_push`, `hets`, `hets-migrate` are managed by the same sidekiq worker process, but with different prioritizations (see the weights in the code).
* The `hets_load_balancing` queue is now managed by the same worker process as the default queue. We don't need special treatment for load balancing.


This is deployed on develop.ontohub.org.