### PR TITLE
1753 wait for sql to finish before parsing worker retry

### DIFF
--- a/app/models/ontology/states.rb
+++ b/app/models/ontology/states.rb
@@ -13,7 +13,8 @@ module Ontology::States
     # Enqueues new parse jobs for all failed ontologies
     def retry_failed
       state(:failed).without_parent.find_each do |ontology|
-        ontology.current_version.try :async_parse
+        OntologySaver.new(ontology.repository).
+          async_parse_version(ontology.current_version)
       end
     end
 

--- a/app/models/ontology_version/parsing.rb
+++ b/app/models/ontology_version/parsing.rb
@@ -30,8 +30,7 @@ module OntologyVersion::Parsing
     end
 
     files_to_parse_afterwards.each do |path|
-      ontology_version_options = OntologyVersionOptions.new(path, pusher,
-                                                            do_not_parse: false)
+      ontology_version_options = OntologyVersionOptions.new(path, pusher)
       version = OntologySaver.new(repository).
         save_ontology(commit_oid, ontology_version_options)
     end

--- a/app/models/ontology_version/parsing.rb
+++ b/app/models/ontology_version/parsing.rb
@@ -21,12 +21,7 @@ module OntologyVersion::Parsing
       # Import version
       ontology.import_version(self, pusher, input_io)
       retrieve_available_provers_for_self_and_children
-
-      update_state!(:done)
-      ontology.children.each do |child|
-        child.versions.where(commit_oid: commit_oid).first.update_state!(:done)
-        child.versions.where(commit_oid: commit_oid).first.save!
-      end
+      update_states_for_self_and_children(:done)
     end
 
     files_to_parse_afterwards.each do |path|
@@ -66,5 +61,13 @@ module OntologyVersion::Parsing
                                             ontology: ontology)
     provers_io = Hets.provers_via_api(ontology, hets_options)
     Hets::Provers::Importer.new(self, provers_io).import
+  end
+
+  def update_states_for_self_and_children(state)
+    update_state!(state)
+    ontology.children.each do |child|
+      child.versions.where(commit_oid: commit_oid).first.update_state!(state)
+      child.versions.where(commit_oid: commit_oid).first.save!
+    end
   end
 end

--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -41,14 +41,14 @@ module Repository::Git
       mark_ontology_as_having_file(filepath, has_file: false)
   end
 
-  def save_file(tmp_file, filepath, message, user, do_not_parse: false)
+  def save_file(tmp_file, filepath, message, user, do_parse: true)
     version = nil
 
     git.add_file(user_info(user), tmp_file, filepath, message) do |commit_oid|
       ontology_version_options = OntologyVersionOptions.new(
-        filepath, user, do_not_parse: do_not_parse)
+        filepath, user)
       version = OntologySaver.new(self).
-        save_ontology(commit_oid, ontology_version_options)
+        save_ontology(commit_oid, ontology_version_options, do_parse: do_parse)
     end
     touch
     version

--- a/app/models/repository/importing.rb
+++ b/app/models/repository/importing.rb
@@ -19,7 +19,7 @@ module Repository::Importing
     include StateUpdater
 
     before_validation :clean_and_initialize_record
-    after_create ->() { call_remote :clone }, if: :source_address?
+    after_commit ->() { call_remote :clone }, on: :create, if: :source_address?
   end
 
   def mirror?

--- a/config/database_cleaner.rb
+++ b/config/database_cleaner.rb
@@ -37,6 +37,14 @@ module DatabaseCleanerConfig
         config.original_hostname = Settings.hostname
       end
 
+      config.before(:each, :example_uses_transaction) do
+        DatabaseCleaner.strategy = NO_TRANSACTION_STRATEGY
+      end
+
+      config.after(:each, :example_uses_transaction) do
+        DatabaseCleaner.strategy = STRATEGY
+      end
+
       config.before(:each, :http_interaction) do
         DatabaseCleaner.strategy = NO_TRANSACTION_STRATEGY
         Settings.hostname =

--- a/db/data/20160310132620_move_loc_id_to_own_model_data.rb
+++ b/db/data/20160310132620_move_loc_id_to_own_model_data.rb
@@ -20,7 +20,8 @@ class MoveLocIdToOwnModelData < ActiveRecord::Migration
     ontologies_to_parse.uniq.each do |ontology|
       # The ontologies need to be parsed asynchronously because the HTTP server
       # does not respond during the migration.
-      ontology.try(:current_version).try(:async_parse)
+      OntologySaver.new(ontology.repository).
+        async_parse_version(ontology.current_version)
     end
   end
 

--- a/db/seeds/040-git.rb
+++ b/db/seeds/040-git.rb
@@ -31,7 +31,7 @@ ontologies.each do |path|
   path = File.join(Rails.root, 'spec', 'fixtures', 'ontologies', path)
   basename = File.basename(path)
 
