### PR TITLE
1728 Eager load everything in lib

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ module Ontohub
     # -- all .rb files in that directory are automatically loaded.
 
     # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths += %W(#{config.root}/lib)
+    config.eager_load_paths += %W(#{config.root}/lib)
 
     # HACK https://gist.github.com/1184816
     if defined? Compass

--- a/lib/environment_light.rb
+++ b/lib/environment_light.rb
@@ -1,21 +1,24 @@
-require 'pathname'
+unless defined?(Rails)
+  require 'pathname'
 
-# Set up Rails configuration
-rails_env = ENV['RAILS_ENV'] || 'production'
-rails_root = Pathname.new(File.dirname(__FILE__) << '/..')
+  # Set up Rails configuration
+  rails_env = ENV['RAILS_ENV'] || 'production'
+  rails_root = Pathname.new(File.dirname(__FILE__) << '/..')
 
-# Load Bundler
-ENV['BUNDLE_GEMFILE'] = rails_root.join('Gemfile').to_s
-require 'rubygems'
-require 'bundler/setup'
+  # Load Bundler
+  ENV['BUNDLE_GEMFILE'] = rails_root.join('Gemfile').to_s
+  require 'rubygems'
+  require 'bundler/setup'
 
-# Load application settings
-require rails_root.join('config/initializers/rails_config.rb')
-# only load basic files, NOT the auxiliaries like hets.yml
-settings_files = RailsConfig.setting_files(rails_root.join('config'), rails_env)
-abs_settings_files = settings_files.map { |f| rails_root.join('config', f) }
-Settings = RailsConfig.load_files(abs_settings_files)
+  # Load application settings
+  require rails_root.join('config/initializers/rails_config.rb')
+  # only load basic files, NOT the auxiliaries like hets.yml
+  settings_files = RailsConfig.
+    setting_files(rails_root.join('config'), rails_env)
+  abs_settings_files = settings_files.map { |f| rails_root.join('config', f) }
+  Settings = RailsConfig.load_files(abs_settings_files)
 
-Rails = Struct.new(:env, :root, :logger).new
-Rails.env  = rails_env
-Rails.root = rails_root
+  Rails = Struct.new(:env, :root, :logger).new
+  Rails.env  = rails_env
+  Rails.root = rails_root
+end

--- a/lib/environment_light_with_hets.rb
+++ b/lib/environment_light_with_hets.rb
@@ -1,4 +1,6 @@
-rails_root = File.join(File.dirname(__FILE__), '..')
-require File.join(rails_root, 'lib', 'environment_light.rb')
-Settings.add_source!(File.join(rails_root, 'config', 'hets.yml'))
-Settings.reload!
+unless defined?(Rails)
+  rails_root = File.join(File.dirname(__FILE__), '..')
+  require File.join(rails_root, 'lib', 'environment_light.rb')
+  Settings.add_source!(File.join(rails_root, 'config', 'hets.yml'))
+  Settings.reload!
+end


### PR DESCRIPTION
Should fix #1728. `lib` will now be eager loaded. For this to work, we must not load `environment_light` when `Rails` is already defined.