### PR TITLE
1458 loc ids are not used everywhere

### DIFF
--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -37,7 +37,7 @@ class FilesController < InheritedResources::Base
     if resource.valid?
       flash[:success] = "Successfully saved the uploaded file."
       if ontology = repository.ontologies.with_path(resource.target_path).without_parent.first
-        redirect_to edit_repository_ontology_path(repository, ontology)
+        redirect_to url_for([ontology, :edit])
       else
         redirect_to fancy_repository_path(repository, path: resource.target_path)
       end

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -94,7 +94,11 @@ class OntologiesController < InheritedResources::Base
 
     scope.retry_failed
 
-    redirect_to (id ? [parent, scope.first!, :ontology_versions] : [parent, :ontologies])
+    if id
+      redirect_to url_for([resource, :ontology_versions])
+    else
+      redirect_to [parent, :ontologies]
+    end
   end
 
   def oops_state

--- a/app/controllers/proofs_controller.rb
+++ b/app/controllers/proofs_controller.rb
@@ -11,7 +11,7 @@ class ProofsController < InheritedResources::Base
     if resource.valid?
       resource.save!
       flash[:success] = t('proofs.create.starting_jobs')
-      redirect_to(redirect_chain)
+      redirect_to(overview_url)
     else
       flash[:alert] = t('proofs.create.invalid_resource')
       redirect_to(action: :new, params: {proof: params[:proof]})
@@ -28,13 +28,11 @@ class ProofsController < InheritedResources::Base
     resource.ontology
   end
 
-  def redirect_chain
-    @redirect_chain = resource_chain
+  def overview_url
     if resource.theorem?
-      @redirect_chain << resource.proof_obligation
-      @redirect_chain << :proof_attempts
+      url_for([resource.proof_obligation, :proof_attempts])
     else
-      @redirect_chain << :theorems
+      url_for([resource.proof_obligation.ontology, :theorems])
     end
   end
 

--- a/app/helpers/proofs_helper.rb
+++ b/app/helpers/proofs_helper.rb
@@ -1,8 +1,8 @@
 module ProofsHelper
-  def form_url_chain
-    chain = resource_chain
-    chain << resource.proof_obligation if resource.theorem?
-    chain << :proofs
+  def url_prove_form
+    destination = resource.proof_obligation
+    destination = destination.ontology if destination.is_a?(OntologyVersion)
+    url_for([destination, :prove])
   end
 
   def klass

--- a/app/helpers/state_helper.rb
+++ b/app/helpers/state_helper.rb
@@ -11,7 +11,7 @@ module StateHelper
 
   def retry_resource_chain(resource)
     if resource.is_a?(Ontology)
-      [:retry_failed, *resource_chain]
+      url_for([resource, :retry])
     elsif resource.is_a?(Theorem)
       [:retry_failed, *resource_chain, resource]
     elsif resource.is_a?(ProofAttempt)

--- a/app/views/ontologies/_menu.html.haml
+++ b/app/views/ontologies/_menu.html.haml
@@ -13,7 +13,7 @@
             - if show_oops?
               %li= link_to 'design with OOPS', repository_ontology_ontology_version_oops_request_path(*resource_chain, current_version), method: 'post'
       - if can? :write, resource.repository
-        = link_to 'Edit', [:edit, *resource_chain], class: 'btn btn-default'
+        = link_to 'Edit', url_for([resource, :edit]), class: 'btn btn-default'
       - if can? :write, resource.repository
         - if resource.can_be_deleted?
           = modal_button(t('ontology.delete'), btn_class: 'btn-default')

--- a/app/views/ontologies/edit.html.haml
+++ b/app/views/ontologies/edit.html.haml
@@ -2,7 +2,7 @@
 
 = ontology_nav resource, :edit
 
-= simple_form_for resource, url: resource_path(resource) do |f|
+= simple_form_for resource, url: url_for(resource) do |f|
   = f.input :name, as: :string
   = f.input :ontology_type_id, collection: OntologyType.all
   = f.association :formality_level, collection: FormalityLevel.all, as: :radio_buttons

--- a/app/views/proof_attempts/index.html.haml
+++ b/app/views/proof_attempts/index.html.haml
@@ -16,7 +16,7 @@
 - if theorem.provable
   %h4 Proof Attempts
   - if can?(:write, parent.repository)
