### PR TITLE
Index specific_* fields in loc_ids table

### DIFF
--- a/db/migrate/20160719104019_index_locid_specifics.rb
+++ b/db/migrate/20160719104019_index_locid_specifics.rb
@@ -1,0 +1,11 @@
+class IndexLocidSpecifics < ActiveRecord::Migration
+  def up
+    add_index :loc_ids, :specific_id
+    add_index :loc_ids, :specific_type
+  end
+
+  def down
+    remove_index :loc_ids, :specific_if
+    remove_index :loc_ids, :specific_type
+  end
+end


### PR DESCRIPTION
This significantly speeds up page loading. For example, the landing page took some 1000 ms to load before and now it takes 275 ms. And the file browser view in bioportal took about 94 seconds (!) which slimmed down to 34 seconds.