### PR TITLE
Set group write permissions on repository create

### DIFF
--- a/app/models/repository/validations.rb
+++ b/app/models/repository/validations.rb
@@ -74,7 +74,7 @@ module Repository::Validations
 
     # It is against our code style conventions to place a constant here,
     # but it is necessary to have all the inherent methods defined above of it.
-    RESERVED_NAMES = toplevel_namespaces
+    RESERVED_NAMES = toplevel_namespaces + ['new']
   end
 
   class NameNotChangedAfterSetValidator < ActiveModel::Validator

--- a/lib/git_repository.rb
+++ b/lib/git_repository.rb
@@ -24,6 +24,7 @@ class GitRepository
     else
       FileUtils.mkdir_p(Ontohub::Application.config.git_root)
       @repo = Rugged::Repository.init_at(path, true)
+      FileUtils.chmod_R('g+ws', path)
     end
   end
 

--- a/lib/git_repository.rb
+++ b/lib/git_repository.rb
@@ -24,8 +24,12 @@ class GitRepository
     else
       FileUtils.mkdir_p(Ontohub::Application.config.git_root)
       @repo = Rugged::Repository.init_at(path, true)
-      FileUtils.chmod_R('g+ws', path)
+      set_group_permissions
     end
+  end
+
+  def set_group_permissions
+    FileUtils.chmod_R('g+ws', path)
   end
 
   def destroy

--- a/lib/git_repository/cloning.rb
+++ b/lib/git_repository/cloning.rb
@@ -12,8 +12,9 @@ module GitRepository::Cloning
       fetch:  '+refs/*:refs/*',
       mirror: 'true'
 
-    pull
+    result = pull
     set_group_permissions
+    result
   end
 
   def clone_svn(url)
@@ -31,8 +32,9 @@ module GitRepository::Cloning
     end
 
     set_section %w(svn-remote svn), options
-    pull_svn
+    result = pull_svn
     set_group_permissions
+    result
   end
 
   def pull

--- a/lib/git_repository/cloning.rb
+++ b/lib/git_repository/cloning.rb
@@ -13,6 +13,7 @@ module GitRepository::Cloning
       mirror: 'true'
 
     pull
+    set_group_permissions
   end
 
   def clone_svn(url)
@@ -31,6 +32,7 @@ module GitRepository::Cloning
 
     set_section %w(svn-remote svn), options
     pull_svn
+    set_group_permissions
   end
 
   def pull


### PR DESCRIPTION
This shall fix the permission denied error for new repositories: Users should now be able to edit files via both git-push and web.