### PR TITLE
1591 child ontologies are indefinitely pending

### DIFF
--- a/app/models/ontology_version/parsing.rb
+++ b/app/models/ontology_version/parsing.rb
@@ -41,7 +41,11 @@ module OntologyVersion::Parsing
       ontology.import_version(self, self.user, input_io)
       retrieve_available_provers_for_self_and_children
 
-      update_state! :done
+      update_state!(:done)
+      ontology.children.each do |child|
+        child.versions.where(commit_oid: commit_oid).first.update_state!(:done)
+        child.versions.where(commit_oid: commit_oid).first.save!
+      end
     end
 
     files_to_parse_afterwards.each do |path|

--- a/app/models/ontology_version/states.rb
+++ b/app/models/ontology_version/states.rb
@@ -45,11 +45,10 @@ module OntologyVersion::States
   protected
 
   def after_update_state
-    ontology.state = state.to_s
+    ontology.state = state
     ontology.save!
     if ontology.distributed?
-      ontology.children.update_all state: ontology.state
+      ontology.children.update_all(state: ontology.state)
     end
   end
-
 end

--- a/spec/models/ontology_spec.rb
+++ b/spec/models/ontology_spec.rb
@@ -467,6 +467,10 @@ describe Ontology do
       parse_ontology(user, ontology, 'casl/test2.casl')
     end
 
+    it "should have state 'done'" do
+      expect(ontology.state).to eq('done')
+    end
+
     it 'should create all single ontologies' do
       expect(SingleOntology.count).to eq(4)
     end

--- a/spec/models/ontology_spec.rb
+++ b/spec/models/ontology_spec.rb
@@ -505,12 +505,11 @@ describe Ontology do
 
     context 'all child ontologies' do
       it 'should have the same state as the parent' do
-        ontology.children.each do |child|
+        ontology.reload.children.each do |child|
           expect(child.state).to eq(ontology.state)
         end
       end
     end
-
   end
 
   context 'Import another distributed Ontology' do


### PR DESCRIPTION
This shall fix #1591.

Most of the changed lines are just fixing test behaviour. Before, we did not just stub the Hets-API call, but the whole parsing process. The last commit fixes this issue by only stubbing Hets and still running the whole rest of the parsing pipeline.