### PR TITLE
Fix Sidekiq loading

### DIFF
--- a/lib/repository_pulling_worker.rb
+++ b/lib/repository_pulling_worker.rb
@@ -4,7 +4,9 @@ class RepositoryPullingWorker
 
   sidekiq_options retry: false, queue: 'default'
 
-  recurrence { minutely(5) }
+  recurrence do
+    hourly.minute_of_hour(0, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55)
+  end
 
   def perform
     Repository.outdated.find_each { |r| r.call_remote :pull }


### PR DESCRIPTION
When Sidekiq started, it had 100% CPU load and did not finish loading
the rb files. This is because of a bug is Sidetiq:
https://github.com/tobiassvn/sidetiq/issues/31#issuecomment-23780476

This commit is a workaround for the bug.