-    = link_to t('theorems.show.prove'), [*resource_chain, theorem, :proofs, :new], class: 'btn btn-primary'
+    = link_to t('theorems.show.prove'), url_for([theorem, :prove]), class: 'btn btn-primary'
   %div
     - if collection.empty?
       = t('theorems.show.proof_attempts_empty')

--- a/app/views/proofs/new.html.haml
+++ b/app/views/proofs/new.html.haml
@@ -12,7 +12,7 @@
     - theorems.each do |theorem|
       = render partial: 'theorems/theorem_large', locals: {resource: theorem}
 %h2= t('proofs.new.configuration')
-= simple_form_for resource, url: form_url_chain do |f|
+= simple_form_for resource, url: url_prove_form do |f|
   #prover-list.columnized-items
     = f.input :prover_ids, label: t('proofs.new.provers.label'), collection: ontology.current_version.provers, label_method: :to_s, as: :check_boxes, hint: t('proofs.new.provers.none_is_default')
     .col-lg-2

--- a/app/views/theorems/index.html.haml
+++ b/app/views/theorems/index.html.haml
@@ -3,7 +3,7 @@
 = ontology_nav @ontology, :theorems
 
 - if can?(:write, parent.repository) && @ontology.theorems.provable.any?
-  = link_to t('theorems.index.prove'), [*resource_chain, :proofs, :new], class: 'btn btn-primary'
+  = link_to t('theorems.index.prove'), url_for([ontology, :prove]), class: 'btn btn-primary'
 
 = pagination(build_links_from_request: true) do
   %table.sentences

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,6 +185,32 @@ Will provide a subsite of a specific ontology.
       end
   end
 
