### PR TITLE
1633 add edit and show buttons to ontology versions

### DIFF
--- a/app/assets/javascripts/codemirror-custom.js.coffee
+++ b/app/assets/javascripts/codemirror-custom.js.coffee
@@ -96,5 +96,5 @@ $ ->
     btn_edit.unbind("click").click enableEditing
 
     if window.location.hash == '#edit'
-      enableEditing(new MouseEvent('click'))
+      enableEditing($.Event("click"))
   return

--- a/app/assets/javascripts/codemirror-custom.js.coffee
+++ b/app/assets/javascripts/codemirror-custom.js.coffee
@@ -95,4 +95,6 @@ $ ->
     editorPreventFocus()
     btn_edit.unbind("click").click enableEditing
 
+    if window.location.hash == '#edit'
+      enableEditing(new MouseEvent('click'))
   return

--- a/app/controllers/path_helpers.rb
+++ b/app/controllers/path_helpers.rb
@@ -12,7 +12,7 @@ module PathHelpers
   def fancy_repository_path(repository, args)
     args ||= {}
     action = args[:action] || :show
-    if !in_ref_path? && action == :show
+    if !in_ref_path? && action == :show && !args[:exact_commit]
       repository_tree_path repository, path: args[:path]
     else
       repository_ref_path repository_id: repository, ref: args[:ref], action: action, path: args[:path]

--- a/app/helpers/ontology_version_helper.rb
+++ b/app/helpers/ontology_version_helper.rb
@@ -1,0 +1,29 @@
+module OntologyVersionHelper
+  def failed?(ontology_version)
+    ontology_version.state == 'failed'
+  end
+
+  def can_edit?(ontology_version)
+    can?(:write, ontology_version.repository) &&
+      failed?(ontology_version) &&
+      ontology_version.latest_version?
+  end
+
+  def btn_url(ontology_version)
+    fancy_repository_path(resource_chain[0],
+                          path: ontology_version.path,
+                          ref: ontology_version.commit_oid,
+                          action: :show,
+                          exact_commit: !ontology_version.latest_version?)
+  end
+
+  def edit_or_view_button(ontology_version)
+    editable = can_edit?(ontology_version)
+    btn_text = editable ? 'Edit' : 'View'
+    anchor = editable ? '#edit' : ''
+
+    link_to btn_text,
+            btn_url(ontology_version) + anchor,
+            class: 'btn btn-xs btn-default'
+  end
+end

--- a/app/models/ontology_version.rb
+++ b/app/models/ontology_version.rb
@@ -75,6 +75,10 @@ class OntologyVersion < ActiveRecord::Base
 
   alias_method :versioned_locid, :locid
 
+  def latest_version?
+    ontology.versions.last == self
+  end
+
   protected
 
   def raw_file_size_maximum

--- a/app/views/ontology_versions/_ontology_version.html.haml
+++ b/app/views/ontology_versions/_ontology_version.html.haml
@@ -4,4 +4,6 @@
   %td= timestamp ontology_version
   %td= ontology_version.user ? fancy_link(ontology_version.user) : '-'
   %td= render partial: 'shared/state_tag', locals: {resource: ontology_version}
-  %td= link_to 'Download', fancy_repository_path(resource_chain[0], path: ontology_version.path, ref: ontology_version.commit_oid, action: :download), class: 'btn btn-xs btn-default'
+  %td
+    = link_to 'Download', fancy_repository_path(resource_chain[0], path: ontology_version.path, ref: ontology_version.commit_oid, action: :download), class: 'btn btn-xs btn-default'
+    = edit_or_view_button(ontology_version)

--- a/app/views/ontology_versions/index.html.haml
+++ b/app/views/ontology_versions/index.html.haml
@@ -5,7 +5,7 @@
 .pull-right
   = link_to 'Show File history', fancy_repository_path(parent.repository, path: parent.path, ref: 'master', action: :history), class: 'btn btn-default'
 
-%table
+%table#ontology_versions
   %thead
     %tr
       %th Number

--- a/features/OntologyVersions.feature
+++ b/features/OntologyVersions.feature
@@ -18,7 +18,7 @@ Scenario: Displaying an edit button on the latest ontology if it is failed with 
   And I am logged in
   And there is an ontology with a "failed" version
   And I have permissions to edit the ontology
-  And there is a ontology file
+  And there is an ontology file
   When I visit the versions tab of the ontology
   And I should see a "Edit" button for the latest version
   And I should see a "View" button for every other version

--- a/features/OntologyVersions.feature
+++ b/features/OntologyVersions.feature
@@ -6,3 +6,30 @@ Scenario: When displaying the versions of a Single in Distributed
   When i visit the versions tab of a child ontology
   Then i should see the corresponding versions
 
