### PR TITLE
Quick fix #1593.

### DIFF
--- a/app/models/ontology_version/parsing.rb
+++ b/app/models/ontology_version/parsing.rb
@@ -71,7 +71,8 @@ module OntologyVersion::Parsing
     retrieve_available_provers
     if ontology.distributed?
       ontology.children.each do |child|
-        child.versions.find_by_commit_oid(commit_oid).retrieve_available_provers
+        child.versions.find_by_commit_oid(commit_oid).
+          try(:retrieve_available_provers)
       end
     end
   end


### PR DESCRIPTION
This shall fix #1593 in a quick and dirty way to prevent HTTP 5xx errors on ontohub.org.

This is going to be reverted as soon as a proper fix is implemented (which is very complicated).