### PR TITLE
Fix requiring libs

### DIFF
--- a/lib/dsl/repo.rb
+++ b/lib/dsl/repo.rb
@@ -1,4 +1,3 @@
-#require 'subprocess.rb'
 require 'singleton'
 
 def init(path)

--- a/lib/parsing_callback.rb
+++ b/lib/parsing_callback.rb
@@ -1,10 +1,4 @@
-# enforce eager-loading of parsing classes
-Dir.glob(Rails.root + 'lib/parsing_callback/*.rb').each do |file|
-  require file
-end
-
 module ParsingCallback
-
   def self.determine_for(ontology)
     logic_name = ontology.logic.to_s
     self.constants.each do |constant|
@@ -17,5 +11,4 @@ module ParsingCallback
     end
     GenericCallback.new(ontology)
   end
-
 end

--- a/lib/parsing_callback/owl.rb
+++ b/lib/parsing_callback/owl.rb
@@ -1,5 +1,4 @@
 module ParsingCallback::OWL
-
   IDENTIFIERS = %w(OWL OWL2)
 
   def self.defined_for?(logic_name)

--- a/lib/tasks/hets.rake
+++ b/lib/tasks/hets.rake
@@ -16,7 +16,7 @@ namespace :hets do
   end
 
   desc 'Start a hets server'
-  task :start do
+  task :start => :environment do
     if already_running?
       puts 'Hets is already running...'
     else
@@ -27,7 +27,7 @@ namespace :hets do
   end
 
   desc 'Stop a running hets server'
-  task :stop do
+  task :stop => :environment do
     if already_running?
       pid = fetch_pid
       system("kill #{pid}")
@@ -38,7 +38,7 @@ namespace :hets do
   end
 
   desc 'Run a hets server synchronously'
-  task :run do
+  task :run => :environment do
     exec(hets_cmd)
   end
 
@@ -73,11 +73,6 @@ namespace :hets do
   end
 
   def hets_server_options
-    load_environment_light_with_hets
     Settings.hets.server_options
-  end
-
-  def load_environment_light_with_hets
-    require Rails.root.join('lib', 'environment_light_with_hets.rb').to_s
   end
 end


### PR DESCRIPTION
Because of the eager loading that was introduced in #1780, some classes were loaded multiple times because we have `require` statements in our code. This shall fix it.

Also, Hets could not be started via the rake task that invoker uses because the light environment could not be loaded.