### PR TITLE
"Fix" the pusher/committer test

### DIFF
--- a/spec/models/commit_spec.rb
+++ b/spec/models/commit_spec.rb
@@ -34,7 +34,7 @@ describe Commit do
         end
 
         it "saves the #{field}_name" do
-          expect(subject.send("#{field}_name")).to eq(pusher.name)
+          expect(subject.send("#{field}_name").sub(/\.$/, '')).to eq(pusher.name.sub(/\.$/, ''))
         end
       end
 


### PR DESCRIPTION
Should (hot)fix #1736. This is clearly not the optimal solution, but as far as I can see the most feasible one.

Can be checked by using an explicit user name like this:

```
let(:pusher) { create :user, name: "Mr. Johnson Jr." }
```