### PR TITLE
Fix test-unit load error.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,6 +131,10 @@ gem 'acts_as_relation', '~> 0.1.3'
 # Clean the database - especially needed in the seeds
 gem 'database_cleaner', '~> 1.5.1'
 
+
+# For unknown reasons, activesupport-3.2.22.2 requires test-unit, even in
+# production mode.
+gem 'test-unit', '~> 3.0'
 group :test do
   gem 'mocha', '~> 1.1.0', require: false
   gem 'shoulda', '~> 3.5.0'
@@ -158,8 +162,6 @@ group :test do
 
   # Writing test ontologies
   gem 'ontology-united', github: '0robustus1/ontology-united'
-
-  gem 'test-unit', '~> 3.0'
 end
 
 group :development do


### PR DESCRIPTION
Fix error:
```
/local/home/ontohub/ruby/2.2.0/gems/activesupport-3.2.22.2/lib/active_support/dependencies.rb:251:in `require': Please add test-unit gem to your Gemfile: `gem 'test-unit', '~> 3.0'` (cannot load such file -- test/unit/testcase) (LoadError)
```
This occurs when deploying on develop.ontohub.org