### PR TITLE
Remove failing chmod call

### DIFF
--- a/lib/git_repository.rb
+++ b/lib/git_repository.rb
@@ -24,12 +24,7 @@ class GitRepository
     else
       FileUtils.mkdir_p(Ontohub::Application.config.git_root)
       @repo = Rugged::Repository.init_at(path, true)
-      set_group_permissions
     end
-  end
-
-  def set_group_permissions
-    FileUtils.chmod_R('g+ws', path)
   end
 
   def destroy

--- a/lib/git_repository/cloning.rb
+++ b/lib/git_repository/cloning.rb
@@ -12,9 +12,7 @@ module GitRepository::Cloning
       fetch:  '+refs/*:refs/*',
       mirror: 'true'
 
-    result = pull
-    set_group_permissions
-    result
+    pull
   end
 
   def clone_svn(url)
@@ -32,9 +30,7 @@ module GitRepository::Cloning
     end
 
     set_section %w(svn-remote svn), options
-    result = pull_svn
-    set_group_permissions
-    result
+    pull_svn
   end
 
   def pull


### PR DESCRIPTION
This call leads to the error on `git clone`:
> Worker: RepositoryFetchingWorker
> Arguments: 1, "clone", "fork"
> Error: Errno::EPERM: Operation not permitted @ chmod_internal - /data/git/repositories/1/

Instead, we should set the umask correctly on the repositories directory once (I already did that):
umask 002