-  version = repository.save_file path, basename, "#{basename} added", @user, do_not_parse: true
+  version = repository.save_file path, basename, "#{basename} added", @user
   begin
     version.parse
   rescue Hets::SyntaxError

--- a/db/seeds/040-git.rb
+++ b/db/seeds/040-git.rb
@@ -31,9 +31,9 @@ ontologies.each do |path|
   path = File.join(Rails.root, 'spec', 'fixtures', 'ontologies', path)
   basename = File.basename(path)
 
-  version = repository.save_file path, basename, "#{basename} added", @user
+  version = nil
   begin
-    version.parse
+    version = repository.save_file path, basename, "#{basename} added", @user
   rescue Hets::SyntaxError
     # Suppress this error in the seeds. We want to have erroneous ontologies in
     # the basic data.

--- a/doc/code_view_on_importing_ontologies.md
+++ b/doc/code_view_on_importing_ontologies.md
@@ -13,8 +13,6 @@ The following files relate to the import of ontologies:
 `app/models/ontology_version/parsing.rb`
 
 The method `parse` is defined to call **hets** and parse the corresponding xml-output.
-`async_parse` calls the same method and performs the same actions but does so asynchronously
-via a sidekiq-worker.
 
 ## Hets system call
 

--- a/lib/hets/dg/node_evaluation_helper.rb
+++ b/lib/hets/dg/node_evaluation_helper.rb
@@ -112,7 +112,9 @@ module Hets
         else
           importer.ontologies_count += 1
           if parent_ontology.distributed?
-            assign_distributed_ontology_logic(parent_ontology)
+            unless parent_ontology.changed_attributes.keys.include?('logic_id')
+              assign_distributed_ontology_logic(parent_ontology)
+            end
 
             ontology = procure_child_ontology(iri)
           else

--- a/lib/hets/dg/node_evaluation_helper.rb
+++ b/lib/hets/dg/node_evaluation_helper.rb
@@ -59,8 +59,6 @@ module Hets
         version.commit_oid = parent_version.try(:commit_oid)
         version.commit = parent_version.try(:commit)
         version.file_extension = ontology.file_extension
-        # This version will not exist if the parsing fails
-        version.do_not_parse!
 
         importer.versions << version
 

--- a/lib/hets/dg/node_evaluator.rb
+++ b/lib/hets/dg/node_evaluator.rb
@@ -191,7 +191,6 @@ module Hets
             "add reference #{Settings.OMS}: #{internal_iri} from #{source_iri}",
             user, location: source_iri)
           version = ontology.versions.build
-          version.do_not_parse!
           version.commit_oid = commit_oid
           version.state = 'done'
           version.basepath = ontology.basepath

--- a/lib/ontology_parsing_worker.rb
+++ b/lib/ontology_parsing_worker.rb
@@ -39,10 +39,6 @@ class OntologyParsingWorker < BaseWorker
   end
 
   def parse_version
-    # We need to wait a second for the SQL query to finish.
-    # Otherwise there is no OntologyVersion with id=@version_id.
-    # FIXME This needs to be handled properly.
-    sleep 0.1 unless defined?(Sidekiq::Testing) && Sidekiq::Testing.inline?
     version = OntologyVersion.find(@version_id)
     @options.each do |method_name, value|
       version.send(:"#{method_name}=", value)

--- a/lib/ontology_saver.rb
+++ b/lib/ontology_saver.rb
@@ -150,7 +150,6 @@ class OntologySaver
         file_extension: File.extname(ontology_version_options.filepath),
         fast_parse: ontology_version_options.fast_parse },
       { without_protection: true })
-    version.do_not_parse! if ontology_version_options.do_not_parse
     version.files_to_parse_afterwards = files_to_parse(ontology, changed_files)
     version.save!
     ontology.ontology_version = version

--- a/lib/ontology_saver.rb
+++ b/lib/ontology_saver.rb
@@ -7,7 +7,8 @@ class OntologySaver
     self.repository = repository
   end
 
-  def save_ontology(commit_oid, ontology_version_options, changed_files: [], do_parse: true)
+  def save_ontology(commit_oid, ontology_version_options, changed_files: [],
+                    do_parse: true)
     # We expect that this method is only called, when we can expect an ontology
     # in this file.
     file_extension = File.extname(ontology_version_options.filepath)

--- a/lib/ontology_version_options.rb
+++ b/lib/ontology_version_options.rb
@@ -1,12 +1,10 @@
 class OntologyVersionOptions
-  attr_reader :filepath, :pusher, :fast_parse, :do_not_parse, :previous_filepath
+  attr_reader :filepath, :pusher, :fast_parse, :previous_filepath
 
