### PR TITLE
1610 offline hetsinstances get chosen and raise errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,7 @@ gem 'sidekiq', '~> 3.5.3'
 # The ref is given to ensure that no other (possibly breaking) changes are taken.
 gem 'sidetiq', github: 'PaulMest/sidetiq', ref: 'd88f9e483affcbadbd9e8b98b4a0a9518933887a'
 gem 'sidekiq-failures', '~> 0.4.5'
+gem 'sidekiq-retries', '~> 0.4.0'
 gem 'sidekiq-status', '~> 0.6.0'
 gem 'sinatra', '~> 1.4.5', require: false, group: [:development, :production]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -494,6 +494,8 @@ GEM
       redis-namespace (~> 1.5, >= 1.5.2)
     sidekiq-failures (0.4.5)
       sidekiq (>= 2.16.0)
+    sidekiq-retries (0.4.0)
+      sidekiq (>= 3.2.4)
     sidekiq-status (0.6.0)
       sidekiq (>= 2.7)
     sigar (0.7.3)
@@ -649,6 +651,7 @@ DEPENDENCIES
   shoulda_routing_macros (~> 0.1.2)
   sidekiq (~> 3.5.3)
   sidekiq-failures (~> 0.4.5)
+  sidekiq-retries (~> 0.4.0)
   sidekiq-status (~> 0.6.0)
   sidetiq!
   simple_form (~> 2.1)
@@ -665,4 +668,4 @@ DEPENDENCIES
   yard (~> 0.8.7.6)
 
 BUNDLED WITH
-   1.11.2
+   1.12.1

--- a/app/models/hets_instance.rb
+++ b/app/models/hets_instance.rb
@@ -25,7 +25,7 @@ has a minimal Hets version of #{Hets.minimal_version_string}
 
   attr_accessible :name, :uri, :state, :queue_size
 
-  before_save :set_up_state, unless: Proc.new { |h| h.changed_attributes.key?("up") }
+  before_save :set_up_state, unless: ->() { changed_attributes.key?("up") }
   before_save :set_state_updated_at
   after_create :start_update_clock
 
@@ -143,11 +143,9 @@ has a minimal Hets version of #{Hets.minimal_version_string}
   end
 
   def check_up_state
-    begin
-      Hets::VersionCaller.new(self).call
-    rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::ECONNRESET
-      nil
-    end
+    Hets::VersionCaller.new(self).call
+  rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::ECONNRESET
+    nil
   end
 
   def set_up_state

--- a/app/models/hets_instance.rb
+++ b/app/models/hets_instance.rb
@@ -147,7 +147,11 @@ has a minimal Hets version of #{Hets.minimal_version_string}
   end
 
   def set_up_state
-    version = check_up_state
+    begin
+      version = check_up_state
+    rescue
+      version = nil
+    end
     self.up = !! version
     self.version = version if up
   end

--- a/app/models/hets_instance.rb
+++ b/app/models/hets_instance.rb
@@ -25,7 +25,7 @@ has a minimal Hets version of #{Hets.minimal_version_string}
 
   attr_accessible :name, :uri, :state, :queue_size
 
-  before_save :set_up_state
+  before_save :set_up_state, unless: Proc.new { |h| h.changed_attributes.key?("up") }
   before_save :set_state_updated_at
   after_create :start_update_clock
 

--- a/app/models/ontology_version/parsing.rb
+++ b/app/models/ontology_version/parsing.rb
@@ -18,6 +18,10 @@ module OntologyVersion::Parsing
     if !@deactivate_parsing
       update_state! :pending
 
+      Sidekiq::RetrySet.new.each do |job|
+        job.kill if job.args.first == id
+      end
+
       if @fast_parse
         OntologyParsingWorker.perform_async(id, :parse_fast,
                                             files_to_parse_afterwards)


### PR DESCRIPTION
This PR closes #1610  and does four things:

- set the `up` flag on `HetsInstance`s correctly when not reachable, so that only online `HetsInstance`s are chosen
- show the correct error message when no `HetsInstance` is available (`There is no HetsInstance which is reachable and has a minimal Hets version of v0.99, 1439380563`)
- schedule a retry job for parsing an ontology for an hour later if no `HetsInstance` is available
- remove already scheduled retries for a specific version when the user hits the `Retry` button, so the same version is only parsed once (unless again there is no `HetsInstance` available, in which case another retry is scheduled)

To achieve the third point I added a new gem `sidekiq-retries` which offers the ability to skip retries or do retries although the max amount of retries has already run. In this case I used it to run a retry only when a certain exception (`HetsInstance::NoSelectableHetsInstanceError`) was thrown.