+Scenario: Displaying view buttons on ontology versions without repository permission
+  Given there is an ontology
+  When I visit the versions tab of the ontology
+  Then I should see a "View" button for each version
+  And I shouldn't see a "Edit" button for each version
+
+@javascript
+Scenario: Displaying an edit button on the latest ontology if it is failed with repository permission
+  Given I have an account
+  And I am logged in
+  And there is an ontology with a "failed" version
+  And I have permissions to edit the ontology
+  When I visit the versions tab of the ontology
+  And I should see a "Edit" button for the latest version
+  And I should see a "View" button for every other version
+  And I click the edit button
+  Then I should see edit page of the ontology
+
+Scenario: Don't display an edit button if the failed version is not the latest one
+  Given I have an account
+  And I am logged in
+  And there is an ontology with a "failed" version
+  And there is a newer "done" version
+  And I have permissions to edit the ontology
+  When I visit the versions tab of the ontology
+  Then I should see a "View" button for each version
+  And I shouldn't see a "Edit" button for each version

--- a/features/OntologyVersions.feature
+++ b/features/OntologyVersions.feature
@@ -18,6 +18,7 @@ Scenario: Displaying an edit button on the latest ontology if it is failed with 
   And I am logged in
   And there is an ontology with a "failed" version
   And I have permissions to edit the ontology
+  And there is a ontology file
   When I visit the versions tab of the ontology
   And I should see a "Edit" button for the latest version
   And I should see a "View" button for every other version

--- a/features/step_definitions/ontology_versions_steps.rb
+++ b/features/step_definitions/ontology_versions_steps.rb
@@ -14,3 +14,60 @@ Then(/^i should see the corresponding versions$/) do
   selector = %(.evaluation-state[data-id="#{id}"][data-klass="OntologyVersion"])
   expect(page).to have_css(selector)
 end
+
+When(/^I visit the versions tab of the ontology$/) do
+  visit repository_ontology_ontology_versions_path(@ontology.repository, @ontology)
+end
+
+Then(/^I should see a "(.*?)" button for each version$/) do |text|
+  within(:css, '#ontology_versions') do
+    all(:css, 'tbody > tr').each do |row|
+      expect(row).to have_link(text)
+    end
+  end
+end
+
+Then(/^I shouldn't see a "(.*?)" button for each version$/) do |text|
+  within(:css, '#ontology_versions') do
+    all(:css, 'tbody > tr').each do |row|
+      expect(row).not_to have_link(text)
+    end
+  end
+end
+
+Given(/^I have an account$/) do
+  @user = FactoryGirl.create :user
+end
+
+Given(/^I have permissions to edit the ontology$/) do
+  perm = FactoryGirl.create :permission, subject: @user, item: @ontology.repository
+end
+
+Then(/^I should see a "(.*?)" button for the latest version$/) do |text|
+  within(:css, '#ontology_versions') do
+    @edit_button = first(:css, 'tbody > tr').find_link(text)
+    expect(first(:css, 'tbody > tr')).to have_link(text)
+  end
+end
+
+Then(/^I should see a "(.*?)" button for every other version$/) do |text|
+  within(:css, '#ontology_versions') do
+    all(:css, 'tbody > tr:nth-of-type(n+2)').each do |row|
+      expect(row).to have_link(text)
+    end
+  end
+end
+
+Given(/^there is a newer "(.*?)" version$/) do |state|
+  @ontology_version = FactoryGirl.create :ontology_version, state: state, ontology: @ontology
+  @ontology.state = state
+  @ontology.save!
+end
+
+When(/^I click the edit button$/) do
+  @edit_button.click
+end
+
+Then(/^I should see edit page of the ontology$/) do
+  expect(page).to have_content('Edit mode')
+end

--- a/features/step_definitions/ontology_versions_steps.rb
+++ b/features/step_definitions/ontology_versions_steps.rb
@@ -3,6 +3,14 @@ Given(/^there is a distributed ontology$/) do
   @ontology = @distributed_ontology
 end
 
+Given(/^there is a ontology file$/) do
+  repository = @ontology.repository
+  user = repository.permissions.first.subject
+  Tempfile.create('testfile') do |f|
+    repository.save_file_only(f.path, @ontology.path, 'add ontology file', user)
+  end
+end
+
 When(/^i visit the versions tab of a child ontology$/) do
   @ontology = @distributed_ontology.children.first
 

--- a/features/step_definitions/ontology_versions_steps.rb
+++ b/features/step_definitions/ontology_versions_steps.rb
@@ -3,7 +3,7 @@ Given(/^there is a distributed ontology$/) do
   @ontology = @distributed_ontology
 end
 
-Given(/^there is a ontology file$/) do
+Given(/^there is an ontology file$/) do
   repository = @ontology.repository
   user = repository.permissions.first.subject
   Tempfile.create('testfile') do |f|


### PR DESCRIPTION
This fixes #1633. Adds edit and show buttons to ontology versions depending on the following factors:

- failed latest version when having write access: edit button
- else: view button to file version at that point