### PR TITLE
Check if returned value is an Ontology

### DIFF
--- a/app/models/ontology/class_methods_and_scopes.rb
+++ b/app/models/ontology/class_methods_and_scopes.rb
@@ -78,7 +78,7 @@ module Ontology::ClassMethodsAndScopes
     def find_with_iri(iri)
       locid = iri_to_locid(iri)
       ontology = LocId.where('locid LIKE ?', '%' << locid).first.try(:specific)
-      if ontology.nil?
+      unless ontology.is_a?(Ontology)
         ontology = AlternativeIri.where('iri LIKE ?', '%' << iri).
           first.try(:ontology)
       end


### PR DESCRIPTION
This should fix #1749. The returned object was not necessarily an ontology.