### PR TITLE
Fix deadlocks caused by semaphore.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,9 @@ gem 'rdf', '~> 1.99.0'
 gem 'rdf-rdfxml', '~> 1.99.0'
 gem 'rdf-n3', '~> 1.99.0'
 
-gem 'redis-semaphore', '~> 0.3.1'
+# As soon as the pull request https://github.com/dv/redis-semaphore/pull/46 is
+# merged and a new release is out, use the upstream gem again.
+gem 'redis-semaphore', github: 'eugenk/redis-semaphore', ref: '45-recognize_the_lock_state_of_multiple_semaphores_using_the_same_key'
 # Used for testing our locking mechanism Semaphore:
 gem 'fork_break', '~> 0.1.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,14 @@ GIT
       activesupport (>= 3.0)
 
 GIT
+  remote: git://github.com/eugenk/redis-semaphore.git
+  revision: 02bf7af7257d5df14a3b3add7cbf584208d53aca
+  ref: 45-recognize_the_lock_state_of_multiple_semaphores_using_the_same_key
+  specs:
+    redis-semaphore (0.3.1)
+      redis
+
+GIT
   remote: git://github.com/llwt/codemirror-rails.git
   revision: df5231e3053773e37b27f8181738c7080cd1c3cd
   specs:
@@ -449,8 +457,6 @@ GEM
     redis (3.3.0)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
-    redis-semaphore (0.3.1)
-      redis
     ref (2.0.0)
     responders (1.0.0)
       railties (>= 3.2, < 5)
@@ -654,7 +660,7 @@ DEPENDENCIES
   rdf-n3 (~> 1.99.0)
   rdf-rdfxml (~> 1.99.0)
   redcarpet (~> 3.3.2)
-  redis-semaphore (~> 0.3.1)
+  redis-semaphore!
   rest-client (~> 1.8.0)
   rspec-activemodel-mocks (~> 1.0.1)
   rspec-its (~> 1.0.1)


### PR DESCRIPTION
This shall fix #1729 and supersede #1730.

With my fork of the redis-semaphore gem, we can simply use the methods of the gem instead of implementing locking on top of it. There, the `locked?` method is fixed.