+  specified_get '/:repository_id/*locid///edit' => 'ontologies#edit',
+    as: :ontology_edit,
+    constraints: [
+      LocIdRouterConstraint.new(Ontology, ontology: :id),
+    ] do
+      accept 'text/html'
+
+      doc title: 'Ontology edit command',
+          body: <<-BODY
+Will provide a site to the ontology command.
+      BODY
+    end
+
+  specified_put '/:repository_id/*locid' => 'ontologies#update',
+    as: :ontology_update,
+    constraints: [
+      LocIdRouterConstraint.new(Ontology, ontology: :id),
+    ] do
+      accept 'text/html'
+
+      doc title: 'Ontology update command',
+          body: <<-BODY
+Will provide a site to the ontology command.
+      BODY
+    end
+
   specified_get "/:repository_id/*locid///sentences" => "api/v1/sentences#index",
     as: :"ontology_iri_sentences",
     constraints: [

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,19 @@ MMT-query-string.
       BODY
     end
 
+  specified_post '/:repository_id/*locid///retry' => 'ontologies#retry_failed',
+    as: :ontology_retry,
+    constraints: [
+      LocIdRouterConstraint.new(Ontology, ontology: :id),
+    ] do
+      accept 'text/html'
+
+      doc title: 'Ontology retry parsing command',
+          body: <<-BODY
+Will parse the ontology again.
+      BODY
+    end
+
   # Subsites for ontologies
   ontology_subsites = %i(
     comments metadata graphs

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,6 +169,34 @@ Will provide a subsite of a specific ontology.
       end
   end
 
+  specified_post '/:repository_id/*locid///prove' => 'proofs#create',
+    as: :"theorem_prove",
+    constraints: [
+      LocIdRouterConstraint.new(Theorem, ontology: :ontology_id, element: :theorem_id),
+    ] do
+      accept 'text/html'
+
+      doc title: 'loc/id reference to a theorem command',
+          body: <<-BODY
+Will return a representation of the theorem command. The theorem
+is determined according to the *locid.
+      BODY
+    end
+
+  specified_get '/:repository_id/*locid///prove' => 'proofs#new',
+    as: :theorem_prove,
+    constraints: [
+      LocIdRouterConstraint.new(Theorem, ontology: :ontology_id, element: :theorem_id),
+    ] do
+      accept 'text/html'
+
+      doc title: 'loc/id reference to a theorem command',
+          body: <<-BODY
+Will return a representation of the theorem command. The theorem
+is determined according to the *locid.
+      BODY
+    end
+
   ontology_api_subsites.each do |category|
     specified_get "/:repository_id/*locid///#{category}" => "#{category}#index",
       as: :"ontology_iri_#{category}",
@@ -184,6 +212,32 @@ Will provide a subsite of a specific ontology.
         BODY
       end
   end
+
+  specified_get '/:repository_id/*locid///prove' => 'proofs#new',
+    as: :ontology_prove,
+    constraints: [
+      LocIdRouterConstraint.new(Ontology, ontology: :ontology_id),
+    ] do
+      accept 'text/html'
+
+      doc title: 'Ontology prove command',
+          body: <<-BODY
+Will provide a site to the ontology command.
+      BODY
+    end
+
+  specified_post '/:repository_id/*locid///prove' => 'proofs#create',
+    as: :ontology_prove,
+    constraints: [
+      LocIdRouterConstraint.new(Ontology, ontology: :ontology_id),
+    ] do
+      accept 'text/html'
+
+      doc title: 'Ontology prove command',
+          body: <<-BODY
+Will provide a site to the ontology command.
+      BODY
+    end
 
   specified_get '/:repository_id/*locid///edit' => 'ontologies#edit',
     as: :ontology_edit,
@@ -291,8 +345,36 @@ Currently this will return the list of all symbols of the ontology.
       end
   end
 
+  specified_post '/:repository_id/*locid///prove' => 'proofs#create',
+    as: :theorem_prove,
+    constraints: [
+      LocIdRouterConstraint.new(Theorem, ontology: :ontology_id, element: :theorem_id),
+    ] do
+      accept 'text/html'
 
-  specified_get "/:repository_id/*locid" => "prover_outputs#show",
+      doc title: 'loc/id reference to a theorem command',
+          body: <<-BODY
+Will return a representation of the theorem command. The theorem
+is determined according to the *locid.
+      BODY
+    end
+
+  specified_get '/:repository_id/*locid///prove' => 'proofs#new',
+    as: :theorem_prove,
+    constraints: [
+      LocIdRouterConstraint.new(Theorem, ontology: :ontology_id, element: :theorem_id),
+    ] do
+      accept 'text/html'
+
+      doc title: 'loc/id reference to a theorem command',
+          body: <<-BODY
+Will return a representation of the theorem command. The theorem
+is determined according to the *locid.
+      BODY
+    end
+
+
+  specified_get '/:repository_id/*locid' => 'prover_outputs#show',
     as: :"prover_output_iri",
     constraints: [
       LocIdRouterConstraint.new(ProverOutput, ontology: :ontology_id, theorem: :theorem_id, proof_attempt: :proof_attempt_id, element: :id),

--- a/spec/controllers/ontologies_controller_spec.rb
+++ b/spec/controllers/ontologies_controller_spec.rb
@@ -24,7 +24,7 @@ describe OntologiesController do
         post :retry_failed, repository_id: repository.to_param, id: ontology.id
       end
 
-      it{ response.should redirect_to [repository, ontology, :ontology_versions] }
+      it{ response.should redirect_to(url_for([ontology, :ontology_versions])) }
     end
 
   end

--- a/spec/controllers/proofs_controller_spec.rb
+++ b/spec/controllers/proofs_controller_spec.rb
@@ -48,7 +48,7 @@ describe ProofsController do
         it { should respond_with :found }
 
         it 'redirect to the theorems view' do
-          expect(response).to redirect_to([repository, ontology, :theorems])
+          expect(response).to redirect_to(url_for([ontology, :theorems]))
         end
 
         it 'instantiates a Proof object' do
@@ -157,7 +157,7 @@ describe ProofsController do
 
         it 'redirect to the proof_attempts index' do
           expect(response).
-            to redirect_to([repository, ontology, theorem, :proof_attempts])
+            to redirect_to(url_for([theorem, :proof_attempts]))
         end
 
         it 'instantiates a Proof object' do


### PR DESCRIPTION
This shall fix only the two cases mentioned in #1458. It gives a glimpse of what needs to be changed to cover everything.

A proper fix could be to implement a better suitable router instead of using Specroutes (which is incompatible to Rails 4.2 anyway).

--

~~This branch is based on `1555-patch_url_for` of #1745 and **not based on staging**. It may be easier to review that one first.~~