### PR TITLE
Hotfix proving

### DIFF
--- a/lib/hets/prove_caller.rb
+++ b/lib/hets/prove_caller.rb
@@ -16,10 +16,7 @@ module Hets
     end
 
     def build_query_string
-      query_string = {}
-      query_string[:'input-type'] = hets_options.options[:'input-type']
-      # FIXME Rails 4.1 introduces query_string.compact. Use it after upgrading.
-      query_string.delete_if { |_k, v| v.nil? }
+      {}
     end
 
     def timeout


### PR DESCRIPTION
Remove input type from query string

This is not needed because the input type is already encoded in the json
body of the request. Hets seems to have problems with this parameter, if
it is specified in the query string in a POST request.