### PR TITLE
1555 links in details of ontology mapping graphs are wrong

### DIFF
--- a/app/assets/javascripts/plugins/graph.js.coffee
+++ b/app/assets/javascripts/plugins/graph.js.coffee
@@ -163,6 +163,7 @@ displayGraph = (data) ->
       payload =
         edge_url: edge_url
         edge: edge
+        url: edge.info.iri
       template = templateName(edge_type, 'edge')
       if template
         d3.select("div#d3_context").html('')

--- a/app/assets/javascripts/templates/graphs/logic_mappings_edge.hamlbars
+++ b/app/assets/javascripts/templates/graphs/logic_mappings_edge.hamlbars
@@ -1,7 +1,7 @@
 %ul#edge_info
   %li
     %span Logic Mapping:
-    %a{href: '{{edge_url}}/{{edge.info.id}}'}
+    %a{href: '{{url}}'}
       {{edge.source.info.name}} → {{edge.target.info.name}}
   %li
     %span exactness:

--- a/app/assets/javascripts/templates/graphs/logic_mappings_node.hamlbars
+++ b/app/assets/javascripts/templates/graphs/logic_mappings_node.hamlbars
@@ -1,7 +1,7 @@
 %ul#node_info
   %li
     %span Logic:
-    %a{href: '{{node_url}}/{{node.info.id}}'} {{node.info.name}}
+    %a{href: '{{url}}'} {{node.info.name}}
   %li
     %span IRI:
     %a{href: '{{node.info.iri}}'} {{node.info.iri}}

--- a/app/assets/javascripts/templates/graphs/mappings_edge.hamlbars
+++ b/app/assets/javascripts/templates/graphs/mappings_edge.hamlbars
@@ -1,7 +1,7 @@
 %ul#edge_info
   %li
     %span Link:
-    %a{href: '{{edge_url}}/{{edge.info.id}}'}
+    %a{href: '{{url}}'}
       {{edge.source.info.name}} → {{edge.target.info.name}}
   %li
     %span Kind:


### PR DESCRIPTION
This shall fix the URL-bug of #1555. It also fixes another URL-bug for the nodes of LogicMappings.