-  def initialize(filepath, pusher, fast_parse: false, do_not_parse: false,
-    previous_filepath: nil)
+  def initialize(filepath, pusher, fast_parse: false, previous_filepath: nil)
     @filepath = filepath
     @pusher = pusher
     @fast_parse = fast_parse
-    @do_not_parse = do_not_parse
     @previous_filepath = previous_filepath
   end
 

--- a/lib/rake_helper.rb
+++ b/lib/rake_helper.rb
@@ -114,7 +114,7 @@ module RakeHelper
         end
       end
       version = meta_repository.
-        save_file(filepath, basename, "Add #{basename}.", user, do_not_parse: true)
+        save_file(filepath, basename, "Add #{basename}.", user, do_parse: false)
       version.parse
       version.ontology
     end

--- a/spec/factories/ontology_factory.rb
+++ b/spec/factories/ontology_factory.rb
@@ -26,7 +26,6 @@ FactoryGirl.define do
                         basepath: ontology.basepath,
                         file_extension: ontology.file_extension,
                         state: 'done'
-        version.do_not_parse!
         ontology.versions << version
       end
 
@@ -41,7 +40,6 @@ FactoryGirl.define do
                       ontology: ontology,
                       basepath: ontology.basepath,
                       file_extension: ontology.file_extension
-      version.do_not_parse!
       ontology.versions << version
     end
 
@@ -52,7 +50,6 @@ FactoryGirl.define do
                         basepath: ontology.basepath,
                         file_extension: ontology.file_extension,
                         state: 'pending'
-        version.do_not_parse!
         ontology.versions << version
       end
     end
@@ -64,7 +61,6 @@ FactoryGirl.define do
                         basepath: ontology.basepath,
                         file_extension: ontology.file_extension
         version.fast_parse = true
-        version.do_not_parse!
         ontology.versions << version
       end
     end
@@ -119,7 +115,6 @@ FactoryGirl.define do
                           basepath: ontology.basepath,
                           file_extension: ontology.file_extension
           version.fast_parse = true
-          version.do_not_parse!
           ontology.versions << version
 
           logic = FactoryGirl.create(:logic)

--- a/spec/factories/ontology_version_factory.rb
+++ b/spec/factories/ontology_version_factory.rb
@@ -17,7 +17,6 @@ FactoryGirl.define do
       version.commit ||= build :commit,
                                repository: version.ontology.repository,
                                commit_oid: version.commit_oid
-      version.do_not_parse!
     end
 
   end

--- a/spec/lib/repository/import/git_spec.rb
+++ b/spec/lib/repository/import/git_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "git import" do
+describe "git import", :example_uses_transaction do
   let(:user){ create :user }
   let(:userinfo){ {email: user[:email], name: user[:name]} }
 

--- a/spec/lib/repository/import/svn_spec.rb
+++ b/spec/lib/repository/import/svn_spec.rb
@@ -15,7 +15,7 @@ def commit(work_dir, count, prefix)
   end
 end
 
-describe "svn import" do
+describe "svn import", :example_uses_transaction do
   let!(:svn_repo_paths) { create :svn_repository }
   let(:bare_url) { "file://#{svn_repo_paths.first}" }
   let(:work_dir) { svn_repo_paths.last }

--- a/spec/models/ontology_spec.rb
+++ b/spec/models/ontology_spec.rb
@@ -255,7 +255,7 @@ describe Ontology do
           path,
           'partial_order.casl',
           'parsing a distributed ontology',
-          user)
+          user).reload
 
         expect(version.ontology.logic.name).to eq('DOL')
       end
@@ -267,7 +267,7 @@ describe Ontology do
         repository.save_file(path,
                              'Simple_Implications_Group.tptp',
                              'parsing a TPTP file',
-                             user)
+                             user).reload
       end
 
       before do
@@ -302,7 +302,7 @@ describe Ontology do
         repository.save_file(path,
                              'zfmisc_1__t92_zfmisc_1.p',
                              'parsing a TPTP file',
-                             user)
+                             user).reload
       end
 
       before do

--- a/spec/models/repository/git_mv_spec.rb
+++ b/spec/models/repository/git_mv_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'git mv', :process_jobs_synchronously do
+describe 'git mv', :process_jobs_synchronously, :example_uses_transaction do
   setup_hets
 
   let(:userinfo) do


### PR DESCRIPTION
This shall fix #1753 and replace #1757.

It removes the `after_create :async_parse` callback from OntologyVersion, because we don't need it. Instead, it schedules a parsing job in the sequential code, when needed.

As a consequence, we do not need the `do_not_parse` flag this much: We have used it to only parse the file once in case of a distributed ontology (and to not parse it for each child ontology). Now, we only use it in the seeds to be explicit and in pushes to call a different ParsingWorker.