### PR TITLE
Remove profiler gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ gem 'rails', '~> 3.2.22'
 gem 'rack-protection', '~> 1.5.3'
 gem 'secure_headers', '~> 3.0.3'
 
-gem 'rack-mini-profiler', require: false
-
 gem 'pry-rails', '~> 0.3.2'
 
 gem 'pg', '~> 0.18.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,8 +399,6 @@ GEM
     rack (1.4.7)
     rack-cache (1.6.1)
       rack (>= 0.4)
-    rack-mini-profiler (0.10.1)
-      rack (>= 1.2.0)
     rack-protection (1.5.3)
       rack
     rack-ssl (1.3.4)
@@ -651,7 +649,6 @@ DEPENDENCIES
   pry-stack_explorer (~> 0.4.9.2)
   puma
   quiet_assets (~> 1.1.0)
-  rack-mini-profiler
   rack-protection (~> 1.5.3)
   rails (~> 3.2.22)
   rails-erd (~> 1.4.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,4 @@
 class ApplicationController < ActionController::Base
-
-  before_filter do
-    if current_user && current_user.admin
-      Rack::MiniProfiler.authorize_request
-    end
-  end
-
   protect_from_forgery
 
   include Pagination

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,6 +1,0 @@
-if ['development', 'production', 'test'].include?(Rails.env)
-  require 'rack-mini-profiler'
-
-  # initialization is skipped so trigger it
-  Rack::MiniProfilerRails.initialize!(Rails.application)
-end


### PR DESCRIPTION
This disables profiling because it violates the content policy.

The profiling is active on develop (**only** on develop) with 617ccf03306fd8b9770859474d7a869072d1418f