### PR TITLE
1779 git push into a repository doesnt start jobs

### DIFF
--- a/git/lib/git_update.rb
+++ b/git/lib/git_update.rb
@@ -5,10 +5,10 @@ require 'ontohub_net'
 class GitUpdate
 
   def self.update_redis(repo_path, oldrev, newrev, refname, key_id)
-    Subprocess.run 'redis-cli', 'rpush', "#{Settings.redis_namespace}:queue:default", {
-      class: 'RepositoryUpdateWorker',
-      args: [repo_path, oldrev, newrev, refname, key_id]
-    }.to_json
+    Subprocess.run 'redis-cli', 'rpush',
+      "#{Settings.redis_namespace}:sidekiq:queue:default",
+      {class: 'RepositoryUpdateWorker',
+       args: [repo_path, oldrev, newrev, refname, key_id]}.to_json
   end
 
   def initialize(repo_path, key_id, refs)

--- a/lib/ontology_saver.rb
+++ b/lib/ontology_saver.rb
@@ -33,6 +33,7 @@ class OntologySaver
     versions = []
     commits_count = 0
     highest_change_file_count = 0
+    user = options.delete(:user)
     repository.walk_commits(options) { |commit|
       commits_count += 1
       current_file_count = 0
@@ -43,7 +44,7 @@ class OntologySaver
           mark_ontology_as_having_file(f.path, has_file: true)
           ontology_version_options = OntologyVersionOptions.new(
             f.path,
-            options.delete(:user),
+            user,
             fast_parse: repository.has_changed?(f.path, commit.oid))
           versions << save_ontology(commit.oid, ontology_version_options,
                                     changed_files: changed_files,
@@ -51,7 +52,7 @@ class OntologySaver
         elsif f.renamed?
           ontology_version_options = OntologyVersionOptions.new(
             f.path,
-            options.delete(:user),
+            user,
             fast_parse: repository.has_changed?(f.path, commit.oid),
             previous_filepath: f.delta.old_file[:path])
           versions << save_ontology(commit.oid, ontology_version_options,


### PR DESCRIPTION
This shall fix #1779. Please test on develop, but be patient because Ontologies are created in the asynchronous jobs (not synchronously as via the web interface). It may take seconds, minutes or even hours for the ontologies to be created. If you look into the Sidekiq web interface, you see that the jobs are created. This is already deployed on develop.ontohub.org.