### PR TITLE
Add puma_worker_killer gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -195,6 +195,7 @@ group :production do
   # puma is __the only exception__ for which we don't specify a version.
   gem 'puma'
   gem 'eye', '~> 0.8'
+  gem 'puma_worker_killer', '~> 0.0.6'
   gem 'exception_notification', '~> 4.1.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,7 @@ GEM
     fork_break (0.1.4)
       fork (= 1.0.1)
     formatador (0.2.5)
+    get_process_mem (0.2.1)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     haml (4.0.7)
@@ -386,6 +387,9 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     puma (3.4.0)
+    puma_worker_killer (0.0.6)
+      get_process_mem (~> 0.2)
+      puma (>= 2.7, < 4)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.4.7)
@@ -644,6 +648,7 @@ DEPENDENCIES
   pry-rails (~> 0.3.2)
   pry-stack_explorer (~> 0.4.9.2)
   puma
+  puma_worker_killer (~> 0.0.6)
   quiet_assets (~> 1.1.0)
   rack-mini-profiler
   rack-protection (~> 1.5.3)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -19,6 +19,13 @@ quiet
 # IMPORTANT wrt. MRI ruby - saves rsources!
 preload_app!
 
+# Invoke rolling restart of workers to keep memory down
+before_fork do
+  require 'puma_worker_killer'
+
+  PumaWorkerKiller.enable_rolling_restart
+end
+
 # let's make sure, that ppl with the same GID as the running puma process
 # are really able to control puma (the group needs write access). See option
 # --control and --control-url above.


### PR DESCRIPTION
Adds the [puma worker killer](https://github.com/schneems/puma_worker_killer) gem to keep memory usage low.

Should be tested on develop before merging.