### PR TITLE
1753 wait for sql to finish before parsing worker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'pry-rails', '~> 0.3.2'
 
 gem 'pg', '~> 0.18.1'
 gem 'foreigner', '~> 1.7.2'
+gem 'ar_after_transaction', '~> 0.4.0'
 
 gem 'rdf', '~> 1.99.0'
 gem 'rdf-rdfxml', '~> 1.99.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,8 @@ GEM
     airbrussh (1.0.2)
       sshkit (>= 1.6.1, != 1.7.0)
     ansi (1.5.0)
+    ar_after_transaction (0.4.0)
+      activerecord
     arel (3.0.3)
     autoprefixer-rails (6.3.6.1)
       execjs
@@ -595,6 +597,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.9.3)
   acts_as_relation (~> 0.1.3)
   acts_as_tree (~> 2.4.0)
+  ar_after_transaction (~> 0.4.0)
   awesome_print (~> 1.6.1)
   better_errors (~> 2.1.1)
   binding_of_caller (~> 0.7.2)

--- a/app/models/ontology_version/parsing.rb
+++ b/app/models/ontology_version/parsing.rb
@@ -5,7 +5,7 @@ module OntologyVersion::Parsing
   included do
     @queue = 'hets'
 
-    after_create :async_parse, :if => :commit_oid?
+    after_create :async_parse
     attr_accessor :fast_parse
     attr_accessor :files_to_parse_afterwards
   end
@@ -15,7 +15,7 @@ module OntologyVersion::Parsing
   end
 
   def async_parse(*args)
-    if !@deactivate_parsing
+    if !@deactivate_parsing || ontology.parent.nil?
       update_state! :pending
 
       Sidekiq::RetrySet.new.each do |job|

--- a/lib/ontology_parsing_worker.rb
+++ b/lib/ontology_parsing_worker.rb
@@ -39,10 +39,6 @@ class OntologyParsingWorker < BaseWorker
   end
 
   def parse_version
-    # We need to wait a second for the SQL query to finish.
-    # Otherwise there is no OntologyVersion with id=@version_id.
-    # FIXME This needs to be handled properly.
-    sleep 0.1 unless defined?(Sidekiq::Testing) && Sidekiq::Testing.inline?
     version = OntologyVersion.find(@version_id)
     @options.each do |method_name, value|
       version.send(:"#{method_name}=", value)

--- a/lib/ontology_saver.rb
+++ b/lib/ontology_saver.rb
@@ -13,17 +13,19 @@ class OntologySaver
     file_extension = File.extname(ontology_version_options.filepath)
     return unless Ontology.file_extensions.include?(file_extension)
     return if already_updated_in_commit?(commit_oid, ontology_version_options)
-    ontology = find_or_create_ontology(ontology_version_options)
+    ActiveRecord::Base.transaction do
+      ontology = find_or_create_ontology(ontology_version_options)
 
-    return unless repository.master_file?(ontology, ontology_version_options)
-    return if ontology.versions.find_by_commit_oid(commit_oid)
+      return unless repository.master_file?(ontology, ontology_version_options)
+      return if ontology.versions.find_by_commit_oid(commit_oid)
 
-    version = create_version(ontology, commit_oid, ontology_version_options,
-                             changed_files)
-    ontology.present = true
-    ontology.save!
+      version = create_version(ontology, commit_oid, ontology_version_options,
+                               changed_files)
+      ontology.present = true
+      ontology.save!
 
-    version
+      version
+    end
   end
 
   def suspended_save_ontologies(options={})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,6 +71,7 @@ RSpec.configure do |config|
   config.tty ||= ENV["SPEC_OPTS"].include?('--color') if ENV["SPEC_OPTS"]
 
   config.before(:suite) do
+    ActiveRecord::Base.normally_open_transactions = 1
     FactoryGirl.create :proof_statuses
   end
 


### PR DESCRIPTION
This shall fix #1753 by adding a gem that allows to wait for all transactions to finish.


It is not feasible to use a `after_commit :method, on: :create` hook because this would save the version dozens of times and even create many versions. I could not find out why this happens. The gem, however, solves the problem.