### PR TITLE
1719 test suite does not honor hets port settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -92,6 +92,10 @@ hets:
   # This is the path to the hets executable we use in `rake hets:*` and for the
   # process manager in production mode (god)
   executable_path: /usr/bin/hets
+  # The port to use in the testing framework to generate fixture files.
+  # This is not used in the "production" and "development" environments, but
+  # only in the "test" environment.
+  testing_port: 8010
   # The URLs to the hets instances without trailing slash.
   # The number of instances is not allowed to be greater than the number of
   # hardware processor cores.

--- a/lib/settings_validation_wrapper.rb
+++ b/lib/settings_validation_wrapper.rb
@@ -58,6 +58,7 @@ class SettingsValidationWrapper
                 yml__git__push_priority__changed_files_per_commit
                 yml__git__fallbacks__committer_name
                 yml__git__fallbacks__committer_email
+                yml__hets__testing_port
                 yml__hets__instance_urls
                 yml__redis__url
                 yml__redis__namespace
@@ -94,6 +95,7 @@ class SettingsValidationWrapper
               yml__git__push_priority__commits
               yml__git__push_priority__changed_files_per_commit
               yml__access_token__expiration_minutes
+              yml__hets__testing_port
               yml__hets__time_between_updates
               yml__hets__version_minimum_revision)
 
@@ -207,6 +209,9 @@ class SettingsValidationWrapper
               if: :in_production?
   end
 
+  validates :yml__hets__testing_port,
+            numericality: {greater_than_or_equal_to: 0,
+                           less_than_or_equal_to: 65_535}
   validates :yml__hets__time_between_updates,
             numericality: {greater_than_or_equal_to: 1}
 

--- a/spec/support/fixtures_generation/base_generator.rb
+++ b/spec/support/fixtures_generation/base_generator.rb
@@ -8,6 +8,7 @@ module FixturesGeneration
   # * subdir: the subdirectory of the generated fixtures
   class BaseGenerator
     HETS_PATH = Settings.hets.executable_path
+    HETS_SERVER_PORT = Settings.hets.testing_port
     HETS_SERVER_ARGS =
       YAML.load(File.open('config/hets.yml'))['hets']['server_options']
 
@@ -30,8 +31,8 @@ module FixturesGeneration
 
     def with_running_hets(&block)
       with_running('hets',
-                   "#{HETS_PATH} --server #{HETS_SERVER_ARGS.join(' ')}",
-                   8000, 1, &block)
+                   "#{HETS_PATH} --server --listen=#{HETS_SERVER_PORT} #{HETS_SERVER_ARGS.join(' ')}",
+                   HETS_SERVER_PORT, 1, &block)
     end
 
     protected

--- a/spec/support/fixtures_generation/direct_hets_generator.rb
+++ b/spec/support/fixtures_generation/direct_hets_generator.rb
@@ -3,7 +3,7 @@ require_relative 'base_generator.rb'
 module FixturesGeneration
   class DirectHetsGenerator < BaseGenerator
     HETS_API_OPTIONS = '/auto'
-    HETS_BASE_IRI = 'http://localhost:8000'
+    HETS_BASE_IRI = "http://localhost:#{HETS_SERVER_PORT}"
 
     def call
       if outdated_cassettes.any?


### PR DESCRIPTION
This shall fix #1719 by adding a new settings key for the port that Hets shall listen to when generating the test fixtures. We cannot use the `instance_urls` key for this because these instances may all run on other hosts.